### PR TITLE
Replace file name in output with a truncated secret.

### DIFF
--- a/Src/Plugins/Security/SEC101.SecurePlaintextSecrets.json
+++ b/Src/Plugins/Security/SEC101.SecurePlaintextSecrets.json
@@ -8,7 +8,7 @@
       "Level": "Warning",
       "FileNameDenyRegex": "$BinaryFiles",
       "Description": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content.",
-      "Message": "'{0:scanTarget}' contains {1:validationPrefix}{2:encoding}{3:secretKind}{4:validationSuffix}{5:validatorMessage}.",
+      "Message": "'{0:truncatedSecret}' is {1:validationPrefix}{2:encoding}{3:secretKind}{4:validationSuffix}{5:validatorMessage}.",
       "MatchExpressions": [
         {
           "Id": "SEC101/001",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_001.HttpAuthorizationRequestHeader.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_001.HttpAuthorizationRequestHeader.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_001.HttpAuthorizationRequestHeader.ps1",
+              "SomeAu…",
               "an apparent ",
               "",
               "Http authorization request header",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_001.HttpAuthorizationRequestHeader.ps1",
+              "SomeAu…",
               "an apparent ",
               "",
               "Http authorization request header",
@@ -130,7 +130,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_001.HttpAuthorizationRequestHeader.ps1",
+              "SomeAu…",
               "an apparent ",
               "",
               "Http authorization request header",
@@ -173,7 +173,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_001.HttpAuthorizationRequestHeader.ps1",
+              "SomeAu…",
               "an apparent ",
               "",
               "Http authorization request header",
@@ -216,7 +216,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_001.HttpAuthorizationRequestHeader.ps1",
+              "666666…",
               "an apparent ",
               "",
               "Http authorization request header",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_002.GoogleOAuthCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_002.GoogleOAuthCredentials.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_002.GoogleOAuthCredentials.ps1",
+              "BsEiZJ…",
               "an apparent ",
               "",
               "Google OAuth id and secret",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_002.GoogleOAuthCredentials.ps1",
+              "BsEiZJ…",
               "an apparent ",
               "",
               "Google OAuth id and secret",
@@ -130,7 +130,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_002.GoogleOAuthCredentials.ps1",
+              "BsEiZJ…",
               "an apparent ",
               "",
               "Google OAuth id and secret",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_003.GoogleApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_003.GoogleApiKey.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_003.GoogleApiKey.txt",
+              "AIza0d…",
               "an apparent ",
               "",
               "Google API key",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_004.FacebookAppCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_004.FacebookAppCredentials.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_004.FacebookAppCredentials.ps1",
+              "c9117d…",
               "an apparent ",
               "",
               "Facebook App id and secret",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_004.FacebookAppCredentials.ps1",
+              "c9117d…",
               "an apparent ",
               "",
               "Facebook App id and secret",
@@ -130,7 +130,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_004.FacebookAppCredentials.ps1",
+              "c9117d…",
               "an apparent ",
               "",
               "Facebook App id and secret",
@@ -173,7 +173,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_004.FacebookAppCredentials.ps1",
+              "c9117d…",
               "an apparent ",
               "",
               "Facebook App id and secret",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_005.SlackTokens.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_005.SlackTokens.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_005.SlackTokens.py",
+              "xoxb-8…",
               "an apparent ",
               "",
               "Slack token",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_006.GitHubPat.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_006.GitHubPat.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_006.GitHubPat.ps1",
+              "ff3488…",
               "an apparent ",
               "",
               "legacy format GitHub personal access token",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_006.GitHubPat.ps1",
+              "dead88…",
               "an apparent ",
               "",
               "legacy format GitHub personal access token",
@@ -130,7 +130,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_006.GitHubPat.ps1",
+              "ff3488…",
               "an apparent ",
               "",
               "legacy format GitHub personal access token",
@@ -173,7 +173,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_006.GitHubPat.ps1",
+              "ghp_00…",
               "an apparent ",
               "",
               "GitHub personal access token",
@@ -216,7 +216,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_006.GitHubPat.ps1",
+              "ghr_11…",
               "an apparent ",
               "",
               "GitHub personal access token",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_007.GitHubAppCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_007.GitHubAppCredentials.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_007.GitHubAppCredentials.ps1",
+              "deadbe…",
               "an apparent ",
               "",
               "GitHub app id and secret",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_007.GitHubAppCredentials.ps1",
+              "0000be…",
               "an apparent ",
               "",
               "GitHub app id and secret",
@@ -130,7 +130,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_007.GitHubAppCredentials.ps1",
+              "deadbe…",
               "an apparent ",
               "",
               "GitHub app id and secret",
@@ -173,7 +173,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_007.GitHubAppCredentials.ps1",
+              "deadbe…",
               "an apparent ",
               "",
               "GitHub app id and secret",
@@ -216,7 +216,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_007.GitHubAppCredentials.ps1",
+              "deadbe…",
               "an apparent ",
               "",
               "GitHub app id and secret",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_008.AwsCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_008.AwsCredentials.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_008.AwsCredentials.ps1",
+              "wJalrX…",
               "an apparent ",
               "",
               "Aws access key and secret",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_008.AwsCredentials.ps1",
+              "xJalrX…",
               "an apparent ",
               "",
               "Aws access key and secret",
@@ -130,7 +130,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_008.AwsCredentials.ps1",
+              "yJalrX…",
               "an apparent ",
               "",
               "Aws access key and secret",
@@ -173,7 +173,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_008.AwsCredentials.ps1",
+              "zJalrX…",
               "an apparent ",
               "",
               "Aws access key and secret",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_009.LinkedInCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_009.LinkedInCredentials.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_009.LinkedInCredentials.ps1",
+              "000000…",
               "an apparent ",
               "",
               "LinkedIn access key and secret",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_009.LinkedInCredentials.ps1",
+              "000000…",
               "an apparent ",
               "",
               "LinkedIn access key and secret",
@@ -130,7 +130,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_009.LinkedInCredentials.ps1",
+              "000000…",
               "an apparent ",
               "",
               "LinkedIn access key and secret",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_010.SquarePat.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_010.SquarePat.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_010.SquarePat.ps1",
+              "EAAAEB…",
               "an apparent ",
               "",
               "Square personal access token",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_010.SquarePat.ps1",
+              "EAAAEB…",
               "an apparent ",
               "",
               "Square personal access token",
@@ -130,7 +130,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_010.SquarePat.ps1",
+              "EAAAEB…",
               "an apparent ",
               "",
               "Square personal access token",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_011.SquareCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_011.SquareCredentials.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_011.SquareCredentials.ps1",
+              "sq0csp…",
               "an apparent ",
               "",
               "Square access key and secret",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_011.SquareCredentials.ps1",
+              "sq0csp…",
               "an apparent ",
               "",
               "Square access key and secret",
@@ -130,7 +130,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_011.SquareCredentials.ps1",
+              "sq0csp…",
               "an apparent ",
               "",
               "Square access key and secret",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_012.SlackWebhook.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_012.SlackWebhook.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_012.SlackWebhook.txt",
+              "B01234…",
               "an apparent ",
               "",
               "Slack web hook",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_013.CryptographicPrivateKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_013.CryptographicPrivateKey.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_013.CryptographicPrivateKey.txt",
+              "lQOsBG…",
               "a valid ",
               "",
               "PEM encoded private key",
@@ -86,7 +86,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_013.CryptographicPrivateKey.txt",
+              "lQOsBG…",
               "a valid but password-protected ",
               "",
               "PEM encoded private key",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_014.FacebookAccessToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_014.FacebookAccessToken.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_014.FacebookAccessToken.ps1",
+              "EAACEd…",
               "an apparent ",
               "",
               "Facebook access token",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_014.FacebookAccessToken.ps1",
+              "EAACEd…",
               "an apparent ",
               "",
               "Facebook access token",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_016.StripeApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_016.StripeApiKey.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_016.StripeApiKey.txt",
+              "sk_tes…",
               "an apparent ",
               "",
               "Stripe API key",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_016.StripeApiKey.txt",
+              "sk_liv…",
               "an apparent ",
               "",
               "Stripe API key",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_017.NpmAuthorToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_017.NpmAuthorToken.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_017.NpmAuthorToken.ps1",
+              "338a0f…",
               "an apparent ",
               "",
               "NPM API key",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_017.NpmAuthorToken.ps1",
+              "338a0f…",
               "an apparent ",
               "",
               "NPM API key",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_018.TwilioCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_018.TwilioCredentials.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_018.TwilioCredentials.ps1",
+              "c9117d…",
               "an apparent ",
               "",
               "Twilio credentials",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_018.TwilioCredentials.ps1",
+              "c9117d…",
               "an apparent ",
               "",
               "Twilio credentials",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_019.PicaticApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_019.PicaticApiKey.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -39,7 +39,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -60,7 +60,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_019.PicaticApiKey.ps1",
+              "sk_tes…",
               "an apparent ",
               "",
               "Stripe API key",
@@ -103,7 +103,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_019.PicaticApiKey.ps1",
+              "sk_liv…",
               "an apparent ",
               "",
               "Stripe API key",
@@ -146,7 +146,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_019.PicaticApiKey.ps1",
+              "sk_tes…",
               "an apparent ",
               "",
               "Picatic API key",
@@ -189,7 +189,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_019.PicaticApiKey.ps1",
+              "sk_liv…",
               "an apparent ",
               "",
               "Picatic API key",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_020.DropboxAccessToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_020.DropboxAccessToken.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_020.DropboxAccessToken.ps1",
+              "3g2u1O…",
               "an apparent ",
               "",
               "Dropbox access token",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_020.DropboxAccessToken.ps1",
+              "sl.AtS…",
               "an apparent ",
               "",
               "Dropbox access token",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_021.DropboxAppCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_021.DropboxAppCredentials.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_021.DropboxAppCredentials.ps1",
+              "sf05ok…",
               "an apparent ",
               "",
               "Dropbox app credentials",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_022.PayPalBraintreeAccessToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_022.PayPalBraintreeAccessToken.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_022.PayPalBraintreeAccessToken.ps1",
+              "111111…",
               "an apparent ",
               "",
               "PayPal/Braintree Access Token",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_022.PayPalBraintreeAccessToken.ps1",
+              "222222…",
               "an apparent ",
               "",
               "PayPal/Braintree Access Token",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_024.TwilioApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_024.TwilioApiKey.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_024.TwilioApiKey.ps1",
+              "SK1111…",
               "an apparent ",
               "",
               "Twilio API Key",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_024.TwilioApiKey.ps1",
+              "SK2222…",
               "an apparent ",
               "",
               "Twilio API Key",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_025.SendGridApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_025.SendGridApiKey.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_025.SendGridApiKey.txt",
+              "SG.0de…",
               "an apparent ",
               "",
               "SendGrid API Key",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_026.MailgunApiCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_026.MailgunApiCredentials.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_026.MailgunApiCredentials.ps1",
+              "0deadb…",
               "an apparent ",
               "",
               "Mailgun API credential",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_027.MailChimpApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_027.MailChimpApiKey.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_027.MailChimpApiKey.ps1",
+              "111111…",
               "an apparent ",
               "",
               "MailChimp API Key",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_027.MailChimpApiKey.ps1",
+              "222222…",
               "an apparent ",
               "",
               "MailChimp API Key",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_028.PlaintextPassword.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_028.PlaintextPassword.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -43,7 +43,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_028.PlaintextPassword.ps1",
+              "doodle…",
               "a valid ",
               "",
               "plaintext password",
@@ -85,7 +85,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_028.PlaintextPassword.ps1",
+              "Doodle…",
               "a valid ",
               "",
               "plaintext password",
@@ -127,7 +127,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_028.PlaintextPassword.ps1",
+              "D00dle…",
               "a valid ",
               "",
               "plaintext password",
@@ -169,7 +169,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_028.PlaintextPassword.ps1",
+              "D$oodl…",
               "a valid ",
               "",
               "plaintext password",
@@ -211,7 +211,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_028.PlaintextPassword.ps1",
+              "D$oodl…",
               "a valid ",
               "",
               "plaintext password",
@@ -253,7 +253,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_028.PlaintextPassword.ps1",
+              "Doodle…",
               "a valid ",
               "",
               "plaintext password",
@@ -295,7 +295,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_028.PlaintextPassword.ps1",
+              "666666",
               "a valid ",
               "",
               "plaintext password",
@@ -337,7 +337,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_028.PlaintextPassword.ps1",
+              "6ood13…",
               "a valid ",
               "",
               "plaintext password",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_029.AlibabaCloudCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_029.AlibabaCloudCredentials.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_029.AlibabaCloudCredentials.ps1",
+              "111111…",
               "an apparent ",
               "",
               "Alibaba cloud credential",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_029.AlibabaCloudCredentials.ps1",
+              "222222…",
               "an apparent ",
               "",
               "Alibaba cloud credential",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_030.GoogleServiceAccountKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_030.GoogleServiceAccountKey.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_030.GoogleServiceAccountKey.ps1",
+              "111111…",
               "an apparent ",
               "",
               "Google service account key",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_030.GoogleServiceAccountKey.ps1",
+              "333333…",
               "an apparent ",
               "",
               "Google service account key",
@@ -130,7 +130,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_030.GoogleServiceAccountKey.ps1",
+              "keyId2",
               "an apparent ",
               "",
               "Google service account key",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_031.NuGetApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_031.NuGetApiKey.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_031.NuGetApiKey.txt",
+              "oy20de…",
               "an apparent ",
               "",
               "NuGet API Key",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_032.GpgCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_032.GpgCredentials.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_032.GpgCredentials.ps1",
+              "doodle…",
               "an apparent ",
               "",
               "GPG credential",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_032.GpgCredentials.ps1",
+              "doodle…",
               "an apparent ",
               "",
               "GPG credential",
@@ -130,7 +130,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_032.GpgCredentials.ps1",
+              "doodle…",
               "an apparent ",
               "",
               "GPG credential",
@@ -173,7 +173,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_032.GpgCredentials.ps1",
+              "doodle…",
               "an apparent ",
               "",
               "GPG credential",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_033.MongoDbConnectionString.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_033.MongoDbConnectionString.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_033.MongoDbConnectionString.ps1",
+              "<passw…",
               "an apparent ",
               "",
               "MongoDb connection string",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_033.MongoDbConnectionString.ps1",
+              "<passw…",
               "an apparent ",
               "",
               "MongoDb connection string",
@@ -130,7 +130,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_033.MongoDbConnectionString.ps1",
+              "<passw…",
               "an apparent ",
               "",
               "MongoDb connection string",
@@ -173,7 +173,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_033.MongoDbConnectionString.ps1",
+              "<passw…",
               "an apparent ",
               "",
               "MongoDb connection string",
@@ -216,7 +216,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_033.MongoDbConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "MongoDb connection string",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_034.CredentialObject.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_034.CredentialObject.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_034.CredentialObject.ps1",
+              "doodle…",
               "an apparent ",
               "",
               "PSCredential constructor",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_034.CredentialObject.ps1",
+              "doodle…",
               "an apparent ",
               "",
               "PSCredential constructor",
@@ -130,7 +130,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_034.CredentialObject.ps1",
+              "doodle…",
               "an apparent ",
               "",
               "PSCredential constructor",
@@ -173,7 +173,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_034.CredentialObject.ps1",
+              "doodle…",
               "an apparent ",
               "",
               "PSCredential object initializer",
@@ -216,7 +216,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_034.CredentialObject.ps1",
+              "doodle…",
               "an apparent ",
               "",
               "PSCredential object initializer",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_035.CloudantCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_035.CloudantCredentials.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_035.CloudantCredentials.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "Cloudant credential",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_035.CloudantCredentials.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "Cloudant credential",
@@ -130,7 +130,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_035.CloudantCredentials.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "Cloudant credential",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_036.MySqlConnectionString.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_036.MySqlConnectionString.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -39,7 +39,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -55,7 +55,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -76,7 +76,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_036.MySqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "ADO or ODBC MySQL connection string",
@@ -119,7 +119,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_036.MySqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "ADO or ODBC MySQL connection string",
@@ -162,7 +162,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_036.MySqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "ADO or ODBC MySQL connection string",
@@ -205,7 +205,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_036.MySqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "ADO or ODBC MySQL connection string",
@@ -248,7 +248,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_036.MySqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "ADO or ODBC MySQL connection string",
@@ -291,7 +291,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_036.MySqlConnectionString.ps1",
+              "your-p…",
               "an apparent ",
               "",
               "ADO or ODBC MySQL connection string",
@@ -334,7 +334,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_036.MySqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "ADO or ODBC MySQL connection string",
@@ -377,7 +377,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_036.MySqlConnectionString.ps1",
+              "PASSwo…",
               "an apparent ",
               "",
               "JDBC MySQL connection string",
@@ -420,7 +420,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_036.MySqlConnectionString.ps1",
+              "PASSwo…",
               "an apparent ",
               "",
               "JDBC MySQL connection string",
@@ -463,7 +463,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_036.MySqlConnectionString.ps1",
+              "cleard…",
               "an apparent ",
               "",
               "JDBC MySQL connection string",
@@ -506,7 +506,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_036.MySqlConnectionString.ps1",
+              "your-p…",
               "an apparent ",
               "",
               "ADO or ODBC SQL connection string",
@@ -549,7 +549,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_036.MySqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "ADO or ODBC SQL connection string",
@@ -592,7 +592,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_036.MySqlConnectionString.ps1",
+              "your-p…",
               "an apparent ",
               "",
               "ADO PostgreSQL connection string",
@@ -635,7 +635,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_036.MySqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "ADO PostgreSQL connection string",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_037.SqlConnectionString.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_037.SqlConnectionString.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -39,7 +39,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -55,7 +55,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -76,7 +76,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_037.SqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "ADO or ODBC MySQL connection string",
@@ -119,7 +119,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_037.SqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "ADO or ODBC MySQL connection string",
@@ -162,7 +162,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_037.SqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "ADO or ODBC SQL connection string",
@@ -205,7 +205,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_037.SqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "ADO or ODBC SQL connection string",
@@ -248,7 +248,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_037.SqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "ADO or ODBC SQL connection string",
@@ -291,7 +291,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_037.SqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "ADO or ODBC SQL connection string",
@@ -334,7 +334,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_037.SqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "ADO or ODBC SQL connection string",
@@ -377,7 +377,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_037.SqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "ADO or ODBC SQL connection string",
@@ -420,7 +420,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_037.SqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "ADO or ODBC SQL connection string",
@@ -463,7 +463,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_037.SqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "ADO or ODBC SQL connection string",
@@ -506,7 +506,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_037.SqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "ADO or ODBC SQL connection string",
@@ -549,7 +549,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_037.SqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "ADO or ODBC SQL connection string",
@@ -592,7 +592,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_037.SqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "ADO or ODBC SQL connection string",
@@ -635,7 +635,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_037.SqlConnectionString.ps1",
+              "a1Pass…",
               "an apparent ",
               "",
               "ADO or ODBC SQL connection string",
@@ -678,7 +678,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_037.SqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "ADO or ODBC SQL connection string",
@@ -721,7 +721,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_037.SqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "ADO or ODBC SQL connection string",
@@ -764,7 +764,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_037.SqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "JDBC SQL connection string",
@@ -807,7 +807,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_037.SqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "JDBC SQL connection string",
@@ -850,7 +850,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_037.SqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "JDBC SQL connection string",
@@ -893,7 +893,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_037.SqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "JDBC SQL connection string",
@@ -936,7 +936,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_037.SqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "PHP SQL connection string",
@@ -979,7 +979,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_037.SqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "ADO PostgreSQL connection string",
@@ -1022,7 +1022,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_037.SqlConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "ADO PostgreSQL connection string",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_038.PostgreSqlConnectionString.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_038.PostgreSqlConnectionString.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_038.PostgreSqlConnectionString.ps1",
+              "my_pw_…",
               "an apparent ",
               "",
               "ADO PostgreSQL connection string",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_038.PostgreSqlConnectionString.ps1",
+              "my_pw_…",
               "an apparent ",
               "",
               "ADO PostgreSQL connection string",
@@ -130,7 +130,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_038.PostgreSqlConnectionString.ps1",
+              "my_pw_…",
               "an apparent ",
               "",
               "ADO PostgreSQL connection string",
@@ -173,7 +173,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_038.PostgreSqlConnectionString.ps1",
+              "my_pw_…",
               "an apparent ",
               "",
               "ADO PostgreSQL connection string",
@@ -216,7 +216,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_038.PostgreSqlConnectionString.ps1",
+              "my_pw_…",
               "an apparent ",
               "",
               "ADO PostgreSQL connection string",
@@ -259,7 +259,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_038.PostgreSqlConnectionString.ps1",
+              "my_pw_…",
               "an apparent ",
               "",
               "ADO PostgreSQL connection string",
@@ -302,7 +302,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_038.PostgreSqlConnectionString.ps1",
+              "my_pw_…",
               "an apparent ",
               "",
               "ADO PostgreSQL connection string",
@@ -345,7 +345,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_038.PostgreSqlConnectionString.ps1",
+              "my_pw_…",
               "an apparent ",
               "",
               "ADO PostgreSQL connection string",
@@ -388,7 +388,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_038.PostgreSqlConnectionString.ps1",
+              "my_pw_…",
               "an apparent ",
               "",
               "ADO PostgreSQL connection string",
@@ -431,7 +431,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_038.PostgreSqlConnectionString.ps1",
+              "my_pw_…",
               "an apparent ",
               "",
               "ADO PostgreSQL connection string",
@@ -474,7 +474,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_038.PostgreSqlConnectionString.ps1",
+              "my_pw_…",
               "an apparent ",
               "",
               "ADO PostgreSQL connection string",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_039.ShopifyAccessToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_039.ShopifyAccessToken.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_039.ShopifyAccessToken.ps1",
+              "shpat_…",
               "an apparent ",
               "",
               "Shopify access token",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_039.ShopifyAccessToken.ps1",
+              "shpca_…",
               "an apparent ",
               "",
               "Shopify access token",
@@ -130,7 +130,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_039.ShopifyAccessToken.ps1",
+              "shppa_…",
               "an apparent ",
               "",
               "Shopify access token",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_040.ShopifySharedSecret.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_040.ShopifySharedSecret.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_040.ShopifySharedSecret.ps1",
+              "shpss_…",
               "an apparent ",
               "",
               "Shopify shared secret",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_040.ShopifySharedSecret.ps1",
+              "shpss_…",
               "an apparent ",
               "",
               "Shopify shared secret",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_041.RabbitMqConnectionString.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_041.RabbitMqConnectionString.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_041.RabbitMqConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "RabbitMq connection string",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_041.RabbitMqConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "RabbitMq connection string",
@@ -130,7 +130,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_041.RabbitMqConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "RabbitMq connection string",
@@ -173,7 +173,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_041.RabbitMqConnectionString.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "RabbitMq connection string",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_042.DynatraceToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_042.DynatraceToken.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_042.DynatraceToken.ps1",
+              "dt0a11…",
               "an apparent ",
               "",
               "Dynatrace Key",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_042.DynatraceToken.ps1",
+              "dt0a11…",
               "an apparent ",
               "",
               "Dynatrace Key",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_043.NuGetCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_043.NuGetCredentials.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_043.NuGetCredentials.ps1",
+              "1111_O…",
               "an apparent ",
               "",
               "NuGet credentials",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_043.NuGetCredentials.ps1",
+              "2222_T…",
               "an apparent ",
               "",
               "NuGet credentials",
@@ -130,7 +130,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_043.NuGetCredentials.ps1",
+              "1111_O…",
               "an apparent ",
               "",
               "NuGet credentials",
@@ -173,7 +173,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_043.NuGetCredentials.ps1",
+              "2222_T…",
               "an apparent ",
               "",
               "NuGet credentials",
@@ -216,7 +216,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_043.NuGetCredentials.ps1",
+              "%passw…",
               "an apparent ",
               "",
               "NuGet credentials",
@@ -259,7 +259,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_043.NuGetCredentials.ps1",
+              "%passw…",
               "an apparent ",
               "",
               "NuGet credentials",
@@ -302,7 +302,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_043.NuGetCredentials.ps1",
+              "%passw…",
               "an apparent ",
               "",
               "NuGet credentials",
@@ -345,7 +345,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_043.NuGetCredentials.ps1",
+              "%passw…",
               "an apparent ",
               "",
               "NuGet credentials",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_044.NpmCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_044.NpmCredentials.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_044.NpmCredentials.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "Npm credential",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_044.NpmCredentials.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "Npm credential",
@@ -130,7 +130,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_044.NpmCredentials.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "Npm credential",
@@ -173,7 +173,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_044.NpmCredentials.ps1",
+              "passwo…",
               "an apparent ",
               "",
               "Npm credential",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_102.AdoPat.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_102.AdoPat.sarif
@@ -23,7 +23,7 @@
                   "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
                 },
                 "Default": {
-                  "text": "'{0}' contains {1}{2}{3}{4}{5}."
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
@@ -44,7 +44,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_102.AdoPat.txt",
+              "h5lxeq…",
               "an apparent ",
               "base64-encoded",
               "Azure DevOps personal access token",
@@ -87,7 +87,7 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "SEC101_102.AdoPat.txt",
+              "h5lxeq…",
               "an apparent ",
               "",
               "Azure DevOps personal access token",

--- a/Src/Sarif.PatternMatcher.Cli/Program.cs
+++ b/Src/Sarif.PatternMatcher.Cli/Program.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Text;
+
 using CommandLine;
 
 using Microsoft.CodeAnalysis.Sarif.Driver;
@@ -11,6 +14,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
     {
         private static int Main(string[] args)
         {
+            Console.OutputEncoding = Encoding.UTF8;
+
             return Parser.Default.ParseArguments<
                 AnalyzeOptions,
                 AnalyzeDatabaseOptions,

--- a/Src/Sarif.PatternMatcher.Sdk/ExtensionMethods.cs
+++ b/Src/Sarif.PatternMatcher.Sdk/ExtensionMethods.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk
+{
+    public static class ExtensionMethods
+    {
+        public static string Truncate(this string text, int lengthExclusiveOfEllipsis = 6)
+        {
+            text ??= string.Empty;
+
+            if (text.Length <= lengthExclusiveOfEllipsis)
+            {
+                return text;
+            }
+
+            // "\u2026" == "…"
+            return text.Substring(0, lengthExclusiveOfEllipsis) + "\u2026";
+        }
+    }
+}

--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -251,17 +251,16 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                     {
                         // An illegal state was returned running check '{0}' against '{1}' ({2}).
                         context.Logger.LogToolNotification(
-                            Errors.CreateNotification(
-                                context.TargetUri,
-                                "ERR998.ValidatorReturnedIllegalValidationState",
-                                context.Rule.Id,
-                                FailureLevel.Error,
-                                exception: null,
-                                persistExceptionStack: false,
-                                messageFormat: SpamResources.ERR998_ValidatorReturnedIllegalValidationState,
-                                context.Rule.Id,
-                                context.TargetUri.GetFileName(),
-                                validatorMessage));
+                            Errors.CreateNotification(context.TargetUri,
+                                                      "ERR998.ValidatorReturnedIllegalValidationState",
+                                                      context.Rule.Id,
+                                                      FailureLevel.Error,
+                                                      exception: null,
+                                                      persistExceptionStack: false,
+                                                      messageFormat: SpamResources.ERR998_ValidatorReturnedIllegalValidationState,
+                                                      context.Rule.Id,
+                                                      context.TargetUri.GetFileName(),
+                                                      validatorMessage));
                     }
 
                     level = FailureLevel.Error;
@@ -416,10 +415,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             }
         }
 
-        private void RunMatchExpressionForContentsRegex(
-            FlexMatch binary64DecodedMatch,
-            AnalyzeContext context,
-            MatchExpression matchExpression)
+        private void RunMatchExpressionForContentsRegex(FlexMatch binary64DecodedMatch,
+                                                        AnalyzeContext context,
+                                                        MatchExpression matchExpression)
         {
             ResultKind kind = matchExpression.Kind;
             FailureLevel level = matchExpression.Level;
@@ -489,6 +487,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                             }
 
                             validatorMessage = validationResult.Message;
+
                             SetPropertiesBasedOnValidationState(validationResult.ValidationState,
                                                                 context,
                                                                 validationResult.ResultLevelKind,
@@ -498,8 +497,10 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                                                                 ref validationSuffix,
                                                                 ref validatorMessage,
                                                                 pluginSupportsDynamicValidation);
+
                             validationResult.Message = validatorMessage;
                             validationResult.ResultLevelKind = new ResultLevelKind { Kind = kind, Level = level };
+
                             ConstructResultAndLogForContentsRegex(binary64DecodedMatch,
                                                                   context,
                                                                   matchExpression,
@@ -566,6 +567,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
             messageArguments["validationPrefix"] = validationPrefix;
             messageArguments["validationSuffix"] = validationSuffix;
+            messageArguments["truncatedSecret"] = validationResult.Fingerprint.Secret.Truncate();
 
             IList<string> arguments = GetMessageArguments(groups,
                                                           matchExpression.ArgumentNameToIndexMap,
@@ -804,16 +806,15 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 validatorMessage: NormalizeValidatorMessage(validatorMessage),
                 messageArguments);
 
-            Result result = this.ConstructResult(
-                    context.TargetUri,
-                    reportingDescriptor.Id,
-                    level,
-                    kind,
-                    region: null,
-                    flexMatch: null,
-                    fingerprint,
-                    matchExpression,
-                    arguments);
+            Result result = this.ConstructResult(context.TargetUri,
+                                                 reportingDescriptor.Id,
+                                                 level,
+                                                 kind,
+                                                 region: null,
+                                                 flexMatch: null,
+                                                 fingerprint,
+                                                 matchExpression,
+                                                 arguments);
 
             context.Logger.Log(reportingDescriptor, result);
         }
@@ -853,16 +854,15 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 fileText: context.FileContents);
         }
 
