### PR TITLE
Improvement in HttpAuthorizationRequestHeader validation

### DIFF
--- a/Src/Plugins/Security/SEC101_001.HttpAuthorizationRequestHeaderValidator.cs
+++ b/Src/Plugins/Security/SEC101_001.HttpAuthorizationRequestHeaderValidator.cs
@@ -1,7 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
@@ -28,6 +32,13 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                                ref message);
         }
 
+        public static string IsValidDynamic(ref string fingerprint, ref string message)
+        {
+            return ValidatorBase.IsValidDynamic(Instance,
+                                                ref fingerprint,
+                                                ref message);
+        }
+
         protected override string IsValidStaticHelper(ref string matchedPattern,
                                                       ref Dictionary<string, string> groups,
                                                       ref string failureLevel,
@@ -44,9 +55,62 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             {
                 Host = host,
                 Key = key,
-                Resource = groups.ContainsKey("resource") ? groups["resource"] : string.Empty,
+                Resource = (groups.ContainsKey("resource") && groups["resource"] != "/")
+                    ? groups["resource"]
+                    : string.Empty,
             }.ToString();
 
+            return nameof(ValidationState.Unknown);
+        }
+
+        protected override string IsValidDynamicHelper(ref string fingerprintText,
+                                                       ref string message)
+        {
+            var fingerprint = new Fingerprint(fingerprintText);
+            string host = fingerprint.Host;
+
+            try
+            {
+                using HttpClient client = CreateHttpClient();
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Guid.NewGuid().ToString());
+
+                using HttpResponseMessage responseDummy = client
+                    .GetAsync(host + (fingerprint.Resource ?? string.Empty), HttpCompletionOption.ResponseHeadersRead)
+                    .GetAwaiter()
+                    .GetResult();
+
+                if (responseDummy.StatusCode == HttpStatusCode.OK)
+                {
+                    return nameof(ValidationState.NoMatch);
+                }
+
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", fingerprint.Key);
+                using HttpResponseMessage response = client
+                    .GetAsync(host + (fingerprint.Resource ?? string.Empty), HttpCompletionOption.ResponseHeadersRead)
+                    .GetAwaiter()
+                    .GetResult();
+
+                switch (response.StatusCode)
+                {
+                    case HttpStatusCode.OK:
+                    {
+                        return ReturnAuthorizedAccess(ref message, asset: host);
+                    }
+
+                    case HttpStatusCode.Forbidden:
+                    case HttpStatusCode.Unauthorized:
+                    {
+                        return ReturnUnauthorizedAccess(ref message, asset: host);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                return ReturnUnhandledException(ref message, e, asset: host);
+            }
+
+            // Since we are just handling 200, 401, and 403.
+            // We will return unknown for all the others if that happen.
             return nameof(ValidationState.Unknown);
         }
     }

