### PR TITLE
PostgreSql Connection String Validator

### DIFF
--- a/Src/Plugins/Security/PostgreSqlConnectionStringValidator.cs
+++ b/Src/Plugins/Security/PostgreSqlConnectionStringValidator.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Text;
+
+using Microsoft.RE2.Managed;
+
+using Npgsql;
+
+namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
+{
+    public class PostgreSqlConnectionStringValidator : ValidatorBase
+    {
+        internal static PostgreSqlConnectionStringValidator Instance;
+        internal static IRegex RegexEngine;
+
+        static PostgreSqlConnectionStringValidator()
+        {
+            Instance = new PostgreSqlConnectionStringValidator();
+            RegexEngine = RE2Regex.Instance;
+        }
+
+        public static string IsValidStatic(ref string matchedPattern,
+                                           ref Dictionary<string, string> groups,
+                                           ref string failureLevel,
+                                           ref string fingerprint,
+                                           ref string message)
+        {
+            return ValidatorBase.IsValidStatic(Instance,
+                                               ref matchedPattern,
+                                               ref groups,
+                                               ref failureLevel,
+                                               ref fingerprint,
+                                               ref message);
+        }
+
+        public static string IsValidDynamic(ref string fingerprint, ref string message)
+        {
+            return ValidatorBase.IsValidDynamic(Instance,
+                                                ref fingerprint,
+                                                ref message);
+        }
+
+        protected override string IsValidStaticHelper(ref string matchedPattern, ref Dictionary<string, string> groups, ref string failureLevel, ref string fingerprintText, ref string message)
+        {
+            if (!groups.TryGetValue("host", out string host) ||
+                !groups.TryGetValue("database", out string database) ||
+                !groups.TryGetValue("account", out string account) ||
+                !groups.TryGetValue("password", out string password))
+            {
+                return nameof(ValidationState.NoMatch);
+            }
+
+            fingerprintText = new Fingerprint()
+            {
+                Host = host.Replace("\"", string.Empty).Replace(",", ";"),
+                Database = database,
+                Account = account,
+                Password = password,
+            }.ToString();
+
+            return nameof(ValidationState.Unknown);
+        }
+
+        protected override string IsValidDynamicHelper(ref string fingerprintText,
+                                                       ref string message)
+        {
+            NpgsqlConnectionFactory npgsqlConnectionFactory = new NpgsqlConnectionFactory();
+
+            var fingerprint = new Fingerprint(fingerprintText);
+
+            string connString = $"Host={fingerprint.Host};Database={fingerprint.Database};Username={fingerprint.Account};Password={fingerprint.Password}";
+
+            try
+            {
+                DbConnection postgreSqlconnection = npgsqlConnectionFactory.CreateConnection(connString);
+                postgreSqlconnection.Open();
+            }
+            catch (Exception e)
+            {
+                // TODO: Are any specific exceptions thrown here?  Npg documentation is lacking
+
+                return ReturnUnhandledException(ref message, e, asset: fingerprint.Host);
+            }
+
+            return ReturnAuthorizedAccess(ref message, asset: fingerprint.Host);
+        }
+    }
+}

--- a/Src/Plugins/Security/SEC101.SecurePlaintextSecrets.json
+++ b/Src/Plugins/Security/SEC101.SecurePlaintextSecrets.json
@@ -186,6 +186,13 @@
           "SubId": "Php",
           "ContentsRegex": "$MySqlConnectionStringPhp",
           "MessageArguments": { "secretKind": "PHP MySQL connection string" }
+        },
+        {
+          "Id": "SEC101/114",
+          "Name": "DoNotExposePlaintextSecrets/PostgreSqlConnectionString",
+          "SubId": "ADO",
+          "ContentsRegex": "$PostgreSqlConnectionStringAdo",
+          "MessageArguments": { "secretKind": "ADO PostgreSQL connection string" }
         }
       ]
     }

