### PR TITLE
Semicolon a separator for search defs files. Update binary files to i…

### DIFF
--- a/Src/Plugins/Security/SEC101.SecurePlaintextSecrets.json
+++ b/Src/Plugins/Security/SEC101.SecurePlaintextSecrets.json
@@ -2,13 +2,10 @@
   "ValidatorsAssemblyName": "Security.dll",
   "Definitions": [
     {
-      "SharedStrings": {
-        "$BinaryFiles": "(?i)\\.(bmp|dll|exe|gif|jpg|jpeg|lock|png|psd|tar\\.gz|tif?|ttf|xcf|zip)$",
-        "$SourceFiles": "(?i)\\.(azure|bat|c|cmd|config|cpp|cs|cscfg|definitions|dtsx|h|hxx|hpp|ini|java|jsx?|json|keys|kt|loadtest|m|md|php|properties|ps1|psm1|pubxml|py|resx|sample|sql|ste|swift|test|tsx?|txt|waz|xml)$"
-      },
       "Id": "SEC101",
       "Name": "DoNotExposePlaintextSecrets",
       "Level": "Error",
+      "FileNameDenyRegex": "$BinaryFiles",
       "Description": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content.",
       "Message": "'{0:scanTarget}' contains an apparent {1:encoding}{2:secretKind}.",
       "MatchExpressions": [

--- a/Src/Plugins/Security/Security.SharedStrings.txt
+++ b/Src/Plugins/Security/Security.SharedStrings.txt
@@ -1,1 +1,24 @@
-﻿$CSourceFiles=(?i)\.(c|cpp|cxx)$
+﻿#
+# This file contains key values pairs which are used to expand variable references in
+# the JSON-based regex pattern definition files. This is useful both to share common
+# regex patterns across multiple rules but also to avoid the complexities of escaping
+# JSON string literals. The strings below are directly testable in web sites such as 
+# reg101.com.
+#
+# Shared strings can be assembled even within this file as long as any shared pattern
+# in a strings only contains variables which are defined earlier in the file. So, 
+# a pattern like this is ok (but these lines in reverse order are not).
+#
+# $MyExample=[a-z]
+# $MyExandedExample=($MyExample|[0-9])
+#
+# Blank lines are ignored when parsing, as are lines that begin with a '#' character.
+# Leading spaces are trimmed at parse time, allowing for indentation.
+
+# Common patterns for file allow and deny lists.
+#
+  $CSourceFiles=(?i)\.(c|cpp|cxx)$
+  $BinaryFiles=(?i)\.(bmp|dll|exe|gif|jpe?g|lock|pack|png|psd|tar\.gz|tiff?|ttf|xcf|zip)$
+  $SourceFiles=(?i)\.(azure|bat|c|cmd|config|cpp|cs|cscfg|definitions|dtsx|h|hxx|hpp|ini|java|jsx?|json|keys|kt|loadtest|m|md|php|properties|ps1|psm1|pubxml|py|resx|sample|sql|ste|swift|test|tsx?|txt|waz|xml)$
+
+

--- a/Src/Sarif.PatternMatcher/AnalyzeOptions.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeOptions.cs
@@ -15,6 +15,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
         [Option(
             'd',
             "search-definitions",
+            Separator = ';',
             HelpText = "A path to a file containing one or more search definitions to drive analysis.")]
         public IEnumerable<string> SearchDefinitionsPaths { get; internal set; }
 

--- a/Src/Sarif.PatternMatcher/ValidateOptions.cs
+++ b/Src/Sarif.PatternMatcher/ValidateOptions.cs
@@ -15,6 +15,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
         [Option(
             'd',
             "search-definitions",
+            Separator = ';',
             HelpText = "A path to a file containing one or more search definitions to drive analysis.")]
         public IEnumerable<string> SearchDefinitionsPaths { get; internal set; }
     }


### PR DESCRIPTION
…nclude pack files. Use deny list for security rules.

@eddynaka, simple but important fixes.
@cfaucon 
@jameswinkler 
@yongyan-gh 