### PR TITLE
Updating SqlConnectionString and GitHubPat validators

### DIFF
--- a/Src/.editorconfig
+++ b/Src/.editorconfig
@@ -204,4 +204,12 @@ dotnet_diagnostic.CS1591.severity = silent
 dotnet_diagnostic.CS1712.severity = silent
 dotnet_diagnostic.CS1734.severity = silent
 
+# SA1649: File name should match first type name
+dotnet_diagnostic.SA1649.severity = none
+
 file_header_template = Copyright (c) Microsoft. All rights reserved.\nLicensed under the MIT license. See LICENSE file in the project root for full license information.
+
+[*Tests.cs]
+
+# CS1591: Missing XML comment for publicly visible type or member
+dotnet_diagnostic.CS1591.severity = none

--- a/Src/Plugins/Security/SEC101_006.GitHubPatValidator.cs
+++ b/Src/Plugins/Security/SEC101_006.GitHubPatValidator.cs
@@ -66,7 +66,16 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                 return nameof(ValidationState.NoMatch);
             }
 
-            if (matchedPattern.Contains("/commit/") || matchedPattern.Contains("/tree/") || matchedPattern.Contains("githubusercontent.com"))
+            if (matchedPattern.IndexOf("commit", StringComparison.OrdinalIgnoreCase) >= 0
+                || matchedPattern.IndexOf("tree", StringComparison.OrdinalIgnoreCase) >= 0
+                || matchedPattern.IndexOf("blob", StringComparison.OrdinalIgnoreCase) >= 0
+                || matchedPattern.IndexOf("gist", StringComparison.OrdinalIgnoreCase) >= 0
+                || matchedPattern.IndexOf("raw", StringComparison.OrdinalIgnoreCase) >= 0
+                || matchedPattern.IndexOf("repos", StringComparison.OrdinalIgnoreCase) >= 0
+                || matchedPattern.IndexOf("spec", StringComparison.OrdinalIgnoreCase) >= 0
+                || matchedPattern.IndexOf("assets", StringComparison.OrdinalIgnoreCase) >= 0
+                || matchedPattern.IndexOf("using ref", StringComparison.OrdinalIgnoreCase) >= 0
+                || matchedPattern.IndexOf("githubusercontent.com", StringComparison.OrdinalIgnoreCase) >= 0)
             {
                 return nameof(ValidationState.NoMatch);
             }

--- a/Src/Plugins/Security/SEC101_006.GitHubPatValidator.cs
+++ b/Src/Plugins/Security/SEC101_006.GitHubPatValidator.cs
@@ -14,8 +14,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
     internal class GitHubPatValidator : ValidatorBase
     {
-        internal static GitHubPatValidator Instance;
         internal static IRegex RegexEngine;
+        internal static GitHubPatValidator Instance;
 
         private const string PatExpression = "[0-9a-z]{40}";
 
@@ -66,16 +66,16 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                 return nameof(ValidationState.NoMatch);
             }
 
