### PR TITLE
Remove 'matchedPattern' argument from static validator phase. Instead…

### DIFF
--- a/Src/Plugins/Security/SEC101_001.HttpAuthorizationRequestHeaderValidator.cs
+++ b/Src/Plugins/Security/SEC101_001.HttpAuthorizationRequestHeaderValidator.cs
@@ -21,12 +21,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new HttpAuthorizationRequestHeaderValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
         public static ValidationState IsValidDynamic(ref Fingerprint fingerprint,
@@ -41,8 +38,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                   ref resultLevelKind);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("host", out FlexMatch host) ||
                 !groups.TryGetNonEmptyValue("scheme", out FlexMatch scheme) ||

--- a/Src/Plugins/Security/SEC101_002.GoogleOAuthCredentialsValidator.cs
+++ b/Src/Plugins/Security/SEC101_002.GoogleOAuthCredentialsValidator.cs
@@ -17,16 +17,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new GoogleOAuthCredentialsValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetValue("id", out FlexMatch id) ||
                 !groups.TryGetValue("secret", out FlexMatch secret))

--- a/Src/Plugins/Security/SEC101_003.GoogleApiKeyValidator.cs
+++ b/Src/Plugins/Security/SEC101_003.GoogleApiKeyValidator.cs
@@ -21,12 +21,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new GoogleApiKeyValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
         public static ValidationState IsValidDynamic(ref Fingerprint fingerprint,
@@ -41,8 +38,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                   ref resultLevelKind);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("secret", out FlexMatch secret))
             {

--- a/Src/Plugins/Security/SEC101_004.FacebookAppCredentialsValidator.cs
+++ b/Src/Plugins/Security/SEC101_004.FacebookAppCredentialsValidator.cs
@@ -21,12 +21,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new FacebookAppCredentialsValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
         public static ValidationState IsValidDynamic(ref Fingerprint fingerprint,
@@ -41,8 +38,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                   ref resultLevelKind);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetValue("id", out FlexMatch id) ||
                 !groups.TryGetValue("secret", out FlexMatch secret))

--- a/Src/Plugins/Security/SEC101_005.SlackTokenValidator.cs
+++ b/Src/Plugins/Security/SEC101_005.SlackTokenValidator.cs
@@ -17,12 +17,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
     {
         internal static SlackTokenValidator Instance = new SlackTokenValidator();
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
         public static ValidationState IsValidDynamic(ref Fingerprint fingerprint,
@@ -37,8 +34,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                   ref resultLevelKind);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("secret", out FlexMatch secret))
             {

--- a/Src/Plugins/Security/SEC101_006.GitHubPatValidator.cs
+++ b/Src/Plugins/Security/SEC101_006.GitHubPatValidator.cs
@@ -22,12 +22,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new GitHubPatValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
         public static ValidationState IsValidDynamic(ref Fingerprint fingerprint,
@@ -42,8 +39,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                   ref resultLevelKind);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("secret", out FlexMatch secret))
             {
@@ -75,6 +71,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             {
                 return ValidationResult.CreateNoMatch();
             }
+
+            string matchedPattern = groups["0"].Value;
 
             if (matchedPattern.IndexOf("raw", StringComparison.OrdinalIgnoreCase) >= 0 ||
                 matchedPattern.IndexOf("tree", StringComparison.OrdinalIgnoreCase) >= 0 ||

--- a/Src/Plugins/Security/SEC101_007.GitHubAppCredentialsValidator.cs
+++ b/Src/Plugins/Security/SEC101_007.GitHubAppCredentialsValidator.cs
@@ -17,16 +17,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new GitHubAppCredentialsValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("id", out FlexMatch id) ||
                 !groups.TryGetNonEmptyValue("secret", out FlexMatch secret))

--- a/Src/Plugins/Security/SEC101_008.AwsCredentialsValidator.cs
+++ b/Src/Plugins/Security/SEC101_008.AwsCredentialsValidator.cs
@@ -29,12 +29,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             RegexEngine.IsMatch(string.Empty, AwsUserExpression);
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
         public static ValidationState IsValidDynamic(ref Fingerprint fingerprint,
@@ -49,8 +46,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                   ref resultLevelKind);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("id", out FlexMatch id) ||
                 !groups.TryGetNonEmptyValue("secret", out FlexMatch secret))

