### PR TITLE
Adding more tests

### DIFF
--- a/Src/Plugins/Security/Properties/AssemblyInfo.cs
+++ b/Src/Plugins/Security/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Tests.Security, PublicKey=0024000004800000940000000602000000240000525341310004000001000100433fbf156abe9718142bdbd48a440e779a1b708fd21486ee0ae536f4c548edf8a7185c1e3ac89ceef76c15b8cc2497906798779a59402f9b9e27281fb15e7111566cdc9a9f8326301d45320623c5222089cf4d0013f365ae729fb0a9c9d15138042825cd511a0f3d4887a7b92f4c2749f81b410813d297b73244cf64995effb1")]

--- a/Src/Plugins/Tests.Security/Validators/AzureDevOpsPersonalAccessTokenValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/Validators/AzureDevOpsPersonalAccessTokenValidatorTests.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Security
+{
+    public class AzureDevOpsPersonalAccessTokenValidatorTests
+    {
+        [Theory]
+        [InlineData("deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdead", "NoMatch")]
+        public void CheckIsValid(string input, string expected)
+        {
+            bool performDynamicValidation = false;
+            string failureLevel = "error";
+            string result = AzureDevOpsPersonalAccessTokenValidator.IsValid(input, ref performDynamicValidation, ref failureLevel);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("a")]
+        [InlineData("")]
+        public void CheckInvalidInput(string input)
+        {
+            bool performDynamicValidation = false;
+            string failureLevel = "error";
+            Assert.Throws<ArgumentException>(() => AzureDevOpsPersonalAccessTokenValidator.IsValid(input, ref performDynamicValidation, ref failureLevel));
+        }
+    }
+}

--- a/Src/Sarif.PatternMatcher.Benchmark/Benchmarks/AnalyzeCommandBenchmarks.cs
+++ b/Src/Sarif.PatternMatcher.Benchmark/Benchmarks/AnalyzeCommandBenchmarks.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 
-using FluentAssertions;
+using BenchmarkDotNet.Attributes;
 
 using Microsoft.CodeAnalysis.Sarif.Driver;
 using Microsoft.Strings.Interop;
@@ -14,25 +14,24 @@ using Moq;
 
 using Newtonsoft.Json;
 
-using Xunit;
-
-namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
+namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Benchmark.Benchmarks
 {
-    public class AnalyzeCommandTests
+    [MemoryDiagnoser]
+    public class AnalyzeCommandBenchmarks
     {
-        [Fact]
+        [Benchmark]
         public void AnalyzeCommand_SimpleAnalysisDotNetRegex()
         {
             AnalyzeCommand(DotNetRegex.Instance);
         }
 
-        [Fact]
+        [Benchmark]
         public void AnalyzeCommand_SimpleAnalysisCachedDotNetRegex()
         {
             AnalyzeCommand(CachedDotNetRegex.Instance);
         }
 
-        [Fact]
+        [Benchmark]
         public void AnalyzeCommand_SimpleAnalysisRegex2()
         {
             AnalyzeCommand(RE2Regex.Instance);
@@ -102,14 +101,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             IEnumerable<Skimmer<AnalyzeContext>> applicableSkimmers = PatternMatcher.AnalyzeCommand.DetermineApplicabilityForTargetHelper(context, skimmers, disabledSkimmers);
 
             PatternMatcher.AnalyzeCommand.AnalyzeTargetHelper(context, applicableSkimmers, disabledSkimmers);
-
-            testLogger.Results.Should().NotBeNull();
-            testLogger.Results.Count.Should().Be(2);
-
-            foreach (Result result in testLogger.Results)
-            {
-                result.Level.Should().Be(FailureLevel.Error);
-            }
         }
     }
 }

--- a/Src/Sarif.PatternMatcher.Benchmark/Program.cs
+++ b/Src/Sarif.PatternMatcher.Benchmark/Program.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Running;
+
+using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Benchmark.Benchmarks;
+
+namespace Sarif.PatternMatcher.Benchmark
+{
+    internal static class Program
+    {
+        static void Main(string[] args)
+        {
+            BenchmarkRunner.Run<AnalyzeCommandBenchmarks>();
+        }
+    }
+}

