### PR TITLE
Enforce that no notifications are generated during file diff tests.

### DIFF
--- a/Src/Plugins/Tests.Security/EndToEndTests.cs
+++ b/Src/Plugins/Tests.Security/EndToEndTests.cs
@@ -147,8 +147,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                 expectedOutputResourceMap[testFileName] =
                     Path.GetFileNameWithoutExtension(testFileName) + ".sarif";
             }
-            RunTest(inputFiles, expectedOutputResourceMap);
 
+            RunTest(inputFiles, expectedOutputResourceMap, enforceNotificationsFree: true);
             RebaselineExpectedResults.Should().BeFalse();
         }
     }


### PR DESCRIPTION
@eddynaka 

Now if a notification is generated during end-to-end testing, the tests will fail. Nice!