--- a/Src/Plugins/Security/SEC101_009.LinkedInCredentialsValidator.cs
+++ b/Src/Plugins/Security/SEC101_009.LinkedInCredentialsValidator.cs
@@ -17,16 +17,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new LinkedInCredentialsValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("id", out FlexMatch id) ||
                 !groups.TryGetNonEmptyValue("secret", out FlexMatch secret))

--- a/Src/Plugins/Security/SEC101_010.SquarePatValidator.cs
+++ b/Src/Plugins/Security/SEC101_010.SquarePatValidator.cs
@@ -21,12 +21,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new SquarePatValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
         public static ValidationState IsValidDynamic(ref Fingerprint fingerprint,
@@ -41,8 +38,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                   ref resultLevelKind);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetValue("secret", out FlexMatch secret))
             {

--- a/Src/Plugins/Security/SEC101_011.SquareCredentialsValidator.cs
+++ b/Src/Plugins/Security/SEC101_011.SquareCredentialsValidator.cs
@@ -17,16 +17,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new SquareCredentialsValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("id", out FlexMatch id) ||
                 !groups.TryGetNonEmptyValue("secret", out FlexMatch secret))

--- a/Src/Plugins/Security/SEC101_012.SlackWebhookValidator.cs
+++ b/Src/Plugins/Security/SEC101_012.SlackWebhookValidator.cs
@@ -21,12 +21,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new SlackWebhookValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
         public static ValidationState IsValidDynamic(ref Fingerprint fingerprint,
@@ -41,8 +38,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                   ref resultLevelKind);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("id", out FlexMatch id) ||
                 !groups.TryGetNonEmptyValue("secret", out FlexMatch secret))

--- a/Src/Plugins/Security/SEC101_013.CryptographicPrivateKeyValidator.cs
+++ b/Src/Plugins/Security/SEC101_013.CryptographicPrivateKeyValidator.cs
@@ -24,21 +24,19 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new CryptographicPrivateKeyValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("secret", out FlexMatch secret))
             {
                 return ValidationResult.CreateNoMatch();
             }
+
+            string matchedPattern = groups["0"].Value;
 
             groups.TryGetValue("kind", out FlexMatch kind);
             string kindValue = matchedPattern.Contains(" PGP ") ? "Pgp" : kind?.Value.String;

--- a/Src/Plugins/Security/SEC101_014.FacebookAccessTokenValidator.cs
+++ b/Src/Plugins/Security/SEC101_014.FacebookAccessTokenValidator.cs
@@ -17,16 +17,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new FacebookAccessTokenValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("secret", out FlexMatch secret))
             {

--- a/Src/Plugins/Security/SEC101_015.AkamaiCredentialsValidator.cs
+++ b/Src/Plugins/Security/SEC101_015.AkamaiCredentialsValidator.cs
@@ -21,12 +21,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new AkamaiCredentialsValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
         public static ValidationState IsValidDynamic(ref Fingerprint fingerprint,
@@ -41,8 +38,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                   ref resultLevelKind);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("id", out FlexMatch id) ||
                 !groups.TryGetNonEmptyValue("host", out FlexMatch host) ||

--- a/Src/Plugins/Security/SEC101_016.StripeApiKeyValidator.cs
+++ b/Src/Plugins/Security/SEC101_016.StripeApiKeyValidator.cs
@@ -27,12 +27,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new StripeApiKeyValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
         public static ValidationState IsValidDynamic(ref Fingerprint fingerprint,
@@ -47,8 +44,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                   ref resultLevelKind);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("secret", out FlexMatch secret))
             {

--- a/Src/Plugins/Security/SEC101_017.NpmAuthorTokenValidator.cs
+++ b/Src/Plugins/Security/SEC101_017.NpmAuthorTokenValidator.cs
@@ -23,12 +23,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new NpmAuthorTokenValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
         public static ValidationState IsValidDynamic(ref Fingerprint fingerprint,
@@ -43,8 +40,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                   ref resultLevelKind);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("secret", out FlexMatch secret))
             {

--- a/Src/Plugins/Security/SEC101_018.TwilioCredentialsValidator.cs
+++ b/Src/Plugins/Security/SEC101_018.TwilioCredentialsValidator.cs
@@ -22,12 +22,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new TwilioCredentialsValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
         public static ValidationState IsValidDynamic(ref Fingerprint fingerprint,
@@ -42,8 +39,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                   ref resultLevelKind);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("id", out FlexMatch id) ||
                 !groups.TryGetNonEmptyValue("secret", out FlexMatch secret))