--- a/Src/Sarif.PatternMatcher.Benchmark/Sarif.PatternMatcher.Benchmark.csproj
+++ b/Src/Sarif.PatternMatcher.Benchmark/Sarif.PatternMatcher.Benchmark.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>$(RootNamespaceBase).Sarif.PatternMatcher.Benchmark</RootNamespace>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="Moq" Version="4.15.2" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\Sarif.PatternMatcher\Sarif.PatternMatcher.csproj" />
+    
+    <Compile Include="$(MSBuildThisFileDirectory)..\Test.UnitTests.Sarif.PatternMatcher\TestAnalyzeCommand.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\Test.UnitTests.Sarif.PatternMatcher\TestLogger.cs" />
+  </ItemGroup>
+
+</Project>

--- a/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
@@ -14,8 +14,13 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 {
     public class AnalyzeCommand : MultithreadedAnalyzeCommandBase<AnalyzeContext, AnalyzeOptions>
     {
-        public static ISet<Skimmer<AnalyzeContext>> CreateSkimmersFromDefinitionsFiles(IFileSystem fileSystem, IEnumerable<string> searchDefinitionsPaths)
+        public static ISet<Skimmer<AnalyzeContext>> CreateSkimmersFromDefinitionsFiles(
+            IFileSystem fileSystem,
+            IEnumerable<string> searchDefinitionsPaths,
+            IRegex engine = null)
         {
+            engine ??= RE2Regex.Instance;
+
             var validators = new ValidatorsCache();
 
             var skimmers = new HashSet<Skimmer<AnalyzeContext>>();
@@ -53,8 +58,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
                 foreach (SearchDefinition definition in definitions.Definitions)
                 {
-                    IRegex engine = RE2Regex.Instance;
-
                     skimmers.Add(
                         new SearchSkimmer(
                             engine: engine,

--- a/Src/Sarif.PatternMatcher/Sarif.PatternMatcher.csproj
+++ b/Src/Sarif.PatternMatcher/Sarif.PatternMatcher.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Sarif.PatternMatcher/ValidatorsCache.cs
+++ b/Src/Sarif.PatternMatcher/ValidatorsCache.cs
@@ -35,11 +35,11 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             _ruleIdToMethodMap ??= LoadValidationAssemblies(ValidatorPaths);
 
             return ValidateHelper(_ruleIdToMethodMap,
-                                  ruleId,
-                                  matchedPattern,
-                                  ref dynamicValidation,
-                                  ref failureLevel,
-                                  out validatorMessage);
+                ruleId,
+                matchedPattern,
+                ref dynamicValidation,
+                ref failureLevel,
+                out validatorMessage);
         }
 
         internal static Validation ValidateHelper(

--- a/Src/SarifPatternMatcher.sln
+++ b/Src/SarifPatternMatcher.sln
@@ -71,6 +71,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test.UnitTests.Sarif.Patter
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test.UnitTests.Sarif.PatternMatcher.Cli", "Test.UnitTests.Sarif.PatternMatcher.Cli\Test.UnitTests.Sarif.PatternMatcher.Cli.csproj", "{1AB0961C-3C1D-4515-8FD5-E4A42BB3C425}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sarif.PatternMatcher.Benchmark", "Sarif.PatternMatcher.Benchmark\Sarif.PatternMatcher.Benchmark.csproj", "{FAACB4CC-5311-4E4D-8C49-D335EF660059}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -249,6 +251,18 @@ Global
 		{1AB0961C-3C1D-4515-8FD5-E4A42BB3C425}.Release|x64.Build.0 = Release|Any CPU
 		{1AB0961C-3C1D-4515-8FD5-E4A42BB3C425}.Release|x86.ActiveCfg = Release|Any CPU
 		{1AB0961C-3C1D-4515-8FD5-E4A42BB3C425}.Release|x86.Build.0 = Release|Any CPU
+		{FAACB4CC-5311-4E4D-8C49-D335EF660059}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FAACB4CC-5311-4E4D-8C49-D335EF660059}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FAACB4CC-5311-4E4D-8C49-D335EF660059}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FAACB4CC-5311-4E4D-8C49-D335EF660059}.Debug|x64.Build.0 = Debug|Any CPU
+		{FAACB4CC-5311-4E4D-8C49-D335EF660059}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FAACB4CC-5311-4E4D-8C49-D335EF660059}.Debug|x86.Build.0 = Debug|Any CPU
+		{FAACB4CC-5311-4E4D-8C49-D335EF660059}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FAACB4CC-5311-4E4D-8C49-D335EF660059}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FAACB4CC-5311-4E4D-8C49-D335EF660059}.Release|x64.ActiveCfg = Release|Any CPU
+		{FAACB4CC-5311-4E4D-8C49-D335EF660059}.Release|x64.Build.0 = Release|Any CPU
+		{FAACB4CC-5311-4E4D-8C49-D335EF660059}.Release|x86.ActiveCfg = Release|Any CPU
+		{FAACB4CC-5311-4E4D-8C49-D335EF660059}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Src/Test.UnitTests.Strings.Interop/String8Tests.cs
+++ b/Src/Test.UnitTests.Strings.Interop/String8Tests.cs
@@ -102,5 +102,45 @@ namespace Microsoft.Strings.Interop
                 }
             }
         }
