### PR TITLE
BannedApi will move content to .spam in root source folder

### DIFF
--- a/Src/Plugins/BannedApi/BannedApi.csproj
+++ b/Src/Plugins/BannedApi/BannedApi.csproj
@@ -4,11 +4,9 @@
   <Import Project="$(SolutionDir)..\Targets\build.product.props" />
 
   <ItemGroup>
-    <Content Include="BannedApiRegex.json">
-      <PackageCopyToOutput>true</PackageCopyToOutput>
-    </Content>
-    <Content Include="tools\Init.ps1">
-      <PackagePath>tools\</PackagePath>
+    <Content Include="BannedApiRegex.json"></Content>
+    <Content Include="build\BannedApi.targets">
+      <PackagePath>build\</PackagePath>
     </Content>
   </ItemGroup>
   

--- a/Src/Plugins/BannedApi/build/BannedApi.targets
+++ b/Src/Plugins/BannedApi/build/BannedApi.targets
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Target Name="CopyUtilityScriptToProject" BeforeTargets="Build">
+        <Message Text="Copying files" />
+        <Copy SourceFiles="$(MSBuildThisFileDirectory)..\content\BannedApiRegex.json" DestinationFiles="$(SolutionDir)..\.spam\BannedApiRegex.json" />
+    </Target>
+</Project>

--- a/Src/Plugins/BannedApi/build/BannedApi.targets
+++ b/Src/Plugins/BannedApi/build/BannedApi.targets
@@ -1,7 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Target Name="CopyUtilityScriptToProject" BeforeTargets="Build">
-        <Message Text="Copying files" />
-        <Copy SourceFiles="$(MSBuildThisFileDirectory)..\content\BannedApiRegex.json" DestinationFiles="$(SolutionDir)..\.spam\BannedApiRegex.json" />
-    </Target>
+  <Target Name="CopyUtilityScriptToProject" BeforeTargets="Build">
+    <Message Text="Copying files" />
+    <Copy 
+      SourceFiles="$(MSBuildThisFileDirectory)..\content\BannedApiRegex.json" 
+      DestinationFiles="$(SolutionDir)..\.spam\BannedApiRegex.json" />
+  </Target>
 </Project>

--- a/Src/Plugins/BannedApi/build/BannedApi.targets
+++ b/Src/Plugins/BannedApi/build/BannedApi.targets
@@ -4,6 +4,6 @@
     <Message Text="Copying files" />
     <Copy 
       SourceFiles="$(MSBuildThisFileDirectory)..\content\BannedApiRegex.json" 
-      DestinationFiles="$(SolutionDir)..\.spam\BannedApiRegex.json" />
+      DestinationFiles="$(SolutionDir)\.spam\BannedApiRegex.json" />
   </Target>
 </Project>

--- a/Src/Plugins/BannedApi/tools/Init.ps1
+++ b/Src/Plugins/BannedApi/tools/Init.ps1
@@ -1,6 +1,0 @@
-﻿param($installPath, $toolsPath, $package, $project)
-
-$file1 = $project.ProjectItems.Item("BannedApiRegex.json")
-
-$copyToOutput1 = $file1.Properties.Item("CopyToOutputDirectory")
-$copyToOutput1.Value = 1 


### PR DESCRIPTION
Below a generic script using `.targets` to move content from the package to somewhere else:
```xml
    <Target Name="CopyScriptsToProject" BeforeTargets="Build">
        <Message Text="Copying scripts to project" />
        <ItemGroup>
            <SourceScripts Include="$(MSBuildThisFileDirectory)..\content\**\*.*"/>
        </ItemGroup>
        <Copy SourceFiles="@(SourceScripts)" DestinationFiles="@(SourceScripts -> '$(MSBuildProjectDirectory)\content\%(RecursiveDir)%(Filename)%(Extension)')" />
    </Target>
    <!-- Or do this for the individual script -->
    <Target Name="CopyUtilityScriptToProject" BeforeTargets="Build">
        <Copy SourceFiles="$(MSBuildThisFileDirectory)..\content\file" DestinationFiles="$(MSBuildProjectDirectory)\content\file" />
    </Target>
```