--- a/Src/Plugins/Security/SEC101_019.PicaticApiKeyValidator.cs
+++ b/Src/Plugins/Security/SEC101_019.PicaticApiKeyValidator.cs
@@ -17,16 +17,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new PicaticApiKeyValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("secret", out FlexMatch secret))
             {

--- a/Src/Plugins/Security/SEC101_020.DropboxAccessTokenValidator.cs
+++ b/Src/Plugins/Security/SEC101_020.DropboxAccessTokenValidator.cs
@@ -21,12 +21,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new DropboxAccessTokenValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
         public static ValidationState IsValidDynamic(ref Fingerprint fingerprint,
@@ -41,8 +38,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                   ref resultLevelKind);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("secret", out FlexMatch secret))
             {

--- a/Src/Plugins/Security/SEC101_021.DropboxAppCredentialsValidator.cs
+++ b/Src/Plugins/Security/SEC101_021.DropboxAppCredentialsValidator.cs
@@ -22,12 +22,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new DropboxAppCredentialsValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
         public static ValidationState IsValidDynamic(ref Fingerprint fingerprint,
@@ -42,8 +39,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                   ref resultLevelKind);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("id", out FlexMatch id) ||
                 !groups.TryGetNonEmptyValue("secret", out FlexMatch secret))

--- a/Src/Plugins/Security/SEC101_022.PayPalBraintreeAccessTokenValidator.cs
+++ b/Src/Plugins/Security/SEC101_022.PayPalBraintreeAccessTokenValidator.cs
@@ -17,16 +17,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new PayPalBraintreeAccessTokenValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("secret", out FlexMatch secret))
             {

--- a/Src/Plugins/Security/SEC101_023.AmazonMwsAuthTokenValidator.cs
+++ b/Src/Plugins/Security/SEC101_023.AmazonMwsAuthTokenValidator.cs
@@ -17,16 +17,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new AmazonMwsAuthTokenValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("secret", out FlexMatch secret))
             {

--- a/Src/Plugins/Security/SEC101_024.TwilioApiKeyValidator.cs
+++ b/Src/Plugins/Security/SEC101_024.TwilioApiKeyValidator.cs
@@ -17,16 +17,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new TwilioApiKeyValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("secret", out FlexMatch secret))
             {

--- a/Src/Plugins/Security/SEC101_025.SendGridApiKeyValidator.cs
+++ b/Src/Plugins/Security/SEC101_025.SendGridApiKeyValidator.cs
@@ -23,12 +23,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new SendGridApiKeyValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
         public static ValidationState IsValidDynamic(ref Fingerprint fingerprint,
@@ -43,8 +40,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                   ref resultLevelKind);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetValue("secret", out FlexMatch secret))
             {

--- a/Src/Plugins/Security/SEC101_026.MailgunApiCredentialsValidator.cs
+++ b/Src/Plugins/Security/SEC101_026.MailgunApiCredentialsValidator.cs
@@ -17,12 +17,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
     {
         internal static MailgunApiCredentialsValidator Instance = new MailgunApiCredentialsValidator();
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
         public static ValidationState IsValidDynamic(ref Fingerprint fingerprint,
@@ -37,8 +34,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                   ref resultLevelKind);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("id", out FlexMatch id) ||
                 !groups.TryGetNonEmptyValue("secret", out FlexMatch secret))

--- a/Src/Plugins/Security/SEC101_027.MailChimpApiKeyValidator.cs
+++ b/Src/Plugins/Security/SEC101_027.MailChimpApiKeyValidator.cs
@@ -23,12 +23,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new MailChimpApiKeyValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
         public static ValidationState IsValidDynamic(ref Fingerprint fingerprint,
@@ -43,8 +40,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                   ref resultLevelKind);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("secret", out FlexMatch secret))
             {

--- a/Src/Plugins/Security/SEC101_028.PlaintextPasswordValidator.cs
+++ b/Src/Plugins/Security/SEC101_028.PlaintextPasswordValidator.cs
@@ -17,16 +17,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new PlaintextPasswordValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("secret", out FlexMatch secret))
             {

--- a/Src/Plugins/Security/SEC101_029.AlibabaCloudCredentialsValidator.cs
+++ b/Src/Plugins/Security/SEC101_029.AlibabaCloudCredentialsValidator.cs
@@ -29,12 +29,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new AlibabaCloudCredentialsValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
         // TODO: uncomment when Alibaba release a signed package/dll.
@@ -46,8 +43,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
         //                           ref options);
         // }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("id", out FlexMatch id) ||
                 !groups.TryGetNonEmptyValue("secret", out FlexMatch secret))