--- a/Src/Plugins/Security/SEC101_001.HttpAuthorizationRequestHeaderValidator.cs
+++ b/Src/Plugins/Security/SEC101_001.HttpAuthorizationRequestHeaderValidator.cs
@@ -68,6 +68,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
         {
             var fingerprint = new Fingerprint(fingerprintText);
             string host = fingerprint.Host;
+            string resource = fingerprint.Resource ?? string.Empty;
+            string uri = host + resource;
 
             try
             {
@@ -75,7 +77,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Guid.NewGuid().ToString());
 
                 using HttpResponseMessage responseDummy = client
-                    .GetAsync(host + (fingerprint.Resource ?? string.Empty), HttpCompletionOption.ResponseHeadersRead)
+                    .GetAsync(uri, HttpCompletionOption.ResponseHeadersRead)
                     .GetAwaiter()
                     .GetResult();
 
@@ -86,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", fingerprint.Key);
                 using HttpResponseMessage response = client
-                    .GetAsync(host + (fingerprint.Resource ?? string.Empty), HttpCompletionOption.ResponseHeadersRead)
+                    .GetAsync(uri, HttpCompletionOption.ResponseHeadersRead)
                     .GetAwaiter()
                     .GetResult();
 

--- a/Src/Plugins/Security/Security.SharedStrings.txt
+++ b/Src/Plugins/Security/Security.SharedStrings.txt
@@ -23,7 +23,7 @@
 
 # $FacebookAppCredentials=(?si)(((facebook|fb)(.{0,20})?[`'"\s>](?<id>[0-9]{13,17})[^0-9].{1,500}?)|((facebook|fb)(.{0,20})?[`'"\s>](?<key>[0-9a-f]{32})([^0-9a-f]?)).{1,500}?){2}
 
-  $SEC101/001.HttpAuthorizationRequestHeader=(?i)(?<host>(http|ftp|https):\/\/[\w_-]+(?:(?:\.[\w_-]+)+))(?<resource>[\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])?(.|$|\s)+?authorization[,\[:= "']+(basic)[\s\r\n]{0,10}(?<key>[a-z0-9\/+_.=]{10,})
+  $SEC101/001.HttpAuthorizationRequestHeader=(?i)((?<host>(http|ftp|https):\/\/[\w_-]+(?:(?:\.[\w_-]+)+))(?<resource>[\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])?(.|\n){0,100}?authorization[,\[:= "']+(basic)[\s\r\n]{0,10}(?<key>[a-z0-9\/+_.=]{10,}))
   $SEC101/002.GoogleOAuthCredentials=(?s)\b(?<id>[0-9]{12}\-[0-9a-z]{32})\.apps\.googleusercontent\.com.{1,500}?\b(?i)(?<key>[0-9a-z\-]{24})
   $SEC101/003.GoogleApiKey=\b(?<refine>AIza(?i)[0-9a-z-_]{35})([^0-9a-z-_]|$)
   $SEC101/004.FacebookAppCredentials=(?si)facebook.{1,50}\b(?<id>[0-9]{15}).{1,500}?\b(?<key>[0-9a-f]{32})

--- a/Src/Plugins/Security/Security.SharedStrings.txt
+++ b/Src/Plugins/Security/Security.SharedStrings.txt
@@ -23,7 +23,7 @@
 
 # $FacebookAppCredentials=(?si)(((facebook|fb)(.{0,20})?[`'"\s>](?<id>[0-9]{13,17})[^0-9].{1,500}?)|((facebook|fb)(.{0,20})?[`'"\s>](?<key>[0-9a-f]{32})([^0-9a-f]?)).{1,500}?){2}
 
-  $SEC101/001.HttpAuthorizationRequestHeader=(?i)((?<host>(http|ftp|https):\/\/[\w_-]+(?:(?:\.[\w_-]+)+))(?<resource>[\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])?(.|\n){0,100}?authorization[,\[:= "']+(basic)[\s\r\n]{0,10}(?<key>[a-z0-9\/+_.=]{10,}))
+  $SEC101/001.HttpAuthorizationRequestHeader=(?i)(?<host>(http|ftp|https):\/\/[\w_-]+(?:(?:\.[\w_-]+)+))(?<resource>[\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])?(.|\n){0,100}?authorization[,\[:= "']+(basic)[\s\r\n]{0,10}(?<key>[a-z0-9\/+_.=]{10,})
   $SEC101/002.GoogleOAuthCredentials=(?s)\b(?<id>[0-9]{12}\-[0-9a-z]{32})\.apps\.googleusercontent\.com.{1,500}?\b(?i)(?<key>[0-9a-z\-]{24})
   $SEC101/003.GoogleApiKey=\b(?<refine>AIza(?i)[0-9a-z-_]{35})([^0-9a-z-_]|$)
   $SEC101/004.FacebookAppCredentials=(?si)facebook.{1,50}\b(?<id>[0-9]{15}).{1,500}?\b(?<key>[0-9a-f]{32})

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_001.HttpAuthorizationRequestHeader.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_001.HttpAuthorizationRequestHeader.sarif
@@ -48,7 +48,7 @@
               "",
               "Http authorization request header",
               "",
-              ""
+              " (no validation occurred as it was not enabled. Pass '--dynamic-validation' on the command-line to validate this match)"
             ]
           },
           "locations": [
@@ -87,7 +87,7 @@
               "",
               "Http authorization request header",
               "",
-              ""
+              " (no validation occurred as it was not enabled. Pass '--dynamic-validation' on the command-line to validate this match)"
             ]
           },
           "locations": [
@@ -126,7 +126,7 @@
               "",
               "Http authorization request header",
               "",
-              ""
+              " (no validation occurred as it was not enabled. Pass '--dynamic-validation' on the command-line to validate this match)"
             ]
           },
           "locations": [
@@ -137,11 +137,11 @@
                   "uriBaseId": "SRC_ROOT"
                 },
                 "region": {
-                  "startLine": 11,
+                  "startLine": 17,
                   "startColumn": 32,
-                  "endLine": 12,
+                  "endLine": 18,
                   "endColumn": 60,
-                  "charOffset": 451,
+                  "charOffset": 733,
                   "charLength": 83,
                   "snippet": {
                     "text": "https://example.com' \\\r\n--header 'Authorization: Basic SomeAuthorizationKey0123456="

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_001.HttpAuthorizationRequestHeader.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_001.HttpAuthorizationRequestHeader.sarif
@@ -137,11 +137,11 @@
                   "uriBaseId": "SRC_ROOT"
                 },
                 "region": {
-                  "startLine": 17,
+                  "startLine": 11,
                   "startColumn": 32,
-                  "endLine": 18,
+                  "endLine": 12,
                   "endColumn": 60,
-                  "charOffset": 733,
+                  "charOffset": 451,
                   "charLength": 83,
                   "snippet": {
                     "text": "https://example.com' \\\r\n--header 'Authorization: Basic SomeAuthorizationKey0123456="

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_001.HttpAuthorizationRequestHeader.ps1
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_001.HttpAuthorizationRequestHeader.ps1
@@ -7,6 +7,12 @@ var client = new RestClient("https://example.com?some=parameters&that=should&app
 var request = new RestRequest(Method.GET);
 request.AddHeader("Authorization", "Basic SomeAuthorizationKey0123456");
 
+# This should not get caught, since it will drop the last slash
+# and would be equal to the first example.
+var client = new RestClient("https://example.com/")
+var request = new RestRequest(Method.GET);
+request.AddHeader("Authorization", "Basic SomeAuthorizationKey0123456");
+
 # cURL
 curl --location --request GET 'https://example.com' \
 --header 'Authorization: Basic SomeAuthorizationKey0123456=' \

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_001.HttpAuthorizationRequestHeader.ps1
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_001.HttpAuthorizationRequestHeader.ps1
@@ -7,12 +7,19 @@ var client = new RestClient("https://example.com?some=parameters&that=should&app
 var request = new RestRequest(Method.GET);
 request.AddHeader("Authorization", "Basic SomeAuthorizationKey0123456");
 
+# cURL
+curl --location --request GET 'https://example.com' \
+--header 'Authorization: Basic SomeAuthorizationKey0123456=' \
+
 # This should not get caught, since it will drop the last slash
 # and would be equal to the first example.
 var client = new RestClient("https://example.com/")
 var request = new RestRequest(Method.GET);
 request.AddHeader("Authorization", "Basic SomeAuthorizationKey0123456");
 
-# cURL
-curl --location --request GET 'https://example.com' \
---header 'Authorization: Basic SomeAuthorizationKey0123456=' \
+# This should not get caught, since it would surpass the length
+# between url and authorization
+var client = new RestClient("https://example.com/")
+var request = new RestRequest(Method.GET);
+var text = "more text to surpass the size.";
+request.AddHeader("Authorization", "Basic SomeAuthorizationKey0123456");

--- a/Src/Plugins/ValidatorBase.cs
+++ b/Src/Plugins/ValidatorBase.cs
@@ -30,19 +30,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins
             PerFileFingerprintCache = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         }
 
-        protected HttpClient CreateHttpClient()
-        {
-            var httpClient = new HttpClient();
-
-            httpClient.DefaultRequestHeaders.Add(ScanIdentityHttpCustomHeaderKey,
-                                                 ScanIdentityHttpCustomHeaderValue);
-
-            httpClient.DefaultRequestHeaders.Add("User-Agent",
-                                                 UserAgentValue);
-
-            return httpClient;
-        }
-
         protected virtual string ScanIdentityHttpCustomHeaderValue =>
             "This call originates with a build of the SARIF pattern matcher " +
             "(https://github.com/microsoft/sarif-pattern/matcher. Someone is " +
@@ -243,6 +230,19 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins
             }
 
             return value.Substring(indexOfFirstEqualSign + 1).Trim();
+        }
+
+        protected HttpClient CreateHttpClient()
+        {
+            var httpClient = new HttpClient();
+
+            httpClient.DefaultRequestHeaders.Add(ScanIdentityHttpCustomHeaderKey,
+                                                 ScanIdentityHttpCustomHeaderValue);
+
+            httpClient.DefaultRequestHeaders.Add("User-Agent",
+                                                 UserAgentValue);
+
+            return httpClient;
         }
 
         /// <summary>


### PR DESCRIPTION
This PR fixes the following issues:
- example.com and example.com/ should return the same fingerprint
- adding a dynamic validator