### PR TITLE
Fix issue in shared string interpretation.

### DIFF
--- a/Src/Plugins/Tests.SalModernization/TestData/UpdateSalToCurrentVersion/ExpectedOutputs/SEC105_001.AnalysisAssume.sarif
+++ b/Src/Plugins/Tests.SalModernization/TestData/UpdateSalToCurrentVersion/ExpectedOutputs/SEC105_001.AnalysisAssume.sarif
@@ -332,6 +332,80 @@
             "ValidationFingerprintHash/v1": "11626548a2bba258a57c3ddd73dc6980361c0e2f0e34895104be73678ce1640b"
           },
           "rank": 54.42
+        },
+        {
+          "ruleId": "SEC105/003/postinvalid",
+          "ruleIndex": 2,
+          "message": {
+            "id": "Default",
+            "arguments": [
+              "__post_invalid"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/Plugins/Tests.SalModernization/TestData/UpdateSalToCurrentVersion/Inputs/SEC105_001.AnalysisAssume.cpp",
+                  "uriBaseId": "SRC_ROOT"
+                },
+                "region": {
+                  "startLine": 2,
+                  "startColumn": 97,
+                  "endLine": 2,
+                  "endColumn": 113,
+                  "charOffset": 192,
+                  "charLength": 16,
+                  "snippet": {
+                    "text": " __post_invalid)"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "AssetFingerprint/v1": "",
+            "ValidationFingerprint/v1": "[secret=4D4967B311CCE348B4DC5945D87CCF8484E0FF1223A889C3D6B2A38B543F38E9]",
+            "ValidationFingerprintHash/v1": "11626548a2bba258a57c3ddd73dc6980361c0e2f0e34895104be73678ce1640b"
+          },
+          "rank": 54.42
+        },
+        {
+          "ruleId": "SEC105/003/postinvalid",
+          "ruleIndex": 2,
+          "message": {
+            "id": "Default",
+            "arguments": [
+              "__post_invalid"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/Plugins/Tests.SalModernization/TestData/UpdateSalToCurrentVersion/Inputs/SEC105_001.AnalysisAssume.cpp",
+                  "uriBaseId": "SRC_ROOT"
+                },
+                "region": {
+                  "startLine": 3,
+                  "startColumn": 103,
+                  "endLine": 3,
+                  "endColumn": 119,
+                  "charOffset": 312,
+                  "charLength": 16,
+                  "snippet": {
+                    "text": " __post_invalid)"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "AssetFingerprint/v1": "",
+            "ValidationFingerprint/v1": "[secret=4D4967B311CCE348B4DC5945D87CCF8484E0FF1223A889C3D6B2A38B543F38E9]",
+            "ValidationFingerprintHash/v1": "11626548a2bba258a57c3ddd73dc6980361c0e2f0e34895104be73678ce1640b"
+          },
+          "rank": 54.42
         }
       ],
       "columnKind": "utf16CodeUnits"

--- a/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
@@ -314,6 +314,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                     continue;
                 }
 
+                if (sharedStrings.TryGetValue(text, out string replaceText))
+                {
+                    text = replaceText;
+                    break;
+                }
+
                 foreach (string key in sharedStrings.Keys)
                 {
                     text = text.Replace(key, sharedStrings[key]);


### PR DESCRIPTION
The interpretation will replace the current key if the key is a substring of current key
E.g.
$SEC105/003.post=[^\w_]__post[^\w_]
$SEC105/003.postinvalid=[^\w_]__post_invalid[^\w_]

$SEC105/003.postinvalid will be interpreted into "{$SEC105/003.post}invalid" = "[^\w_]__post[^\w_]invalid"

This is a fix for the case if another key is a substring of current key.

If need to fully support multiple keys (e.g. "$string1with$string11", may need to consider adding left/right boundaries to the key.