--- a/Src/Plugins/Security/SEC101_030.GoogleServiceAccountKeyValidator.cs
+++ b/Src/Plugins/Security/SEC101_030.GoogleServiceAccountKeyValidator.cs
@@ -17,16 +17,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new GoogleServiceAccountKeyValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("secret", out FlexMatch secret))
             {

--- a/Src/Plugins/Security/SEC101_031.NuGetApiKeyValidator.cs
+++ b/Src/Plugins/Security/SEC101_031.NuGetApiKeyValidator.cs
@@ -17,16 +17,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new NuGetApiKeyValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("secret", out FlexMatch secret))
             {

--- a/Src/Plugins/Security/SEC101_032.GpgCredentialsValidator.cs
+++ b/Src/Plugins/Security/SEC101_032.GpgCredentialsValidator.cs
@@ -17,16 +17,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new GpgCredentialsValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("secret", out FlexMatch secret))
             {

--- a/Src/Plugins/Security/SEC101_033.MongoDbConnectionStringValidator.cs
+++ b/Src/Plugins/Security/SEC101_033.MongoDbConnectionStringValidator.cs
@@ -22,12 +22,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Internal
             Instance = new MongoDbConnectionStringValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
         // public static ValidationState IsValidDynamic(ref Fingerprint fingerprint, ref string message, ref Dictionary<string, string> options)
@@ -38,8 +35,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Internal
         //                           ref options);
         // }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("id", out FlexMatch id) ||
                 !groups.TryGetNonEmptyValue("host", out FlexMatch host) ||

--- a/Src/Plugins/Security/SEC101_034.CredentialObjectValidator.cs
+++ b/Src/Plugins/Security/SEC101_034.CredentialObjectValidator.cs
@@ -17,16 +17,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new CredentialObjectValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                   Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("id", out FlexMatch id) ||
                 !groups.TryGetNonEmptyValue("secret", out FlexMatch secret))

--- a/Src/Plugins/Security/SEC101_035.CloudantCredentialsValidator.cs
+++ b/Src/Plugins/Security/SEC101_035.CloudantCredentialsValidator.cs
@@ -20,12 +20,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new CloudantCredentialsValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
         public static ValidationState IsValidDynamic(ref Fingerprint fingerprint,
@@ -40,8 +37,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                   ref resultLevelKind);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             // We need uri and neither account nor password, or uri and both account and password.  Use XOR
             if (!groups.TryGetNonEmptyValue("id", out FlexMatch id) ||

--- a/Src/Plugins/Security/SEC101_036.MySqlConnectionStringValidator.cs
+++ b/Src/Plugins/Security/SEC101_036.MySqlConnectionStringValidator.cs
@@ -33,12 +33,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             RegexEngine = RE2Regex.Instance;
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
         public static ValidationState IsValidDynamic(ref Fingerprint fingerprint,
@@ -53,8 +50,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                   ref resultLevelKind);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("id", out FlexMatch id) ||
                 !groups.TryGetNonEmptyValue("secret", out FlexMatch secret))

--- a/Src/Plugins/Security/SEC101_037.SqlConnectionStringValidator.cs
+++ b/Src/Plugins/Security/SEC101_037.SqlConnectionStringValidator.cs
@@ -46,12 +46,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             RegexEngine.Match(string.Empty, SecretExpression);
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
         public static ValidationState IsValidDynamic(ref Fingerprint fingerprint,
@@ -66,8 +63,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                   ref resultLevelKind);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             FlexMatch id, host, secret, database;
 

--- a/Src/Plugins/Security/SEC101_038.PostgreSqlConnectionStringValidator.cs
+++ b/Src/Plugins/Security/SEC101_038.PostgreSqlConnectionStringValidator.cs
@@ -35,12 +35,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             RegexEngine = RE2Regex.Instance;
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
         public static ValidationState IsValidDynamic(ref Fingerprint fingerprint,
@@ -55,8 +52,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                   ref resultLevelKind);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("id", out FlexMatch id) ||
                 !groups.TryGetNonEmptyValue("host", out FlexMatch host) ||

