### PR TITLE
Push data to match expressions

### DIFF
--- a/Src/Plugins/Security/SEC1001.SecurePlaintextSecrets.json
+++ b/Src/Plugins/Security/SEC1001.SecurePlaintextSecrets.json
@@ -1,7 +1,7 @@
 {
   "Definitions": [
     {
-      "Strings": {
+      "SharedStrings": {
         "BinaryFiles": "(?i)\\.(bmp|dll|exe|gif|jpg|jpeg|lock|png|psd|tar\\.gz|tif?|ttf|xcf|zip)$",
         "SourceFiles": "(?i)\\.(azure|bat|c|cmd|config|cpp|cs|cscfg|definitions|dtsx|h|hxx|hpp|ini|java|jsx?|json|keys|kt|loadtest|m|md|php|properties|ps1|psm1|pubxml|py|resx|sample|sql|ste|swift|test|tsx?|txt|waz|xml)$"
       },

--- a/Src/Plugins/Security/SEC1004.UseSecureApi.json
+++ b/Src/Plugins/Security/SEC1004.UseSecureApi.json
@@ -1,10 +1,11 @@
 {
+  "SharedStringsFileName": "Security.SharedStrings.txt",
   "Definitions": [
     {
       "Name": "DoNotUseBannedApi",
       "Id": "SEC1004/Memory/Allocation",
       "Level": "Error",
-      "FileNameAllowRegex": "(?i)\\.(c|cpp|cxx)$",
+      "FileNameAllowRegex": "$CSourceFiles",
       "Description": "Developers should use secure API in preferance of insecure alternates.",
       "Message": "'{0:scanTarget}' contains a call to '{1:insecureApi}', a potentially insecure API that could be replaced with a more secure alternative: '{2:secureApi}'.",
       "MatchExpressions": [

--- a/Src/Plugins/Security/Security.SharedStrings.txt
+++ b/Src/Plugins/Security/Security.SharedStrings.txt
@@ -1,0 +1,1 @@
+﻿$CSourceFiles=(?i)\.(c|cpp|cxx)$

--- a/Src/Plugins/Security/Security.csproj
+++ b/Src/Plugins/Security/Security.csproj
@@ -16,10 +16,17 @@
     <Content Include="build\Sarif.PatternMatcher.Security.targets">
       <PackagePath>build\</PackagePath>
     </Content>
+    <Content Include="Security.SharedStrings.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>
     <SpamFiles Include="$(MSBuildThisFileDirectory)*.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="Security.SharedStrings.txt" />
   </ItemGroup>
 
   <Target Name="CopyingSpam" AfterTargets="Build">

--- a/Src/Plugins/Security/build/Sarif.PatternMatcher.Security.targets
+++ b/Src/Plugins/Security/build/Sarif.PatternMatcher.Security.targets
@@ -14,6 +14,9 @@
     <Copy
       SourceFiles="$(MSBuildThisFileDirectory)..\content\SEC1004.UseSecureApi.json"
       DestinationFiles="$(SolutionDir)\.spam\Security\SEC1004.UseSecureApi.json" />
+    <Copy
+      SourceFiles="$(MSBuildThisFileDirectory)..\content\Security.SharedStrings.txt"
+      DestinationFiles="$(SolutionDir)\.spam\Security\Security.SharedStrings.txt" />
   <Copy
       SourceFiles="$(MSBuildThisFileDirectory)..\lib\netstandard2.0\Security.dll"
       DestinationFiles="$(SolutionDir)\.spam\Security\Security.dll" />

--- a/Src/Plugins/ValidatorBase.cs
+++ b/Src/Plugins/ValidatorBase.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins
         public static string CreateReturnValueForUnauthorizedAccess(string asset)
         {
             return nameof(ValidationState.Unauthorized) +
-                $"to '{asset}'.";
+                $"#to '{asset}'.";
         }
 
         public static string CreateReturnValueForCompromisedAsset(string asset, string user = null)

--- a/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
@@ -58,6 +58,15 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                     }
                 }
 
+                Dictionary<string, string> sharedStrings = null;
+                if (!string.IsNullOrEmpty(definitions.SharedStringsFileName))
+                {
+                    string sharedStringsFullPath = Path.Combine(definitionsDirectory, definitions.SharedStringsFileName);
+                    sharedStrings = LoadSharedStrings(sharedStringsFullPath, fileSystem);
+                }
+
+                PushInheritedData(definitions, sharedStrings);
+
                 foreach (SearchDefinition definition in definitions.Definitions)
                 {
                     skimmers.Add(
@@ -69,11 +78,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                             name: definition.Name,
                             defaultLevel: definition.Level,
                             description: definition.Description ?? string.Empty,
-                            fileNameDenyRegex: definition.FileNameDenyRegex,
-                            fileNameAllowRegex: definition.FileNameAllowRegex,
                             defaultMessageString: definition.Message,
-                            matchExpressions: definition.MatchExpressions,
-                            strings: definition.Strings));
+                            matchExpressions: definition.MatchExpressions));
 
                     const string singleSpace = " ";
 
@@ -101,6 +107,57 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             return skimmers;
         }
 
+        internal static void PushInheritedData(SearchDefinitions definitions, Dictionary<string, string> sharedStrings)
+        {
+            foreach (SearchDefinition searchDefinition in definitions.Definitions)
+            {
+                searchDefinition.FileNameDenyRegex = PushData(searchDefinition.FileNameDenyRegex, sharedStrings);
+                searchDefinition.FileNameAllowRegex = PushData(searchDefinition.FileNameAllowRegex, sharedStrings);
+
+                foreach (MatchExpression matchExpression in searchDefinition.MatchExpressions)
+                {
+                    matchExpression.FileNameDenyRegex = PushData(matchExpression.FileNameDenyRegex, sharedStrings);
+                    matchExpression.FileNameDenyRegex ??= searchDefinition.FileNameDenyRegex;
+
+                    matchExpression.FileNameAllowRegex = PushData(matchExpression.FileNameAllowRegex, sharedStrings);
+                    matchExpression.FileNameAllowRegex ??= searchDefinition.FileNameDenyRegex;
+
+                    matchExpression.ContentsRegex = PushData(matchExpression.ContentsRegex, sharedStrings);
+                }
+            }
+        }
+
+        private static string PushData(string text, Dictionary<string, string> sharedStrings)
+        {
+            if (text?.Contains("$") != true) { return text; }
+
+            foreach (string key in sharedStrings.Keys)
+            {
+                text = text.Replace(key, sharedStrings[key]);
+            }
+
+            return text;
+        }
+
+        internal static Dictionary<string, string> LoadSharedStrings(string sharedStringsFullPath, IFileSystem fileSystem)
+        {
+            var result = new Dictionary<string, string>();
+
+            foreach (string line in fileSystem.FileReadAllLines(sharedStringsFullPath))
+            {
+                int index = line.IndexOf('=');
+                if (index == -1) { ThrowInvalidSharedStringsEntry(line); }
+
+                string key = line.Substring(0, index);
+                if (!key.StartsWith("$")) { ThrowInvalidSharedStringsEntry(line); }
+
+                string value = line.Substring(key.Length + "=".Length);
+                result[key] = value;
+            }
+
+            return result;
+        }
+
         protected override AnalyzeContext CreateContext(
             AnalyzeOptions options,
             IAnalysisLogger logger,
@@ -123,6 +180,14 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
         protected override ISet<Skimmer<AnalyzeContext>> CreateSkimmers(AnalyzeOptions options, AnalyzeContext context)
         {
             return CreateSkimmersFromDefinitionsFiles(this.FileSystem, options.SearchDefinitionsPaths);
+        }
+
+        private static void ThrowInvalidSharedStringsEntry(string line)
+        {
+            throw new InvalidOperationException(
+                $"Malformed shared strings entry. Every shared string should consist of a " +
+                $"key name (prefixed with $) followed by an equals sign and the string value " +
+                $"(e.g., $MyKey=MyValue). The malformed line was: {line}");
         }
     }
 }

--- a/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
@@ -110,27 +110,35 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
         {
             foreach (SearchDefinition definition in definitions.Definitions)
             {
-                definition.FileNameDenyRegex = PushData(definition.FileNameDenyRegex, sharedStrings);
-                definition.FileNameAllowRegex = PushData(definition.FileNameAllowRegex, sharedStrings);
+                PushInheritedData(definition, sharedStrings);
+            }
+        }
 
-                foreach (MatchExpression matchExpression in definition.MatchExpressions)
-                {
-                    matchExpression.FileNameDenyRegex = PushData(matchExpression.FileNameDenyRegex, sharedStrings);
-                    matchExpression.FileNameDenyRegex ??= definition.FileNameDenyRegex;
+        internal static void PushInheritedData(SearchDefinition definition, Dictionary<string, string> sharedStrings)
+        {
+            definition.FileNameDenyRegex = PushData(definition.FileNameDenyRegex, sharedStrings);
+            definition.FileNameAllowRegex = PushData(definition.FileNameAllowRegex, sharedStrings);
 
-                    matchExpression.FileNameAllowRegex = PushData(matchExpression.FileNameAllowRegex, sharedStrings);
-                    matchExpression.FileNameAllowRegex ??= definition.FileNameDenyRegex;
+            foreach (MatchExpression matchExpression in definition.MatchExpressions)
+            {
+                matchExpression.FileNameDenyRegex = PushData(matchExpression.FileNameDenyRegex, sharedStrings);
+                matchExpression.FileNameDenyRegex ??= definition.FileNameDenyRegex;
 
-                    matchExpression.ContentsRegex = PushData(matchExpression.ContentsRegex, sharedStrings);
+                matchExpression.FileNameAllowRegex = PushData(matchExpression.FileNameAllowRegex, sharedStrings);
+                matchExpression.FileNameAllowRegex ??= definition.FileNameDenyRegex;
 
-                    if (matchExpression.Level == 0) { matchExpression.Level = definition.Level; }
-                }
+                matchExpression.ContentsRegex = PushData(matchExpression.ContentsRegex, sharedStrings);
+
+                if (matchExpression.Level == 0) { matchExpression.Level = definition.Level; }
             }
         }
 
         private static string PushData(string text, Dictionary<string, string> sharedStrings)
         {
-            if (text?.Contains("$") != true) { return text; }
+            if (sharedStrings == null || text?.Contains("$") != true)
+            { 
+                return text; 
+            }
 
             foreach (string key in sharedStrings.Keys)
             {

--- a/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
@@ -76,7 +76,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                             fileRegionsCache: fileRegionsCache,
                             id: definition.Id,
                             name: definition.Name,
-                            defaultLevel: definition.Level,
                             description: definition.Description ?? string.Empty,
                             defaultMessageString: definition.Message,
                             matchExpressions: definition.MatchExpressions));
@@ -109,20 +108,22 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
         internal static void PushInheritedData(SearchDefinitions definitions, Dictionary<string, string> sharedStrings)
         {
-            foreach (SearchDefinition searchDefinition in definitions.Definitions)
+            foreach (SearchDefinition definition in definitions.Definitions)
             {
-                searchDefinition.FileNameDenyRegex = PushData(searchDefinition.FileNameDenyRegex, sharedStrings);
-                searchDefinition.FileNameAllowRegex = PushData(searchDefinition.FileNameAllowRegex, sharedStrings);
+                definition.FileNameDenyRegex = PushData(definition.FileNameDenyRegex, sharedStrings);
+                definition.FileNameAllowRegex = PushData(definition.FileNameAllowRegex, sharedStrings);
 
-                foreach (MatchExpression matchExpression in searchDefinition.MatchExpressions)
+                foreach (MatchExpression matchExpression in definition.MatchExpressions)
                 {
                     matchExpression.FileNameDenyRegex = PushData(matchExpression.FileNameDenyRegex, sharedStrings);
-                    matchExpression.FileNameDenyRegex ??= searchDefinition.FileNameDenyRegex;
+                    matchExpression.FileNameDenyRegex ??= definition.FileNameDenyRegex;
 
                     matchExpression.FileNameAllowRegex = PushData(matchExpression.FileNameAllowRegex, sharedStrings);
-                    matchExpression.FileNameAllowRegex ??= searchDefinition.FileNameDenyRegex;
+                    matchExpression.FileNameAllowRegex ??= definition.FileNameDenyRegex;
 
                     matchExpression.ContentsRegex = PushData(matchExpression.ContentsRegex, sharedStrings);
+
+                    if (matchExpression.Level == 0) { matchExpression.Level = definition.Level; }
                 }
             }
         }

--- a/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
@@ -136,8 +136,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
         private static string PushData(string text, Dictionary<string, string> sharedStrings)
         {
             if (sharedStrings == null || text?.Contains("$") != true)
-            { 
-                return text; 
+            {
+                return text;
             }
 
             foreach (string key in sharedStrings.Keys)

--- a/Src/Sarif.PatternMatcher/SearchDefinitions.cs
+++ b/Src/Sarif.PatternMatcher/SearchDefinitions.cs
@@ -7,9 +7,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 {
     public class SearchDefinitions
     {
-        public string ValidatorsAssemblyName { get; set; }
+        public string SharedStringsFileName { get; set; }
 
-        public Dictionary<string, string> Strings { get; set; }
+        public string ValidatorsAssemblyName { get; set; }
 
         public List<SearchDefinition> Definitions { get; set; }
     }

--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -43,7 +43,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                   fileRegionsCache,
                   definition.Id,
                   definition.Name,
-                  definition.Level,
                   definition.Description,
                   definition.Message,
                   definition.MatchExpressions,
@@ -57,7 +56,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             FileRegionsCache fileRegionsCache,
             string id,
             string name,
-            FailureLevel defaultLevel,
             string description,
             string defaultMessageString,
             IList<MatchExpression> matchExpressions,
@@ -82,15 +80,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 { "Default", new MultiformatMessageString() { Text = defaultMessageString, } },
             };
 
-            var reportingConfiguration = new ReportingConfiguration { Level = defaultLevel };
-
             foreach (MatchExpression matchExpression in matchExpressions)
             {
-                if (matchExpression.Level == 0)
-                {
-                    matchExpression.Level = defaultLevel;
-                }
-
                 _matchExpressionToRule[matchExpression] = new ReportingDescriptor
                 {
                     Id = string.IsNullOrEmpty(matchExpression.SubId) ? id : $"{id}/{matchExpression.SubId}",

--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -535,10 +535,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
         {
             if (fingerprint == null) { return null; }
 
-            string[] tokens = fingerprint.Split('#');
             return new Dictionary<string, string>()
             {
-                { tokens[0], tokens[1] },
+                { "SecretFingerprint/v1", fingerprint },
             };
         }
 

--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -338,7 +338,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                         case Validation.HostUnknown:
                         {
                             level = FailureLevel.Warning;
-                            validationState = " which references an unknown host";
+                            validationState = " which references an unknown host or resource";
                             break;
                         }
 

--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -45,8 +45,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                   definition.Name,
                   definition.Level,
                   definition.Description,
-                  definition.FileNameDenyRegex,
-                  definition.FileNameAllowRegex,
                   definition.Message,
                   definition.MatchExpressions,
                   fileSystem)
@@ -61,12 +59,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             string name,
             FailureLevel defaultLevel,
             string description,
-            string fileNameDenyRegex,
-            string fileNameAllowRegex,
             string defaultMessageString,
             IList<MatchExpression> matchExpressions,
-            IFileSystem fileSystem = null,
-            Dictionary<string, string> strings = null)
+            IFileSystem fileSystem = null)
         {
             _id = id;
             _name = name;
@@ -94,21 +89,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 if (matchExpression.Level == 0)
                 {
                     matchExpression.Level = defaultLevel;
-                }
-
-                matchExpression.FileNameDenyRegex ??= fileNameDenyRegex;
-                matchExpression.FileNameAllowRegex ??= fileNameAllowRegex;
-
-                // Replacing common strings for real value.
-                if (matchExpression.FileNameAllowRegex?.StartsWith("$") == true && strings.ContainsKey(matchExpression.FileNameAllowRegex.Substring(1)))
-                {
-                    matchExpression.FileNameAllowRegex = strings[matchExpression.FileNameAllowRegex.Substring(1)];
-                }
-
-                // Replacing common strings for real value.
-                if (matchExpression.FileNameDenyRegex?.StartsWith("$") == true && strings.ContainsKey(matchExpression.FileNameDenyRegex.Substring(1)))
-                {
-                    matchExpression.FileNameDenyRegex = strings[matchExpression.FileNameDenyRegex.Substring(1)];
                 }
 
                 _matchExpressionToRule[matchExpression] = new ReportingDescriptor

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/SearchSkimmerTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/SearchSkimmerTests.cs
@@ -320,6 +320,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             FileRegionsCache fileRegionsCache = null,
             IFileSystem fileSystem = null)
         {
+            AnalyzeCommand.PushInheritedData(definition, sharedStrings: null);
+
             return new SearchSkimmer(
                 engine: engine ?? RE2Regex.Instance,
                 validators: validators,


### PR DESCRIPTION
@eddynaka 

This change provides a model for populating replacement strings directly from disk. This will allow us to store complex regular expressions without requiring any escaping. This will greatly facilitate developing complex patterns. :)

Also, we should switch to instantiating a skimmer *per rule*. We have a problem today, we support two models: one in which a definition refers to a single rule, with multiple match expressions. The other in which a parent definition flows common information to each match expression. This flexibility isn't serving us well. :) We'll talk more about cleaning it up. For now, I'm aggressively pushing inherited data (and replacing global strings) in match expressions before passing them to the skimmers...