+
+        [Fact]
+        public void CheckEquality_Strings8AndString()
+        {
+            string text = "abc    def";
+            byte[] buffer = null;
+            String8 value = String8.Convert(text, ref buffer);
+            Assert.Equal(0, value.CompareTo(text));
+            Assert.True(value.Equals(text));
+            Assert.True(value.Equals(value));
+            Assert.Equal(0, value.CompareTo(value));
+
+            text = "abc    defg";
+            Assert.Equal(-1, value.CompareTo(text));
+            Assert.False(value.Equals(text));
+
+            text = "abc    de";
+            Assert.Equal(1, value.CompareTo(text));
+            Assert.False(value.Equals(text));
+
+            String8 empty = String8.Convert(string.Empty, ref buffer);
+            Assert.Equal(-1, empty.CompareTo(value));
+            Assert.Equal(1, value.CompareTo(empty));
+            Assert.False(value.Equals(empty));
+
+            text = "def    abc";
+            String8 value2 = String8.Convert(text, ref buffer);
+            Assert.Equal(0, value.CompareTo(value2));
+            Assert.True(value.Equals(value2));
+
+            text = "abc    defg";
+            value2 = String8.Convert(text, ref buffer);
+            Assert.Equal(3, value.CompareTo(value2));
+            Assert.False(value.Equals(value2));
+
+            text = "abc    de";
+            value2 = String8.Convert(text, ref buffer);
+            Assert.Equal(3, value.CompareTo(value2));
+            Assert.False(value.Equals(value2));
+        }
     }
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,6 @@ steps:
     script: |
       dotnet tool install -g dotnet-reportgenerator-globaltool      
       reportgenerator -reports:**/*.coverage.xml -targetdir:TestResults -reporttypes:Cobertura -assemblyFilters:"-xunit*;-moq*;-sarif.driver*;-sarif.converters*;-sarif.dll;-test.utilities.sarif.dll"
-
 - task: PublishCodeCoverageResults@1
   inputs:
     codeCoverageTool: 'cobertura'


### PR DESCRIPTION
## Changes:
- Added more tests, which increased our coverage from 76% to 90.5%
- Changed the method `CreateSkimmersFromDefinitionsFiles` to accept the engine, so the user could choose to use `DotNetRegex,` `CachedRegex` or `RE2Regex`
- Added a benchmark project so we can always take a look and compare our different regex providers.

Below a snippet:
|                                         Method |     Mean |     Error |    StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------------------------- |---------:|----------:|----------:|------:|------:|------:|----------:|
|       AnalyzeCommand_SimpleAnalysisDotNetRegex | 3.681 ms | 0.1905 ms | 0.5496 ms |     - |     - |     - |  70.98 KB |
| AnalyzeCommand_SimpleAnalysisCachedDotNetRegex | 4.682 ms | 0.0931 ms | 0.2533 ms |     - |     - |     - |   71.4 KB |
|            AnalyzeCommand_SimpleAnalysisRegex2 | 4.444 ms | 0.0878 ms | 0.2327 ms |     - |     - |     - |  70.79 KB |

// * Warnings *
MultimodalDistribution
  AnalyzeCommandBenchmarks.AnalyzeCommand_SimpleAnalysisDotNetRegex: Default -> It seems that the distribution is bimodal (mValue = 4)
MinIterationTime
  AnalyzeCommandBenchmarks.AnalyzeCommand_SimpleAnalysisDotNetRegex: Default       -> The minimum observed iteration time is 2.6855 ms which is very small. It's recommended to increase it to at least 100.0000 ms using more operations.
  AnalyzeCommandBenchmarks.AnalyzeCommand_SimpleAnalysisCachedDotNetRegex: Default -> The minimum observed iteration time is 4.3403 ms which is very small. It's recommended to increase it to at least 100.0000 ms using more operations.
  AnalyzeCommandBenchmarks.AnalyzeCommand_SimpleAnalysisRegex2: Default            -> The minimum observed iteration time is 4.0670 ms which is very small. It's recommended to increase it to at least 100.0000 ms using more operations.