--- a/Src/Plugins/Security/SEC101_039.ShopifyAccessTokenValidator.cs
+++ b/Src/Plugins/Security/SEC101_039.ShopifyAccessTokenValidator.cs
@@ -17,16 +17,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new ShopifyAccessTokenValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("secret", out FlexMatch secret))
             {

--- a/Src/Plugins/Security/SEC101_040.ShopifySharedSecretValidator.cs
+++ b/Src/Plugins/Security/SEC101_040.ShopifySharedSecretValidator.cs
@@ -17,16 +17,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new ShopifySharedSecretValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("secret", out FlexMatch secret))
             {

--- a/Src/Plugins/Security/SEC101_041.RabbitMqConnectionStringValidator.cs
+++ b/Src/Plugins/Security/SEC101_041.RabbitMqConnectionStringValidator.cs
@@ -21,12 +21,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new RabbitMqConnectionStringValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
         public static ValidationState IsValidDynamic(ref Fingerprint fingerprint,
@@ -41,8 +38,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                   ref resultLevelKind);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("id", out FlexMatch id) ||
                 !groups.TryGetNonEmptyValue("host", out FlexMatch host) ||

--- a/Src/Plugins/Security/SEC101_042.DynatraceTokenValidator.cs
+++ b/Src/Plugins/Security/SEC101_042.DynatraceTokenValidator.cs
@@ -17,16 +17,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new DynatraceTokenValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("secret", out FlexMatch secret))
             {

--- a/Src/Plugins/Security/SEC101_043.NuGetCredentialsValidator.cs
+++ b/Src/Plugins/Security/SEC101_043.NuGetCredentialsValidator.cs
@@ -25,12 +25,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new NuGetCredentialsValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
         public static ValidationState IsValidDynamic(ref Fingerprint fingerprint,
@@ -70,8 +67,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             }
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("host", out FlexMatch hostsXml) ||
                 !groups.TryGetNonEmptyValue("secret", out FlexMatch secret))

--- a/Src/Plugins/Security/SEC101_044.NpmCredentialsValidator.cs
+++ b/Src/Plugins/Security/SEC101_044.NpmCredentialsValidator.cs
@@ -23,12 +23,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new NpmCredentialsValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
         public static ValidationState IsValidDynamic(ref Fingerprint fingerprint,
@@ -43,8 +40,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                   ref resultLevelKind);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("host", out FlexMatch host) ||
                 !groups.TryGetNonEmptyValue("secret", out FlexMatch secret))

--- a/Src/Plugins/Security/SEC101_045.PostmanApiKeyValidator.cs
+++ b/Src/Plugins/Security/SEC101_045.PostmanApiKeyValidator.cs
@@ -20,12 +20,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             Instance = new PostmanApiKeyValidator();
         }
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
-            return IsValidStatic(Instance,
-                                 ref matchedPattern,
-                                 groups);
+            return IsValidStatic(Instance, groups);
         }
 
         public static ValidationState IsValidDynamic(ref Fingerprint fingerprint,
@@ -40,8 +37,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                   ref resultLevelKind);
         }
 