-            if (matchedPattern.IndexOf("commit", StringComparison.OrdinalIgnoreCase) >= 0
-                || matchedPattern.IndexOf("tree", StringComparison.OrdinalIgnoreCase) >= 0
-                || matchedPattern.IndexOf("blob", StringComparison.OrdinalIgnoreCase) >= 0
-                || matchedPattern.IndexOf("gist", StringComparison.OrdinalIgnoreCase) >= 0
-                || matchedPattern.IndexOf("raw", StringComparison.OrdinalIgnoreCase) >= 0
-                || matchedPattern.IndexOf("repos", StringComparison.OrdinalIgnoreCase) >= 0
-                || matchedPattern.IndexOf("spec", StringComparison.OrdinalIgnoreCase) >= 0
-                || matchedPattern.IndexOf("assets", StringComparison.OrdinalIgnoreCase) >= 0
-                || matchedPattern.IndexOf("using ref", StringComparison.OrdinalIgnoreCase) >= 0
-                || matchedPattern.IndexOf("githubusercontent.com", StringComparison.OrdinalIgnoreCase) >= 0)
+            if (matchedPattern.IndexOf("commit", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                matchedPattern.IndexOf("tree", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                matchedPattern.IndexOf("blob", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                matchedPattern.IndexOf("gist", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                matchedPattern.IndexOf("raw", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                matchedPattern.IndexOf("repos", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                matchedPattern.IndexOf("spec", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                matchedPattern.IndexOf("assets", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                matchedPattern.IndexOf("using ref", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                matchedPattern.IndexOf("githubusercontent.com", StringComparison.OrdinalIgnoreCase) >= 0)
             {
                 return nameof(ValidationState.NoMatch);
             }

--- a/Src/Plugins/Security/SEC101_045.PostgreSqlConnectionStringValidator.cs
+++ b/Src/Plugins/Security/SEC101_045.PostgreSqlConnectionStringValidator.cs
@@ -15,11 +15,11 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
     {
         internal static PostgreSqlConnectionStringValidator Instance;
         internal static IRegex RegexEngine;
-        private const string HostRegex = "(?i)(Host\\s*=\\s*(?-i)(?<host>[\\w\\-_\\.]{3,91}))";
-        private const string PortRegex = "(?i)(Port\\s*=\\s*(?<port>[0-9]{1,5}))";
-        private const string AccountRegex = "(?i)(Username\\s*=\\s*(?<account>[^,;]+))";
-        private const string PasswordRegex = "(?i)(Password\\s*=\\s*(?<account>[^,;\"\\s]+))";
-        private const string DatabaseRegex = "(?i)(Database\\s*=\\s*(?<database>[^;]+))";
+        private const string HostRegex = @"(?i)(host|server)\s*=\s*(?-i)(?<host>[\w\-_\.]{3,91})";
+        private const string PortRegex = @"(?i)Port\s*=\s*(?<port>[0-9]{1,5})";
+        private const string AccountRegex = @"(?i)(username|uid|user id)\s*=\s*(?<account>[^,;]+)";
+        private const string PasswordRegex = @"(?i)(password|pwd)\s*=\s*(?<password>[^,;""\s]+)";
+        private const string DatabaseRegex = @"(?i)(database|db)\s*=\s*(?<database>[^;]+)";
 
         static PostgreSqlConnectionStringValidator()
         {
@@ -63,6 +63,13 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             if (string.IsNullOrWhiteSpace(host) ||
                 string.IsNullOrWhiteSpace(account) ||
                 string.IsNullOrWhiteSpace(password))
+            {
+                return nameof(ValidationState.NoMatch);
+            }
+
+            // Ignoring Azure SQL and Azure MySQL databases
+            if (host.EndsWith("database.windows.net", StringComparison.OrdinalIgnoreCase)
+                || host.EndsWith("mysql.database.azure.com", StringComparison.OrdinalIgnoreCase))
             {
                 return nameof(ValidationState.NoMatch);
             }

--- a/Src/Plugins/Security/SEC101_045.PostgreSqlConnectionStringValidator.cs
+++ b/Src/Plugins/Security/SEC101_045.PostgreSqlConnectionStringValidator.cs
@@ -67,9 +67,14 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                 return nameof(ValidationState.NoMatch);
             }
 
-            // Ignoring Azure SQL and Azure MySQL databases
-            if (host.EndsWith("database.windows.net", StringComparison.OrdinalIgnoreCase)
-                || host.EndsWith("mysql.database.azure.com", StringComparison.OrdinalIgnoreCase))
+            if (LocalhostList.Contains(host))
+            {
+                host = "localhost";
+            }
+
+            // Other rules will handle these cases.
+            if (host.EndsWith("database.windows.net", StringComparison.OrdinalIgnoreCase) ||
+                host.EndsWith("mysql.database.azure.com", StringComparison.OrdinalIgnoreCase))
             {
                 return nameof(ValidationState.NoMatch);
             }
@@ -90,6 +95,11 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                                        ref string message)
         {
             var fingerprint = new Fingerprint(fingerprintText);
+
+            if (LocalhostList.Contains(fingerprint.Host))
+            {
+                return nameof(ValidationState.Unknown);
+            }
 
             var connectionStringBuilder = new StringBuilder();
             connectionStringBuilder.Append($"Host={fingerprint.Host};Username={fingerprint.Account};Password={fingerprint.Password};Ssl Mode=Require;");

--- a/Src/Plugins/Security/SEC101_046.SqlConnectionStringValidator.cs
+++ b/Src/Plugins/Security/SEC101_046.SqlConnectionStringValidator.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
         private const string PasswordExpression = @"(?i)(Password|Pwd)\s*=\s*[^;<]+";
         private const string ClientIPExpression = @"Client with IP address '[^']+' is not allowed to access the server.";
 
-        private readonly HashSet<string> ignoreList = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase)
+        private readonly HashSet<string> ignoreList = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "localhost",
             "(local)",

--- a/Src/Plugins/Security/SEC101_046.SqlConnectionStringValidator.cs
+++ b/Src/Plugins/Security/SEC101_046.SqlConnectionStringValidator.cs
@@ -96,6 +96,13 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                 return nameof(ValidationState.NoMatch);
             }
 
+            // Ignoring Azure MySQL and Azure Postgres databases
+            if (host.EndsWith("postgres.database.azure.com", StringComparison.OrdinalIgnoreCase)
+                || host.EndsWith("mysql.database.azure.com", StringComparison.OrdinalIgnoreCase))
+            {
+                return nameof(ValidationState.NoMatch);
+            }
+
             if (ignoreList.Contains(host))
             {
                 return nameof(ValidationState.NoMatch);

--- a/Src/Plugins/Security/SEC101_047.MySqlConnectionStringValidator.cs
+++ b/Src/Plugins/Security/SEC101_047.MySqlConnectionStringValidator.cs
@@ -69,9 +69,14 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Internal
                 return nameof(ValidationState.NoMatch);
             }
 
-            // Ignoring Azure SQL and Azure Postgres databases
-            if (host.EndsWith("database.windows.net", StringComparison.OrdinalIgnoreCase)
-                || host.EndsWith("postgres.database.azure.com", StringComparison.OrdinalIgnoreCase))
+            if (LocalhostList.Contains(host))
+            {
+                host = "localhost";
+            }
+
+            // Other rules will handle these cases.
+            if (host.EndsWith("database.windows.net", StringComparison.OrdinalIgnoreCase) ||
+                host.EndsWith("postgres.database.azure.com", StringComparison.OrdinalIgnoreCase))
             {
                 return nameof(ValidationState.NoMatch);
             }
@@ -99,7 +104,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Internal
             string account = fingerprint.Account;
             string password = fingerprint.Password;
 
-            StringBuilder connectionStringBuilder = new StringBuilder();
+            if (LocalhostList.Contains(host))
+            {
+                return nameof(ValidationState.Unknown);
+            }
+
+            var connectionStringBuilder = new StringBuilder();
             connectionStringBuilder.Append($"Server={host}; Database={database}; Uid={account}; Pwd={password}; SslMode=Preferred;");
 
             if (!string.IsNullOrWhiteSpace(port))

--- a/Src/Plugins/Security/SEC101_047.MySqlConnectionStringValidator.cs
+++ b/Src/Plugins/Security/SEC101_047.MySqlConnectionStringValidator.cs
@@ -69,6 +69,13 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Internal
                 return nameof(ValidationState.NoMatch);
             }
 
+            // Ignoring Azure SQL and Azure Postgres databases
+            if (host.EndsWith("database.windows.net", StringComparison.OrdinalIgnoreCase)
+                || host.EndsWith("postgres.database.azure.com", StringComparison.OrdinalIgnoreCase))
+            {
+                return nameof(ValidationState.NoMatch);
+            }
+
             fingerprintText = new Fingerprint()
             {
                 Host = host.Replace("\"", string.Empty).Replace(",", ";"),

--- a/Src/Plugins/Security/Security.SharedStrings.txt
+++ b/Src/Plugins/Security/Security.SharedStrings.txt
@@ -33,4 +33,4 @@
   $SqlConnectionStringJdbc=(?i)jdbc:sqlserver:\/\/(?<host>[^;]+);database\s*=\s*(?<database>[^;]+);user\s*=\s*(?<account>[^@]+)@[^;]+;password\s*=\s*(?<password>[^;]+);
   $SqlConnectionStringPhp=(?i)sqlsrv:server\s*=\s*(?<host>[^;]+);\s*Database\s*=\s*(?<database>[^\"]+)",\s*"(?<account>[^"]+)",\s*"(?<password>[^"]+)"
   $SlackToken=\b(?<refine>xox(?<type>p|b|a|o|r|s)-(?i)[0-9a-z\-]+)
-  $PostgreSqlConnectionStringAdo=((?i)(((Port\s*=\s*([0-9]{1,5}))|(Database\s*=\s*[^;]+));.*)?(Host\s*=\s*[\w\-_\.]{3,91}|Username\s*=\s*[^,;\"\s]+|Password\s*=\s*[^,;\"\s]+).+?){3}(.*((Port\s*=\s*[0-9]{1,5})|(Database\s*=\s*[^;]+)))?
+  $PostgreSqlConnectionStringAdo=((?i)(((Port\s*=\s*([0-9]{1,5}))|((database|db)\s*=\s*[^;]+));.*)?((host|server)\s*=\s*[\w\-_\.]{3,91}|(username|uid|user id)\s*=\s*[^,;\"\s]+|(password|pwd)\s*=\s*[^,;\"\s]+).+?){3}(.*((Port\s*=\s*[0-9]{1,5})|((database|db)\s*=\s*[^;]+)))?

--- a/Src/Plugins/Security/Security.SharedStrings.txt
+++ b/Src/Plugins/Security/Security.SharedStrings.txt
@@ -25,7 +25,7 @@
   $AwsCredentials=(?s)\b(?<id>(A3T[0-9A-Z]|AKIA|AGPA|AROA|AIPA|ANPA|ANVA|ASIA)[0-9A-Z]{16}).+?\b(?i)(?<key>[0-9a-z\/+]{40})
   $FacebookAppCredentials=(?si)(facebook|fb)(.{0,20})?[`'"\s>](?<id>[0-9]{13,17})[^0-9].+?(facebook|fb)(.{0,20})?[`'"\s>](?<key>[0-9a-f]{32})([^0-9a-f]|$)
   $GitHubAppCredentials=(?s)\b(?<id>Iv1.[0-9a-z]{16}).+?\b(?i)(?<key>[0-9a-z]{35,40})([^0-9a-f]|$)
-  $GitHubPat=(?si)(?<refine>github.{0,50}[0-9a-z]{40})([^0-9a-z]|$)
+  $GitHubPat=(?si)(?<refine>github.{0,50}[^0-9a-z][0-9a-z]{40})([^0-9a-z]|$)
   $GoogleApiKey=\b(?<refine>AIza(?i)[0-9a-z-_]{35})([^0-9a-z-_]|$)
   $HockeyAppToken=(?si)hockey.{0,50}[`'"\s>]?(?<refine>[0-9a-f]{32})([^0-9a-f]|$)
   $MySqlConnectionStringAdo=(?i)(Port\s*=\s*([0-9]{4,5}).*)?(((Server\s*=\s*(?<host>[\w\-.]{3,90}))|(Uid=(?-i)(?<account>[a-z\@\-]{1,120})(?i))|(Pwd=(?<password>[^;]{8,128}))).*?){3}(.*Port\s*=\s*([0-9]{4,5}))?

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_046.SqlConnectionString.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_046.SqlConnectionString.sarif
@@ -13,6 +13,22 @@
           "semanticVersion": "15.0.0",
           "rules": [
             {
+              "id": "SEC101/045",
+              "name": "DoNotExposePlaintextSecrets/PostgreSqlConnectionString",
+              "fullDescription": {
+                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
+              },
+              "messageStrings": {
+                "NotApplicable_InvalidMetadata": {
+                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                },
+                "Ado": {
+                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                }
+              },
+              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
+            },
+            {
               "id": "SEC101/046",
               "name": "DoNotExposePlaintextSecrets/SqlConnectionString",
               "fullDescription": {
@@ -60,8 +76,47 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/046",
+          "ruleId": "SEC101/045",
           "ruleIndex": 0,
+          "message": {
+            "id": "Ado",
+            "arguments": [
+              "SEC101_046.SqlConnectionString.ps1",
+              "an apparent ",
+              "",
+              "ADO PostgreSQL connection string",
+              "",
+              " (no validation occurred as it was not enabled. Pass '--dynamic-validation' on the command-line to validate this match)"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_046.SqlConnectionString.ps1",
+                  "uriBaseId": "SRC_ROOT"
+                },
+                "region": {
+                  "startLine": 5,
+                  "startColumn": 40,
+                  "endLine": 5,
+                  "endColumn": 157,
+                  "charOffset": 422,
+                  "charLength": 117,
+                  "snippet": {
+                    "text": "Server=tcp:some-database-name.database.windows.net,1433;Database=tse-internal-spam-testing;Uid=username;Pwd=password;"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "ValidationFingerprint/v1": "[acct=username][host=tcp][pwd=password][resource=tse-internal-spam-testing]"
+          }
+        },
+        {
+          "ruleId": "SEC101/046",
+          "ruleIndex": 1,
           "message": {
             "id": "Odbc",
             "arguments": [
@@ -100,7 +155,7 @@
         },
         {
           "ruleId": "SEC101/046",
-          "ruleIndex": 0,
+          "ruleIndex": 1,
           "message": {
             "id": "Odbc",
             "arguments": [
@@ -139,7 +194,7 @@
         },
         {
           "ruleId": "SEC101/046",
-          "ruleIndex": 0,
+          "ruleIndex": 1,
           "message": {
             "id": "Odbc",
             "arguments": [
@@ -178,7 +233,7 @@
         },
         {
           "ruleId": "SEC101/046",
-          "ruleIndex": 0,
+          "ruleIndex": 1,
           "message": {
             "id": "Odbc",
             "arguments": [
@@ -217,7 +272,7 @@
         },
         {
           "ruleId": "SEC101/046",
-          "ruleIndex": 0,
+          "ruleIndex": 1,
           "message": {
             "id": "Odbc",
             "arguments": [
@@ -256,7 +311,7 @@
         },
         {
           "ruleId": "SEC101/046",
-          "ruleIndex": 0,
+          "ruleIndex": 1,
           "message": {
             "id": "Odbc",
             "arguments": [
@@ -295,7 +350,7 @@
         },
         {
           "ruleId": "SEC101/046",
-          "ruleIndex": 0,
+          "ruleIndex": 1,
           "message": {
             "id": "Odbc",
             "arguments": [
@@ -334,7 +389,7 @@
         },
         {
           "ruleId": "SEC101/046",
-          "ruleIndex": 0,
+          "ruleIndex": 1,
           "message": {
             "id": "Jdbc",
             "arguments": [
@@ -373,7 +428,7 @@
         },
         {
           "ruleId": "SEC101/046",
-          "ruleIndex": 0,
+          "ruleIndex": 1,
           "message": {
             "id": "Php",
             "arguments": [
@@ -412,7 +467,7 @@
         },
         {
           "ruleId": "SEC101/047",
-          "ruleIndex": 1,
+          "ruleIndex": 2,
           "message": {
             "id": "Odbc",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_046.SqlConnectionString.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_046.SqlConnectionString.sarif
@@ -430,6 +430,123 @@
           "ruleId": "SEC101/046",
           "ruleIndex": 1,
           "message": {
+            "id": "Jdbc",
+            "arguments": [
+              "SEC101_046.SqlConnectionString.ps1",
+              "an apparent ",
+              "",
+              "JDBC SQL connection string",
+              "",
+              " (no validation occurred as it was not enabled. Pass '--dynamic-validation' on the command-line to validate this match)"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_046.SqlConnectionString.ps1",
+                  "uriBaseId": "SRC_ROOT"
+                },
+                "region": {
+                  "startLine": 37,
+                  "startColumn": 1,
+                  "endLine": 37,
+                  "endColumn": 114,
+                  "charOffset": 2201,
+                  "charLength": 113,
+                  "snippet": {
+                    "text": "jdbc:sqlserver://localhost;database=tse-internal-spam-testing;user=username@some-database-name;password=password;"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "ValidationFingerprint/v1": "[acct=username][host=localhost][pwd=password][resource=tse-internal-spam-testing]"
+          }
+        },
+        {
+          "ruleId": "SEC101/046",
+          "ruleIndex": 1,
+          "message": {
+            "id": "Jdbc",
+            "arguments": [
+              "SEC101_046.SqlConnectionString.ps1",
+              "an apparent ",
+              "",
+              "JDBC SQL connection string",
+              "",
+              " (no validation occurred as it was not enabled. Pass '--dynamic-validation' on the command-line to validate this match)"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_046.SqlConnectionString.ps1",
+                  "uriBaseId": "SRC_ROOT"
+                },
+                "region": {
+                  "startLine": 38,
+                  "startColumn": 1,
+                  "endLine": 38,
+                  "endColumn": 112,
+                  "charOffset": 2419,
+                  "charLength": 111,
+                  "snippet": {
+                    "text": "jdbc:sqlserver://(local);database=tse-internal-spam-testing;user=username@some-database-name;password=password;"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "ValidationFingerprint/v1": "[acct=username][host=localhost][pwd=password][resource=tse-internal-spam-testing]"
+          }
+        },
+        {
+          "ruleId": "SEC101/046",
+          "ruleIndex": 1,
+          "message": {
+            "id": "Jdbc",
+            "arguments": [
+              "SEC101_046.SqlConnectionString.ps1",
+              "an apparent ",
+              "",
+              "JDBC SQL connection string",
+              "",
+              " (no validation occurred as it was not enabled. Pass '--dynamic-validation' on the command-line to validate this match)"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_046.SqlConnectionString.ps1",
+                  "uriBaseId": "SRC_ROOT"
+                },
+                "region": {
+                  "startLine": 39,
+                  "startColumn": 1,
+                  "endLine": 39,
+                  "endColumn": 114,
+                  "charOffset": 2635,
+                  "charLength": 113,
+                  "snippet": {
+                    "text": "jdbc:sqlserver://127.0.0.1;database=tse-internal-spam-testing;user=username@some-database-name;password=password;"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "ValidationFingerprint/v1": "[acct=username][host=localhost][pwd=password][resource=tse-internal-spam-testing]"
+          }
+        },
+        {
+          "ruleId": "SEC101/046",
+          "ruleIndex": 1,
+          "message": {
             "id": "Php",
             "arguments": [
               "SEC101_046.SqlConnectionString.ps1",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_047.MySqlConnectionString.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_047.MySqlConnectionString.sarif
@@ -13,6 +13,22 @@
           "semanticVersion": "15.0.0",
           "rules": [
             {
+              "id": "SEC101/045",
+              "name": "DoNotExposePlaintextSecrets/PostgreSqlConnectionString",
+              "fullDescription": {
+                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
+              },
+              "messageStrings": {
+                "NotApplicable_InvalidMetadata": {
+                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                },
+                "Ado": {
+                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                }
+              },
+              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
+            },
+            {
               "id": "SEC101/046",
               "name": "DoNotExposePlaintextSecrets/SqlConnectionString",
               "fullDescription": {
@@ -60,15 +76,15 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/046",
+          "ruleId": "SEC101/045",
           "ruleIndex": 0,
           "message": {
-            "id": "Odbc",
+            "id": "Ado",
             "arguments": [
               "SEC101_047.MySqlConnectionString.ps1",
               "an apparent ",
               "",
-              "ADO or ODBC SQL connection string",
+              "ADO PostgreSQL connection string",
               "",
               " (no validation occurred as it was not enabled. Pass '--dynamic-validation' on the command-line to validate this match)"
             ]
@@ -81,182 +97,26 @@
                   "uriBaseId": "SRC_ROOT"
                 },
                 "region": {
-                  "startLine": 2,
+                  "startLine": 30,
                   "startColumn": 1,
-                  "endLine": 2,
-                  "endColumn": 131,
-                  "charOffset": 65,
-                  "charLength": 130,
+                  "endLine": 30,
+                  "endColumn": 97,
+                  "charOffset": 2531,
+                  "charLength": 96,
                   "snippet": {
-                    "text": "Server=some-database-name.mysql.database.azure.com; Port=3306; Database=catalog_db; Uid=username@some-database-name; Pwd=password;"
+                    "text": "Server=your-host; Port=3306; Database=your-database; Uid=username@servername; Pwd=your-password;"
                   }
                 }
               }
             }
           ],
           "fingerprints": {
-            "ValidationFingerprint/v1": "[acct=username@some-database-name][host=some-database-name.mysql.database.azure.com][pwd=password][resource=catalog_db]"
+            "ValidationFingerprint/v1": "[acct=username@servername][host=your-host][pwd=your-password][port=3306][resource=your-database]"
           }
         },
         {
           "ruleId": "SEC101/046",
-          "ruleIndex": 0,
-          "message": {
-            "id": "Odbc",
-            "arguments": [
-              "SEC101_047.MySqlConnectionString.ps1",
-              "an apparent ",
-              "",
-              "ADO or ODBC SQL connection string",
-              "",
-              " (no validation occurred as it was not enabled. Pass '--dynamic-validation' on the command-line to validate this match)"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_047.MySqlConnectionString.ps1",
-                  "uriBaseId": "SRC_ROOT"
-                },
-                "region": {
-                  "startLine": 3,
-                  "startColumn": 12,
-                  "endLine": 3,
-                  "endColumn": 131,
-                  "charOffset": 227,
-                  "charLength": 119,
-                  "snippet": {
-                    "text": "Server=some-database-name.mysql.database.azure.com; Database=catalog_db; Uid=username@some-database-name; Pwd=password;"
-                  }
-                }
-              }
-            }
-          ],
-          "fingerprints": {
-            "ValidationFingerprint/v1": "[acct=username@some-database-name][host=some-database-name.mysql.database.azure.com][pwd=password][resource=catalog_db]"
-          }
-        },
-        {
-          "ruleId": "SEC101/046",
-          "ruleIndex": 0,
-          "message": {
-            "id": "Odbc",
-            "arguments": [
-              "SEC101_047.MySqlConnectionString.ps1",
-              "an apparent ",
-              "",
-              "ADO or ODBC SQL connection string",
-              "",
-              " (no validation occurred as it was not enabled. Pass '--dynamic-validation' on the command-line to validate this match)"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_047.MySqlConnectionString.ps1",
-                  "uriBaseId": "SRC_ROOT"
-                },
-                "region": {
-                  "startLine": 4,
-                  "startColumn": 1,
-                  "endLine": 4,
-                  "endColumn": 120,
-                  "charOffset": 367,
-                  "charLength": 119,
-                  "snippet": {
-                    "text": "Server=some-database-name.mysql.database.azure.com; Database=catalog_db; Uid=username@some-database-name; Pwd=password;"
-                  }
-                }
-              }
-            }
-          ],
-          "fingerprints": {
-            "ValidationFingerprint/v1": "[acct=username@some-database-name][host=some-database-name.mysql.database.azure.com][pwd=password][resource=catalog_db]"
-          }
-        },
-        {
-          "ruleId": "SEC101/046",
-          "ruleIndex": 0,
-          "message": {
-            "id": "Odbc",
-            "arguments": [
-              "SEC101_047.MySqlConnectionString.ps1",
-              "an apparent ",
-              "",
-              "ADO or ODBC SQL connection string",
-              "",
-              " (no validation occurred as it was not enabled. Pass '--dynamic-validation' on the command-line to validate this match)"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_047.MySqlConnectionString.ps1",
-                  "uriBaseId": "SRC_ROOT"
-                },
-                "region": {
-                  "startLine": 5,
-                  "startColumn": 1,
-                  "endLine": 5,
-                  "endColumn": 138,
-                  "charOffset": 518,
-                  "charLength": 137,
-                  "snippet": {
-                    "text": "Server=some-database-name.mysql.database.azure.com;Database=catalog_db; SslMode=Preferred; Pwd=password; Uid=username@some-database-name;"
-                  }
-                }
-              }
-            }
-          ],
-          "fingerprints": {
-            "ValidationFingerprint/v1": "[acct=username@some-database-name][host=some-database-name.mysql.database.azure.com][pwd=password][resource=catalog_db]"
-          }
-        },
-        {
-          "ruleId": "SEC101/046",
-          "ruleIndex": 0,
-          "message": {
-            "id": "Odbc",
-            "arguments": [
-              "SEC101_047.MySqlConnectionString.ps1",
-              "an apparent ",
-              "",
-              "ADO or ODBC SQL connection string",
-              "",
-              " (no validation occurred as it was not enabled. Pass '--dynamic-validation' on the command-line to validate this match)"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_047.MySqlConnectionString.ps1",
-                  "uriBaseId": "SRC_ROOT"
-                },
-                "region": {
-                  "startLine": 23,
-                  "startColumn": 1,
-                  "endLine": 25,
-                  "endColumn": 40,
-                  "charOffset": 2186,
-                  "charLength": 175,
-                  "snippet": {
-                    "text": "Database=catalog_db; Data Source=some-database-name.mysql.database.azure.com; User Id=username@some-database-name; Password=password\r\n\r\n################ MariaDB shares the sam"
-                  }
-                }
-              }
-            }
-          ],
-          "fingerprints": {
-            "ValidationFingerprint/v1": "[acct=username@some-database-name][host=some-database-name.mysql.database.azure.com][pwd=password\r\n\r\n################ MariaDB shares the sam][resource=catalog_db]"
-          }
-        },
-        {
-          "ruleId": "SEC101/046",
-          "ruleIndex": 0,
+          "ruleIndex": 1,
           "message": {
             "id": "Odbc",
             "arguments": [
@@ -295,7 +155,7 @@
         },
         {
           "ruleId": "SEC101/046",
-          "ruleIndex": 0,
+          "ruleIndex": 1,
           "message": {
             "id": "Odbc",
             "arguments": [
@@ -334,7 +194,7 @@
         },
         {
           "ruleId": "SEC101/046",
-          "ruleIndex": 0,
+          "ruleIndex": 1,
           "message": {
             "id": "Odbc",
             "arguments": [
@@ -373,7 +233,7 @@
         },
         {
           "ruleId": "SEC101/047",
-          "ruleIndex": 1,
+          "ruleIndex": 2,
           "message": {
             "id": "Odbc",
             "arguments": [
@@ -412,7 +272,7 @@
         },
         {
           "ruleId": "SEC101/047",
-          "ruleIndex": 1,
+          "ruleIndex": 2,
           "message": {
             "id": "Odbc",
             "arguments": [
@@ -451,7 +311,7 @@
         },
         {
           "ruleId": "SEC101/047",
-          "ruleIndex": 1,
+          "ruleIndex": 2,
           "message": {
             "id": "Odbc",
             "arguments": [
@@ -490,7 +350,7 @@
         },
         {
           "ruleId": "SEC101/047",
-          "ruleIndex": 1,
+          "ruleIndex": 2,
           "message": {
             "id": "Odbc",
             "arguments": [
@@ -529,7 +389,7 @@
         },
         {
           "ruleId": "SEC101/047",
-          "ruleIndex": 1,
+          "ruleIndex": 2,
           "message": {
             "id": "Odbc",
             "arguments": [
@@ -568,7 +428,7 @@
         },
         {
           "ruleId": "SEC101/047",
-          "ruleIndex": 1,
+          "ruleIndex": 2,
           "message": {
             "id": "Odbc",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_006.GitHubPat.ps1
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_006.GitHubPat.ps1
@@ -16,3 +16,6 @@ var myGitHubPersonalAccessToken = "ff34885a8624460a855540c6592698d2f1812843";
 https://github.com/microsoft/sarif-pattern-matcher/commit/4196919fb12cc4aa8ec0159a746c1e03b4ffa89c
 https://avatars0.githubusercontent.com/u/16199012?u=4196919fb12cc4aa8ec0159a746c1e03b4ffa89c&v=4
 https://github.com/microsoft/sarif-pattern-matcher/tree/7af498925c89a9e8c07fb8a65223e89d513d4eea
+
+# This should trigger, but it should report as NoMatch
+GitHubTriggersShouldReturnBothSourceRepoAndPullRequestTriggers

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_046.SqlConnectionString.ps1
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_046.SqlConnectionString.ps1
@@ -32,3 +32,8 @@ new PDO("sqlsrv:server = tcp:some-database-name.database.windows.net,1433; Datab
   <add key="ConnectionString" value="Password=password;User ID=username;Initial Catalog=catalog-db;Data Source=server-name;" />
   <add key="ConnectionString" value="Initial Catalog=catalog-db;Data Source=server-name;Password=password;User ID=username;" />
 </appSettings>
+
+# Should be ignored, since is localhost/(local)/127.0.0.1
+jdbc:sqlserver://localhost;database=tse-internal-spam-testing;user=username@some-database-name;password=password;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.database.windows.net;loginTimeout=30;
+jdbc:sqlserver://(local);database=tse-internal-spam-testing;user=username@some-database-name;password=password;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.database.windows.net;loginTimeout=30;
+jdbc:sqlserver://127.0.0.1;database=tse-internal-spam-testing;user=username@some-database-name;password=password;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.database.windows.net;loginTimeout=30;

--- a/Src/Plugins/ValidatorBase.cs
+++ b/Src/Plugins/ValidatorBase.cs
@@ -76,6 +76,11 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins
         {
             bool oneDigit = false, oneLetter = false;
 
+            if (string.IsNullOrWhiteSpace(matchedPattern))
+            {
+                return false;
+            }
+
             foreach (char ch in matchedPattern)
             {
                 if (char.IsDigit(ch)) { oneDigit = true; }

--- a/Src/Plugins/ValidatorBase.cs
+++ b/Src/Plugins/ValidatorBase.cs
@@ -12,6 +12,13 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins
 {
     public abstract class ValidatorBase
     {
+        public static readonly HashSet<string> LocalhostList = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "localhost",
+            "(local)",
+            "127.0.0.1",
+        };
+
         static ValidatorBase()
         {
             ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
@@ -75,11 +82,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins
         public static bool ContainsDigitAndChar(string matchedPattern)
         {
             bool oneDigit = false, oneLetter = false;
-
-            if (string.IsNullOrWhiteSpace(matchedPattern))
-            {
-                return false;
-            }
 
             foreach (char ch in matchedPattern)
             {


### PR DESCRIPTION
## Changes for SqlConnectionString
- Adding host/account/database/password limits based on docs.microsoft
- Adding ignoreList (this will reduce 1500 results)

## Changes for GitHubPat
- Adding more words to ignore in case it finds something in the matched pattern
- Checking if string is not null or whitespace before checking for letters and numbers, preventing a null reference