--- a/Src/Plugins/Security/Security.SharedStrings.txt
+++ b/Src/Plugins/Security/Security.SharedStrings.txt
@@ -31,3 +31,4 @@
   $MySqlConnectionStringAdo=(?i)Server\s*=(?<host>[^,;]+mysql\.database\.azure\.com.*)(,|;).*Uid=(?<account>[a-z\@\-]+)(,|;).*Pwd=(?<password>[^;]+);
   $MySqlConnectionStringPhp=(?i)user=\"(?<account>[a-z\@\-]+)(\").*password=(?<password>[^;]+)(,).*host=\"(?<host>[^;]+), ssl_ca
   $SlackToken=\b(?<refine>xox(?<type>p|b|a|o|r|s)-(?i)[0-9a-z\-]+)
+  $PostgreSqlConnectionStringAdo=(?i)Host\s*=(?-i)(?<host>[0-9a-z\-_]{3,91});(?i)Database\s*=(?-i)(?<database>[0-9a-z\-_]{3,91});Username=(?<account>[^,;]+);Password=(?<password>[^,;\s]+)

--- a/Src/Plugins/Security/Security.csproj
+++ b/Src/Plugins/Security/Security.csproj
@@ -28,6 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.IdentityManagement" Version="3.5.0.61" />
+    <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.1" />
     <PackageReference Include="GoogleApi" Version="3.10.5" />
     <PackageReference Include="MySqlConnector" Version="1.2.1" />
     <PackageReference Include="System.Text.Json" Version="5.0.1" />

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_114.PostgreSqlConnectionString.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_114.PostgreSqlConnectionString.sarif
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "testhost",
+          "organization": "Microsoft Corporation",
+          "product": "Microsoft.TestHost",
+          "fullName": "testhost 15.0.0.0",
+          "version": "15.0.0.0",
+          "semanticVersion": "15.0.0",
+          "rules": [
+            {
+              "id": "SEC101/114",
+              "name": "DoNotExposePlaintextSecrets/PostgreSqlConnectionString",
+              "fullDescription": {
+                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
+              },
+              "messageStrings": {
+                "NotApplicable_InvalidMetadata": {
+                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                },
+                "ADO": {
+                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                }
+              },
+              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
+            }
+          ]
+        }
+      },
+      "invocations": [
+        {
+          "executionSuccessful": true
+        }
+      ],
+      "results": [
+        {
+          "ruleId": "SEC101/114",
+          "ruleIndex": 0,
+          "message": {
+            "id": "ADO",
+            "arguments": [
+              "SEC101_114.PostgreSqlConnectionString.ps1",
+              "an apparent ",
+              "",
+              "ADO PostgreSQL connection string",
+              "",
+              " (no validation occurred as it was not enabled. Pass '--dynamic-validation' on the command-line to validate this match)"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_114.PostgreSqlConnectionString.ps1",
+                  "uriBaseId": "SRC_ROOT"
+                },
+                "region": {
+                  "startLine": 4,
+                  "startColumn": 1,
+                  "endLine": 4,
+                  "endColumn": 60,
+                  "charOffset": 47,
+                  "charLength": 59,
+                  "snippet": {
+                    "text": "Host=my_host;Database=my_db;Username=my_user;Password=my_pw"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "ValidationFingerprint/v1": "[acct=my_user][host=my_host][pwd=my_pw]"
+          }
+        }
+      ],
+      "columnKind": "utf16CodeUnits"
+    }
+  ]
+}

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_114.PostgreSqlConnectionString.ps1
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_114.PostgreSqlConnectionString.ps1
@@ -1,0 +1,69 @@
+﻿# ADO.NET
+# Using Npgsql
+# Currently caught
+Host=my_host;Database=my_db;Username=my_user;Password=my_pw
+############### The rest of these patterns are not implemented!!
+Username=mylogin;Password=mypass;Database=mydatabase
+Password=mypass;Database=mydatabase;Username=mylogin;
+
+# JDBC
+# Dream validation will catch the first method of connection string declaration
+# but it's not expected.
+String url = "jdbc:postgresql://localhost/test";
+Properties props = new Properties();
+props.setProperty("user","fred");
+props.setProperty("password","secret");
+props.setProperty("ssl","true");
+Connection conn = DriverManager.getConnection(url, props);
+
+jdbc:postgresql://localhost/test?user=fred&password=secret&ssl=true
+
+# Node.js
+# Using node-postgresql
+# Node uses environment variables by default, which would be declared something like the first method
+PGUSER=dbuser \
+PGHOST=database.server.com \
+PGPASSWORD=secretpassword \
+PGDATABASE=mydb \
+PGPORT=3211 \
+node script.js
+
+const pool = new Pool({
+  user: 'dbuser',
+  host: 'database.server.com',
+  database: 'mydb',
+  password: 'secretpassword',
+  port: 3211,
+})
+
+const pool = new Pool({ user: 'dbuser', host: 'database.server.com', database: 'mydb', password: 'secretpassword', port: 3211,})
+
+const client = new Client({
+  user: 'dbuser',
+  host: 'database.server.com',
+  database: 'mydb',
+  password: 'secretpassword',
+  port: 3211,
+})
+
+const client = new Client({ user: 'dbuser', host: 'database.server.com', database: 'mydb', password: 'secretpassword', port: 3211,})
+
+# PHP
+$dbconn3 = pg_connect("host=sheep port=5432 dbname=mary user=lamb password=foo");
+$conn_string = "host=sheep port=5432 dbname=test user=lamb password=bar";
+$dbconn4 = pg_connect($conn_string);
+
+# Python
+# Using psycopg2 
+conn = psycopg2.connect("dbname=suppliers user=postgres password=postgres")
+conn = psycopg2.connect(
+    host="localhost",
+    database="suppliers",
+    user="postgres",
+    password="Abcd1234")
+
+conn = psycopg2.connect(host="localhost",database="suppliers",user="postgres",password="Abcd1234")
+
+# Ruby
+# Using libpq 
+con = PG.connect :dbname => 'testdb', :user => 'janbodnar', :password => 'pswd37'

