### PR TITLE
Deprecated name

### DIFF
--- a/Src/Plugins/Security/SEC101.SecurePlaintextSecrets.json
+++ b/Src/Plugins/Security/SEC101.SecurePlaintextSecrets.json
@@ -204,6 +204,7 @@
         {
           "Id": "SEC101/026",
           "Name": "DoNotExposePlaintextSecrets/MailgunApiCredentials",
+          "DeprecatedName": "DoNotExposePlaintextSecrets/MailgunApiKey",
           "ContentsRegex": "$SEC101/026.MailgunApiCredentials",
           "MessageArguments": { "secretKind": "Mailgun API credential" }
         },
@@ -222,6 +223,7 @@
         {
           "Id": "SEC101/029",
           "Name": "DoNotExposePlaintextSecrets/AlibabaCloudCredentials",
+          "DeprecatedName": "DoNotExposePlaintextSecrets/AlibabaAccessKey",
           "ContentsRegex": "$SEC101/029.AlibabaCloudCredentials",
           "MessageArguments": { "secretKind": "Alibaba cloud credential" }
         },

--- a/Src/Sarif.PatternMatcher.Cli/ExportRulesMetatadaOptions.cs
+++ b/Src/Sarif.PatternMatcher.Cli/ExportRulesMetatadaOptions.cs
@@ -7,12 +7,12 @@ using CommandLine;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
 {
-    [Verb("export-rules", HelpText = "Export rules metadata to a SARIF or SonarQube XML file.")]
+    [Verb("export-rules", HelpText = "Export rules metadata to a markdown (*.md) file.")]
     internal class ExportRulesMetatadaOptions
     {
         [Value(
             0,
-            HelpText = "Output path for exported analysis options. Use .md to produce a markdow rule descriptor file.",
+            HelpText = "Output path for exported rules data as markdown (*.md).",
             Required = true)]
         public string OutputFilePath { get; set; }
 

--- a/Src/Sarif.PatternMatcher/MatchExpression.cs
+++ b/Src/Sarif.PatternMatcher/MatchExpression.cs
@@ -13,6 +13,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
         public string Name { get; set; }
 
+        public string DeprecatedName { get; set; }
+
         public string Message { get; set; }
 
         public FailureLevel Level { get; set; }


### PR DESCRIPTION
@eddynaka 

We need a mechanism to specify deprecated names. This information should actually be written out to SARIF logs! But as we know, it's very difficult now to configure that output in an already very complicated class.

For now, I've added a couple examples to the new export rules to markdown command. We should make two obvious improvements:

1) We should first go find all the recent rule name renames to make sure they are there. Note that we don't need to track every rule rename scrupulously. We really only require that we retrain the *last* changed rule name (to help with fingerprint breaks).
2) We should improve our export rules command to emit this data as SARIF! :) That would be easier for our data processing jobs to generate and parse. The markdown is trivial to parse but of course, it's not intended to be structured data.