-        protected override IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups)
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups)
         {
             if (!groups.TryGetNonEmptyValue("secret", out FlexMatch secret))
             {

--- a/Src/Plugins/Security/SEC101_102.AdoPatValidator.cs
+++ b/Src/Plugins/Security/SEC101_102.AdoPatValidator.cs
@@ -79,8 +79,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 
 #pragma warning disable IDE0060 // Remove unused parameter
 
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
 #pragma warning restore IDE0060
             if (!groups.TryGetNonEmptyValue("secret", out FlexMatch secret))

--- a/Src/Plugins/Security/SEC102.ReviewPotentiallySensitiveData.json
+++ b/Src/Plugins/Security/SEC102.ReviewPotentiallySensitiveData.json
@@ -12,7 +12,7 @@
         {
           "Id": "SEC102/001",
           "Name": "ReviewPotentiallySensitiveData/EmailAddress",
-          "ContentsRegex": "\\b(?i)(?P<refine>[0-9a-z._%+-]*[0-9a-z]+@[0-9a-z]+[0-9a-z.-]*\\.[0-9a-z]{2,})",
+          "ContentsRegex": "\\b(?i)(?P<id>[0-9a-z._%+-]*[0-9a-z]+)@(?P<host>[0-9a-z]+[0-9a-z.-]*\\.[0-9a-z]{2,})",
           "Message": "'{0:id}@{1:host}' is an apparent {2:dataKind}.",
           "MessageArguments": { "dataKind": "email address" },
           "Notes": [ "This will not catch every possible email address.  According to https://www.regular-expressions.info/email.html it is not reasonable to expect to do so.  The formal RFC definition of an email address includes things which some systems can't support, such as double quotes, spaces, and other special characters.  What we have here should capture about 99% of email addresses in use today." ]

--- a/Src/Plugins/Security/SEC103_017.PfxCryptographicKeyfileValidator.cs
+++ b/Src/Plugins/Security/SEC103_017.PfxCryptographicKeyfileValidator.cs
@@ -12,8 +12,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
     public static class PfxCryptographicKeyfileValidator
     {
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
             groups.TryGetValue("content", out FlexMatch content);
 
@@ -28,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             string message = string.Empty;
             Fingerprint fingerprint = default;
             ResultLevelKind resultLevelKind = default;
-            ValidationState validationState = CertificateHelper.TryLoadCertificate(matchedPattern,
+            ValidationState validationState = CertificateHelper.TryLoadCertificate(groups["scanTargetFullPath"].Value,
                                                                                    ref fingerprint,
                                                                                    ref message,
                                                                                    ref resultLevelKind);

--- a/Src/Plugins/Security/SEC103_024.MicrosoftSerializedCertificateStoreFileValidator.cs
+++ b/Src/Plugins/Security/SEC103_024.MicrosoftSerializedCertificateStoreFileValidator.cs
@@ -11,13 +11,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
     public static class MicrosoftSerializedCertificateStoreFileValidator
     {
-        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-                                                                  Dictionary<string, FlexMatch> groups)
+        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, FlexMatch> groups)
         {
             string message = string.Empty;
             Fingerprint fingerprint = default;
             ResultLevelKind resultLevelKind = default;
-            ValidationState validationState = CertificateHelper.TryLoadCertificateCollection(matchedPattern,
+            ValidationState validationState = CertificateHelper.TryLoadCertificateCollection(groups["scanTargetFullPath"].Value,
                                                                                              ref fingerprint,
                                                                                              ref message);
 

--- a/Src/Plugins/Security/Utilities/CertificateHelper.cs
+++ b/Src/Plugins/Security/Utilities/CertificateHelper.cs
@@ -65,8 +65,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Utilities
         }
 
         public static ValidationState TryLoadCertificateCollection(string certificatePath,
-                                                          ref Fingerprint fingerprint,
-                                                          ref string message)
+                                                                   ref Fingerprint fingerprint,
+                                                                   ref string message)
         {
             var certificates = new X509Certificate2Collection();
             try

--- a/Src/Plugins/Tests.Security/Validators/SEC101_006.GitHubPatValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/Validators/SEC101_006.GitHubPatValidatorTests.cs
@@ -19,11 +19,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
 
             string matchedPattern = "ghp_stuffchecksum"; // Insert new GitHub PAT here
             var groups = new Dictionary<string, FlexMatch>();
+            groups.Add("0", new FlexMatch() { Value = matchedPattern });
             groups.Add("secret", new FlexMatch() { Value = matchedPattern });
             groups.Add("checksum", new FlexMatch() { Value = "checksum" });
             groups.Add("scanTargetFullPath", new FlexMatch() { Value = "GitHitPatTest" });
 
-            IEnumerable<ValidationResult> validationResults = GitHubPatValidator.IsValidStatic(ref matchedPattern, groups);
+            IEnumerable<ValidationResult> validationResults = GitHubPatValidator.IsValidStatic(groups);
             foreach (ValidationResult validationResult in validationResults)
             {
                 Assert.Equal(matchedPattern, validationResult.Fingerprint.Secret);

--- a/Src/Plugins/Tests.Security/Validators/SEC101_013.CryptographicPrivateKeyValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/Validators/SEC101_013.CryptographicPrivateKeyValidatorTests.cs
@@ -24,10 +24,11 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
         {
             var keyValuePairs = new Dictionary<string, FlexMatch>
             {
+                { "0", new FlexMatch() { Value = TestMatchedPattern } },
                 { "secret", new FlexMatch() { Value = TestKey } }
             };
 
-            IEnumerable<ValidationResult> validationResults = CryptographicPrivateKeyValidator.IsValidStatic(ref TestMatchedPattern, keyValuePairs);
+            IEnumerable<ValidationResult> validationResults = CryptographicPrivateKeyValidator.IsValidStatic(keyValuePairs);
             foreach (ValidationResult validationResult in validationResults)
             {
                 Assert.Equal(ExpectedValidationState, validationResult.ValidationState);

--- a/Src/Plugins/Tests.Security/Validators/SEC101_102.AdoPatValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/Validators/SEC101_102.AdoPatValidatorTests.cs
@@ -55,8 +55,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                 string fingerprintText = null;
                 var groups = new Dictionary<string, FlexMatch>();
 
-                IEnumerable<ValidationResult> validationResults = AdoPatValidator.IsValidStatic(ref testCase.Input,
-                                                                                                groups);
+                IEnumerable<ValidationResult> validationResults = AdoPatValidator.IsValidStatic(groups);
 
                 string title = testCase.Title;
 

--- a/Src/Sarif.PatternMatcher.Sdk/ValidatorBase.cs
+++ b/Src/Sarif.PatternMatcher.Sdk/ValidatorBase.cs
@@ -83,11 +83,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk
         protected ISet<string> PerFileFingerprintCache { get; }
 
         public static IEnumerable<ValidationResult> IsValidStatic(ValidatorBase validator,
-                                                                  ref string matchedPattern,
                                                                   Dictionary<string, FlexMatch> groups)
         {
-            IEnumerable<ValidationResult> validationResults = validator.IsValidStaticHelper(ref matchedPattern,
-                                                                                            groups);
+            IEnumerable<ValidationResult> validationResults = validator.IsValidStaticHelper(groups);
 
             foreach (ValidationResult validationResult in validationResults)
             {
@@ -325,20 +323,13 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk
         /// <summary>
         /// Validate if the match is a secret or credential.
         /// </summary>
-        /// <param name="matchedPattern">
-        /// The matched text to be validated. This pattern can be further refined
-        /// to a substring of the original parameter value, with the result that
-        /// the refined matched pattern will be used as the code region associated
-        /// with the match.
-        /// </param>
         /// <param name="groups">
         /// Capture groups from the regex match. Dictionary entries can be modified or new entries
         /// added in order to refine or add argument values that will be used in result messages.
         /// </param>
         ///
         /// <returns>Return an enumerable ValidationResult collection.</returns>
-        protected abstract IEnumerable<ValidationResult> IsValidStaticHelper(ref string matchedPattern,
-                                                                             Dictionary<string, FlexMatch> groups);
+        protected abstract IEnumerable<ValidationResult> IsValidStaticHelper(Dictionary<string, FlexMatch> groups);
 
         protected virtual ValidationState IsValidDynamicHelper(ref Fingerprint fingerprint,
                                                                ref string message,

--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -493,7 +493,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
                 IEnumerable<ValidationResult> validationResults = _validators.Validate(reportingDescriptor.Name,
                                                                                        context,
-                                                                                       ref refinedMatchedPattern,
                                                                                        mergedGroups,
                                                                                        matchExpression.Properties,
                                                                                        out bool pluginSupportsDynamicValidation);
@@ -585,7 +584,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 {
                     IEnumerable<ValidationResult> validationResults = _validators.Validate(reportingDescriptor.Name,
                                                                                            context,
-                                                                                           ref refinedMatchedPattern,
                                                                                            match,
                                                                                            out bool pluginSupportsDynamicValidation);
 
@@ -740,9 +738,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 : context.TargetUri.OriginalString;
             if (_validators != null && matchExpression.IsValidatorEnabled)
             {
+                groups["scanTargetFullPath"] = new FlexMatch() { Value = filePath };
                 IEnumerable<ValidationResult> validationResults = _validators.Validate(reportingDescriptor.Name,
                                                                                        context,
-                                                                                       ref filePath,
                                                                                        groups,
                                                                                        out bool pluginSupportsDynamicValidation);
 

--- a/Src/Sarif.PatternMatcher/ValidatorsCache.cs
+++ b/Src/Sarif.PatternMatcher/ValidatorsCache.cs
@@ -67,14 +67,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
         }
 
         public static IEnumerable<ValidationResult> ValidateStaticHelper(MethodInfo isValidStaticMethodInfo,
-                                                                         ref string matchedPattern,
                                                                          IDictionary<string, FlexMatch> groups)
         {
             IEnumerable<ValidationResult> validationResults;
 
             object[] arguments = new object[]
             {
-                matchedPattern,
                 groups,
             };
 
@@ -96,8 +94,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 Environment.CurrentDirectory = currentDirectory;
             }
 
-            matchedPattern = (string)arguments[0];
-            groups = (Dictionary<string, FlexMatch>)arguments[1];
+            groups = (Dictionary<string, FlexMatch>)arguments[0];
 
             return validationResults;
         }
@@ -170,21 +167,18 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
         public IEnumerable<ValidationResult> Validate(string ruleName,
                                                       AnalyzeContext context,
-                                                      ref string matchedPattern,
                                                       IDictionary<string, FlexMatch> groups,
                                                       out bool pluginCanPerformDynamicAnalysis)
         {
             return ValidateHelper(RuleNameToValidationMethods,
                                   ruleName,
                                   context,
-                                  ref matchedPattern,
                                   groups,
                                   out pluginCanPerformDynamicAnalysis);
         }
 
         public IEnumerable<ValidationResult> Validate(string ruleName,
                                                       AnalyzeContext context,
-                                                      ref string matchedPattern,
                                                       IDictionary<string, ISet<FlexMatch>> mergedGroups,
                                                       IDictionary<string, string> properties,
                                                       out bool pluginCanPerformDynamicAnalysis)
@@ -207,7 +201,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 results.AddRange(ValidateHelper(RuleNameToValidationMethods,
                                                 ruleName,
                                                 context,
-                                                ref matchedPattern,
                                                 groups,
                                                 out pluginCanPerformDynamicAnalysis));
             }
@@ -225,7 +218,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
         internal static IEnumerable<ValidationResult> ValidateHelper(Dictionary<string, ValidationMethods> ruleIdToMethodMap,
                                                                      string ruleName,
                                                                      AnalyzeContext context,
-                                                                     ref string matchedPattern,
                                                                      IDictionary<string, FlexMatch> groups,
                                                                      out bool pluginCanPerformDynamicAnalysis)
         {
@@ -266,7 +258,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             }
 
             IEnumerable<ValidationResult> validationResults = ValidateStaticHelper(validationMethods.IsValidStatic,
-                                                                                   ref matchedPattern,
                                                                                    groups);
 
             pluginCanPerformDynamicAnalysis = validationMethods.IsValidDynamic != null;
@@ -363,7 +354,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                             "IsValidStatic",
                             new[]
                             {
-                                typeof(string).MakeByRefType(), // Matched pattern.
                                 typeof(Dictionary<string, FlexMatch>), // Regex groups.
                             },
                             null);

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/TestRuleValidators.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/TestRuleValidators.cs
@@ -13,8 +13,7 @@
 //    public class OverrideIndexTestValidator
 //    {
 //        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "<Pending>")]
-//        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-//                                                                  Dictionary<string, string> groups)
+//        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, string> groups)
 //        {
 //            // "TestTerm Another-TEST-TERM"
 //            // original index is 0, override it to 17, length to 9
@@ -36,8 +35,7 @@
 //    public class DoesNotOverrideTestValidator
 //    {
 //        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "<Pending>")]
-//        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-//                                                                  Dictionary<string, string> groups)
+//        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, string> groups)
 //        {
 //            var result = new ValidationResult
 //            {
@@ -54,8 +52,7 @@
 //    public class VerifyResultKindLevelTestValidator
 //    {
 //        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "<Pending>")]
-//        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-//                                                                  Dictionary<string, string> groups)
+//        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, string> groups)
 //        {
 //            // result multiple results
 //            ValidationResult[] results = new[]
@@ -104,8 +101,7 @@
 //    public class InvalidIndexLengthTestValidator
 //    {
 //        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "<Pending>")]
-//        public static IEnumerable<ValidationResult> IsValidStatic(ref string matchedPattern,
-//                                                                  Dictionary<string, string> groups)
+//        public static IEnumerable<ValidationResult> IsValidStatic(Dictionary<string, string> groups)
 //        {
 //            // matchedPatrtern "TestTerm Another-TEST-TERM", length is 26
 //            ValidationResult[] results = new[]


### PR DESCRIPTION
…, rules can consult groups["0"] if they need to inspect the full original match.

@eddynaka 