-        private Result ConstructResult(
-            Uri targetUri,
-            string ruleId,
-            FailureLevel level,
-            ResultKind kind,
-            Region region,
-            FlexMatch flexMatch,
-            Fingerprint fingerprint,
-            MatchExpression matchExpression,
-            IList<string> arguments)
+        private Result ConstructResult(Uri targetUri,
+                                       string ruleId,
+                                       FailureLevel level,
+                                       ResultKind kind,
+                                       Region region,
+                                       FlexMatch flexMatch,
+                                       Fingerprint fingerprint,
+                                       MatchExpression matchExpression,
+                                       IList<string> arguments)
         {
             var location = new Location()
             {
@@ -886,7 +886,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             // We'll limit rank precision to two decimal places. Because this value
             // is actually converted from a nomalized range of 0.0 to 1.0, to the
             // SARIF 0.0 to 100.0 equivalent, this is effectively four decimal places
-            // of precision as far as the normalized Shannon entrop is concerned.
+            // of precision in terms of the normalized Shannon entropy value.
             rank = Math.Round(rank, 2, MidpointRounding.AwayFromZero);
 
             var result = new Result()

--- a/Src/SarifPatternMatcher.sln
+++ b/Src/SarifPatternMatcher.sln
@@ -85,6 +85,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SalModernization", "Plugins
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tests.SalModernization", "Plugins\Tests.SalModernization\Tests.SalModernization.csproj", "{843E818B-1BC2-43FB-97E0-56F6005CE12A}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test.UnitTests.Sarif.PatternMatcher.Sdk", "Test.UnitTests.Sarif.PatternMatcher.Sdk\Test.UnitTests.Sarif.PatternMatcher.Sdk.csproj", "{DA444E2B-28A2-4884-BECC-656CE22690F5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -335,6 +337,18 @@ Global
 		{843E818B-1BC2-43FB-97E0-56F6005CE12A}.Release|x64.Build.0 = Release|Any CPU
 		{843E818B-1BC2-43FB-97E0-56F6005CE12A}.Release|x86.ActiveCfg = Release|Any CPU
 		{843E818B-1BC2-43FB-97E0-56F6005CE12A}.Release|x86.Build.0 = Release|Any CPU
+		{DA444E2B-28A2-4884-BECC-656CE22690F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DA444E2B-28A2-4884-BECC-656CE22690F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DA444E2B-28A2-4884-BECC-656CE22690F5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DA444E2B-28A2-4884-BECC-656CE22690F5}.Debug|x64.Build.0 = Debug|Any CPU
+		{DA444E2B-28A2-4884-BECC-656CE22690F5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DA444E2B-28A2-4884-BECC-656CE22690F5}.Debug|x86.Build.0 = Debug|Any CPU
+		{DA444E2B-28A2-4884-BECC-656CE22690F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DA444E2B-28A2-4884-BECC-656CE22690F5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DA444E2B-28A2-4884-BECC-656CE22690F5}.Release|x64.ActiveCfg = Release|Any CPU
+		{DA444E2B-28A2-4884-BECC-656CE22690F5}.Release|x64.Build.0 = Release|Any CPU
+		{DA444E2B-28A2-4884-BECC-656CE22690F5}.Release|x86.ActiveCfg = Release|Any CPU
+		{DA444E2B-28A2-4884-BECC-656CE22690F5}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Src/Test.UnitTests.Sarif.PatternMatcher.Sdk/ExtensionMethodTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher.Sdk/ExtensionMethodTests.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk
+{
+    public class ExtensionMethodTests
+    {
+        [Fact]
+        public void ExtensionMethods_Truncate()
+        {
+            var failedTests = new List<string>();
+
+            var testCases = new[]
+            {
+                new { Input = "", Expected = "", Length = -1},
+                new { Input = "1234", Expected = "…", Length = 0},
+                new { Input = "1234", Expected = "1234", Length = -1},
+                new { Input = (string)null, Expected = "", Length = -1},
+                new { Input = "1234", Expected = "12…", Length = 2},
+                new { Input = "123456", Expected = "123456", Length = -1},
+                new { Input = "1234567", Expected = "123456…", Length = -1},
+                new { Input = "1234567890", Expected = "123456…", Length = -1},
+            };
+
+            foreach (var testCase in testCases)
+            {
+                string actual;
+
+                if (testCase.Length == -1)
+                {
+                    actual = testCase.Input.Truncate();
+                }
+                else
+                {
+                    actual = testCase.Input.Truncate(testCase.Length);
+                }
+
+                if (!actual.Equals(testCase.Expected))
+                {
+                    failedTests.Add($"Truncation of '{testCase.Input}' returned '{actual}' rather than '{testCase.Expected}'");
+                }
+            }
+
+            failedTests.Should().BeEmpty();
+        }
+    }
+}

--- a/Src/Test.UnitTests.Sarif.PatternMatcher.Sdk/Test.UnitTests.Sarif.PatternMatcher.Sdk.csproj
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher.Sdk/Test.UnitTests.Sarif.PatternMatcher.Sdk.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Targets\build.app.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Targets\build.test.props" />
+
+  <PropertyGroup Label="AssemblyAttributes">
+    <RootNamespace>$(RootNamespaceBase).Sarif.PatternMatcher.Sdk</RootNamespace>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Moq" Version="4.15.2" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\Sarif.PatternMatcher.Sdk\Sarif.PatternMatcher.Sdk.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
@cfaucon, this is an important change for any consumers that attempt to replace message string arguments in-place. :)

@eddynaka

Where previously, we repeated the file location of the find:

> e:\repros\test.txt(2,16-77): error SEC101/006: 'test.txt' contains a valid legacy format GitHub personal access token (the compromised GitHub account is '[someaccount](https://github.com/someaccount)')

We now report a truncated form of the exposed secret:

> e:\repros\test.txt(2,16-77): error SEC101/006: 'ab41f9…' is a valid legacy format GitHub personal access token (the compromised GitHub account is '[someaccount](https://github.com/someaccount)')