### PR TITLE
Fix fingerprint emit. Fix unauthorized reporting.

### DIFF
--- a/Src/Plugins/ValidatorBase.cs
+++ b/Src/Plugins/ValidatorBase.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins
         public static string CreateReturnValueForUnauthorizedAccess(string asset)
         {
             return nameof(ValidationState.Unauthorized) +
-                $"to '{asset}'.";
+                $"#to '{asset}'.";
         }
 
         public static string CreateReturnValueForCompromisedAsset(string asset, string user = null)

--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -535,10 +535,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
         {
             if (fingerprint == null) { return null; }
 
-            string[] tokens = fingerprint.Split('#');
             return new Dictionary<string, string>()
             {
-                { tokens[0], tokens[1] },
+                { "SecretFingerprint/v1", fingerprint },
             };
         }
 


### PR DESCRIPTION
@eddynaka @cfaucon 

We weren't actually persisting fingerprints properly, now fixed. Also, the 'unauthorized' helper omitted the '#' delimiter, with the result that these issues were elevated to error (because the validator output could not be parsed).

We need to make this condition produce a useful error! Probably any result in these circumstances s/be dropped to a warning, I'll make that change soon.