### PR TITLE
enable net472 support

### DIFF
--- a/Src/Plugins/Security/Security.csproj
+++ b/Src/Plugins/Security/Security.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="$(MSBuildThisFileDirectory)..\..\..\Targets\build.lib.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\..\Targets\build.common.props" />
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\Targets\build.product.props" />
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\Targets\build.plugins.props" />
 
   <PropertyGroup Label="AssemblyAttributes">
+    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <RootNamespace>$(RootNamespaceBase).Sarif.PatternMatcher.Plugins.Security</RootNamespace>
     <PackageId>Sarif.PatternMatcher.Security</PackageId>


### PR DESCRIPTION
## Changes
- with this pr we will enable net472 support.

## Reason:
- for the previous package if we added to a netframework project, it wasn't moving the files correctly to the output folder