--- a/Src/Plugins/Tests.Security/Tests.Security.csproj
+++ b/Src/Plugins/Tests.Security/Tests.Security.csproj
@@ -14,6 +14,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="TestData\SecurePlaintextSecrets\ExpectedOutputs\SEC101_114.PostgreSqlConnectionString.sarif" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\Sarif.PatternMatcher\Sarif.PatternMatcher.csproj" />
     <ProjectReference Include="..\Security\Security.csproj" />
     <ProjectReference Include="..\..\sarif-sdk\src\Sarif\Sarif.csproj" />

--- a/Src/Sarif.PatternMatcher/Fingerprint.cs
+++ b/Src/Sarif.PatternMatcher/Fingerprint.cs
@@ -13,6 +13,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
         public const string UriKeyName = "uri";
         public const string HmacKeyName = "hmac";
         public const string HostKeyName = "host";
+        public const string DatabaseKeyName = "database";
         public const string AccountKeyName = "acct";
         public const string PasswordKeyName = "pwd";
         public const string KeyNameKeyName = "keyName";
@@ -26,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
         public Fingerprint(string fingerprintText)
         {
-            Account = Hmac = Host = Id = Key = KeyName = Password = Uri = SasToken = null;
+            Account = Hmac = Host = Database = Id = Key = KeyName = Password = Uri = SasToken = null;
             PersonalAccessToken = SymmetricKey128Bit = SymmetricKey256Bit = Thumbprint = null;
 
             fingerprintText = fingerprintText ??
@@ -72,6 +73,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
         public string Host { get; set; }
 
+        public string Database { get; set; }
+
         public string Account { get; set; }
 
         public string KeyName { get; set; }
@@ -100,6 +103,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 case UriKeyName: { Uri = value; break; }
                 case HmacKeyName: { Hmac = value; break; }
                 case HostKeyName: { Host = value; break; }
+                case DatabaseKeyName: { Database = value; break; }
                 case AccountKeyName: { Account = value; break; }
                 case KeyNameKeyName: { KeyName = value; break; }
                 case PasswordKeyName: { Password = value; break; }
@@ -131,6 +135,11 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             if (!string.IsNullOrEmpty(Host))
             {
                 components.Add($"[{HostKeyName}={this.Host.Trim()}]");
+            }
+
+            if (!string.IsNullOrEmpty(Database))
+            {
+                components.Add($"[{DatabaseKeyName}={this.Database.Trim()}]");
             }
 
             if (!string.IsNullOrEmpty(Id))


### PR DESCRIPTION
Add new validator and accompanying files.  Only the first and most basic form of connection string has a regex.  The rest are unimplemented.