### PR TITLE
Fix handling of optional groups in RE2 wrapper

### DIFF
--- a/Src/RE2.Managed/Regex2.cs
+++ b/Src/RE2.Managed/Regex2.cs
@@ -197,6 +197,7 @@ namespace Microsoft.RE2.Managed
         /// <param name="pattern">Pattern to search for in RE2 syntax.</param>
         /// <param name="text">Text to search.</param>
         /// <param name="matches">A list of successive, non-overlapping matches.</param>
+        /// <returns>A bool indicating if 1 or more matches were found.</returns>
         ///
         /// <example>
         /// <code>
@@ -228,6 +229,7 @@ namespace Microsoft.RE2.Managed
             {
                 MatchesCaptureGroupsOutput* output;
 
+                // Use RE2 to search the text for the pattern.
                 NativeMethods.MatchesCaptureGroups(
                     new StringUtf8(patternUtf8BytesPtr, pattern.Length),
                     new StringUtf8(textUtf8BytesPtr, text.Length),
@@ -242,7 +244,7 @@ namespace Microsoft.RE2.Managed
                     submatchIndex2GroupName[output->GroupNameHeaders[i].Index] = groupName;
                 }
 
-                // Build matches.
+                // Build matches output.
                 matches = new List<Dictionary<string, string>>(output->NumMatches);
                 for (int matchIndex = 0; matchIndex < output->NumMatches; matchIndex++)
                 {
@@ -255,7 +257,15 @@ namespace Microsoft.RE2.Managed
                         int submatchTextStartIndex = submatchRe2.Index;
                         int submatchLength = submatchRe2.Length;
 
-                        string submatchString = Encoding.UTF8.GetString(textUtf8Bytes, submatchTextStartIndex, submatchLength);
+                        string submatchString;
+                        if ((submatchTextStartIndex == -1) && (submatchLength == -1))
+                        {
+                            submatchString = string.Empty;
+                        }
+                        else
+                        {
+                            submatchString = Encoding.UTF8.GetString(textUtf8Bytes, submatchTextStartIndex, submatchLength);
+                        }
 
                         if (submatchIndex2GroupName.ContainsKey(submatchIndex))
                         {

--- a/Src/RE2.Native/RE2Native.cpp
+++ b/Src/RE2.Native/RE2Native.cpp
@@ -228,13 +228,24 @@ extern "C" __declspec(dllexport) void MatchesCaptureGroups(
 		// Write submatches.
 		for (auto const& submatchSp : submatchesSp)
 		{
-			// Convert submatches to substring index and length.
-			int32_t index = static_cast<int32_t>(submatchSp.data() - textSp.data());
-			int32_t length = static_cast<int32_t>(submatchSp.length());
+			if (submatchSp.data() == 0)
+			{
+				// This is an optional group that was not found.
+				submatches->Index = -1;
+				submatches->Length = -1;
+			}
+			else
+			{
+				// This group was found.
 
-			// Write submatch entry.
-			submatches->Index = index;
-			submatches->Length = length;
+				// Convert submatches to substring index and length.
+				int32_t index = static_cast<int32_t>(submatchSp.data() - textSp.data());
+				int32_t length = static_cast<int32_t>(submatchSp.length());
+
+				// Write submatch entry.
+				submatches->Index = index;
+				submatches->Length = length;
+			}
 
 			// Advance pointer to next entry.
 			submatches += 1;


### PR DESCRIPTION
RE2 allows for optional capturing groups.

The way this is handled in RE2 is unexpected (to me at least) and was not explicitly documented in the header API, which is why I missed it.
RE2 reports a submatch with index=0 if the submatch is not found.

I did not explicitly handle that case in my code. This PR adds that handling.