### PR TITLE
Unicode escaping

### DIFF
--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -134,12 +134,13 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
         public override void Analyze(AnalyzeContext context)
         {
+            string filePath = context.TargetUri.OriginalString;
+
             if (context.FileContents == null)
             {
-                context.FileContents = _fileSystem.FileReadAllText(context.TargetUri.LocalPath);
+                context.FileContents = _fileSystem.FileReadAllText(filePath);
             }
 
-            string filePath = context.TargetUri.GetFilePath();
             foreach (MatchExpression matchExpression in _matchExpressions)
             {
                 if (!string.IsNullOrEmpty(matchExpression.FileNameAllowRegex))

--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -136,6 +136,11 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
         {
             string filePath = context.TargetUri.OriginalString;
 
+            if (filePath.StartsWith("file://"))
+            {
+                filePath = context.TargetUri.LocalPath;
+            }
+
             if (context.FileContents == null)
             {
                 context.FileContents = _fileSystem.FileReadAllText(filePath);


### PR DESCRIPTION
@eddynaka 

Some unicode characters are escaped by URL.LocalPath. This breaks file reads. We can't simply URL decode these values, as some apparently URL decoded file names are actually valid on disk. The solution is to simply use the OriginalString provided to us originally by the file system.