### PR TITLE
Fixing ArgumentException during ValidatingVisitor analysis

### DIFF
--- a/Src/Sarif.PatternMatcher.Sdk/Fingerprint.cs
+++ b/Src/Sarif.PatternMatcher.Sdk/Fingerprint.cs
@@ -30,6 +30,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk
 
         private const char RightBracketReplacement = '\t';
         private const string HashKey = "7B2FD4B8B55B49428DBFB22C9E61D817";
+
         private const string Base64EncodingSymbolSet =
             "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
@@ -90,6 +91,40 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk
                         $"there are no spaces between components, etc. Initializer was '{fingerprintText}'. " +
                         $"Valid computed fingerprint was '{computedFingerprint}'.",
                         nameof(fingerprintText));
+                }
+            }
+        }
+
+        public Fingerprint(IDictionary<string, string> fingerprints)
+        {
+            SecretSymbolSetCount = 0;
+
+            // Validation fingerprint properties.
+            Id = Host = Path = Port = Scheme = Secret = Resource = Thumbprint = null;
+
+            // Asset fingerprint properties.
+            Platform = Part = null;
+
+            IgnorePathInFingerprint = false;
+
+            bool jsonFingerprintFound = false;
+
+            foreach (KeyValuePair<string, string> kp in fingerprints)
+            {
+                if (!kp.Value.StartsWith("{"))
+                {
+                    continue;
+                }
+
+                jsonFingerprintFound = true;
+                ParseJson(kp.Value);
+            }
+
+            if (!jsonFingerprintFound)
+            {
+                foreach (KeyValuePair<string, string> kp in fingerprints)
+                {
+                    Parse(kp.Value);
                 }
             }
         }

--- a/Src/Sarif.PatternMatcher/ValidatingVisitor.cs
+++ b/Src/Sarif.PatternMatcher/ValidatingVisitor.cs
@@ -34,17 +34,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 return node;
             }
 
-            // Looking for V2 fingerprint
-            if (!node.Fingerprints.TryGetValue(SearchSkimmer.ValidationFingerprintV2, out string fingerprintText))
-            {
-                // Looking for v1 fingerprint
-                if (!node.Fingerprints.TryGetValue(SearchSkimmer.ValidationFingerprint, out fingerprintText))
-                {
-                    return node;
-                }
-            }
-
-            var fingerprint = new Fingerprint(fingerprintText, validate: false);
+            var fingerprint = new Fingerprint(node.Fingerprints);
 
             ReportingDescriptor rule = node.GetRule(_run);
 
@@ -92,7 +82,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                                                                   ref message,
                                                                   pluginSupportsDynamicValidation: true);
 
-                fingerprint.Merge(node.Fingerprints[SearchSkimmer.AssetFingerprintV2]);
                 node.Level = level;
                 node.Kind = kind;
                 node.Message.Arguments[1] = validationPrefix;

--- a/Src/Sarif.PatternMatcher/ValidatingVisitor.cs
+++ b/Src/Sarif.PatternMatcher/ValidatingVisitor.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                                                                   ref message,
                                                                   pluginSupportsDynamicValidation: true);
 
-                fingerprint.Merge(node.Fingerprints[SearchSkimmer.AssetFingerprint]);
+                fingerprint.Merge(node.Fingerprints[SearchSkimmer.AssetFingerprintV2]);
                 node.Level = level;
                 node.Kind = kind;
                 node.Message.Arguments[1] = validationPrefix;

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/ValidatingVisitorTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/ValidatingVisitorTests.cs
@@ -73,6 +73,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 Fingerprints = new Dictionary<string, string>
                 {
                     { SearchSkimmer.AssetFingerprint, fingerprint.GetAssetFingerprintText() },
+                    { SearchSkimmer.AssetFingerprintV2, fingerprint.GetAssetFingerprintText(jsonFormat: true) },
                     { SearchSkimmer.ValidationFingerprint, fingerprint.GetValidationFingerprintText() },
                     { SearchSkimmer.ValidationFingerprintV2, fingerprint.GetValidationFingerprintText(jsonFormat: true)},
                 },

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/ValidatingVisitorTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/ValidatingVisitorTests.cs
@@ -95,5 +95,95 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             result.Fingerprints[SearchSkimmer.ValidationFingerprint].Should().Be(fingerprint.GetValidationFingerprintText());
             result.Fingerprints[SearchSkimmer.AssetFingerprintV2].Should().Be(updatedFingerprint.GetAssetFingerprintText(jsonFormat: true));
         }
+
+        [Fact]
+        public void ValidatingVisitor_ShouldNotThrowAnExcecption()
+        {
+            TestRuleValidator.OverrideIsValidDynamic = (ref Fingerprint fingerprint,
+                                                        ref string message,
+                                                        Dictionary<string, string> options,
+                                                        ref ResultLevelKind resultLevelKind) =>
+            {
+                fingerprint.Id = "test";
+                return ValidationState.Authorized;
+            };
+
+            string validatorAssemblyPath = $@"c:\{Guid.NewGuid()}.dll";
+            string scanTargetExtension = Guid.NewGuid().ToString();
+
+            var mockFileSystem = new Mock<IFileSystem>();
+            mockFileSystem.Setup(x => x.FileExists(validatorAssemblyPath)).Returns(true);
+            mockFileSystem.Setup(x => x.AssemblyLoadFrom(validatorAssemblyPath)).Returns(this.GetType().Assembly);
+
+            var validators = new ValidatorsCache(
+                new string[] { validatorAssemblyPath },
+                fileSystem: mockFileSystem.Object);
+
+            var validatingVisitor = new ValidatingVisitor(validators);
+            validatingVisitor.VisitRun(new Run
+            {
+                Tool = new Tool
+                {
+                    Driver = new ToolComponent
+                    {
+                        Rules = new[]
+                        {
+                            new ReportingDescriptor
+                            {
+                                Id = "TestRule",
+                                Name = "TestRule"
+                            }
+                        }
+                    }
+                }
+            });
+
+            var fingerprint = new Fingerprint
+            {
+                Host = "some-database-name.database.windows.net:1433",
+                Id = "username",
+                Part = "servers",
+                Resource = "catalog-db][host=tcp:some-database-name.database.windows.net,1433][pwd=password]\\",
+                Platform = nameof(AssetPlatform.GitHub),
+            };
+
+            var updatedFingerprint = new Fingerprint
+            {
+                Host = "some-database-name.database.windows.net:1433",
+                Id = "test", // This value was changed during the "analysis".
+                Part = "servers",
+                Resource = "catalog-db][host=tcp:some-database-name.database.windows.net,1433][pwd=password]\\",
+                Platform = nameof(AssetPlatform.GitHub),
+            };
+
+            var result = new Result
+            {
+                RuleId = "TestRule",
+                Fingerprints = new Dictionary<string, string>
+                {
+                    { SearchSkimmer.AssetFingerprint, fingerprint.GetAssetFingerprintText() },
+                    { SearchSkimmer.AssetFingerprintV2, fingerprint.GetAssetFingerprintText(jsonFormat: true) },
+                    { SearchSkimmer.ValidationFingerprint, fingerprint.GetValidationFingerprintText() },
+                    { SearchSkimmer.ValidationFingerprintV2, fingerprint.GetValidationFingerprintText(jsonFormat: true)},
+                },
+                Message = new Message
+                {
+                    Arguments = new List<string>
+                    {
+                        "secret…",
+                        "a valid ",
+                        "",
+                        "legacy format GitHub personal access token",
+                        "",
+                        " (the compromised GitHub account is '[username](https://github.com/username)' which has access to the following orgs '[None]')"
+                    }
+                }
+            };
+
+            result = validatingVisitor.VisitResult(result);
+            result.Fingerprints[SearchSkimmer.AssetFingerprint].Should().Be(updatedFingerprint.GetAssetFingerprintText());
+            result.Fingerprints[SearchSkimmer.ValidationFingerprint].Should().Be(fingerprint.GetValidationFingerprintText());
+            result.Fingerprints[SearchSkimmer.AssetFingerprintV2].Should().Be(updatedFingerprint.GetAssetFingerprintText(jsonFormat: true));
+        }
     }
 }

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/ValidatingVisitorTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/ValidatingVisitorTests.cs
@@ -19,86 +19,14 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
         [Fact]
         public void ValidatingVisitor_ShouldOverrideAssetFingerprint()
         {
-            TestRuleValidator.OverrideIsValidDynamic = (ref Fingerprint fingerprint,
-                                                        ref string message,
-                                                        Dictionary<string, string> options,
-                                                        ref ResultLevelKind resultLevelKind) =>
+            for (int i = 0; i < s_validatingVisitorTestCases.Length; i++)
             {
-                fingerprint.Id = "test";
-                return ValidationState.Authorized;
-            };
-
-            string validatorAssemblyPath = $@"c:\{Guid.NewGuid()}.dll";
-            string scanTargetExtension = Guid.NewGuid().ToString();
-
-            var mockFileSystem = new Mock<IFileSystem>();
-            mockFileSystem.Setup(x => x.FileExists(validatorAssemblyPath)).Returns(true);
-            mockFileSystem.Setup(x => x.AssemblyLoadFrom(validatorAssemblyPath)).Returns(this.GetType().Assembly);
-
-            var validators = new ValidatorsCache(
-                new string[] { validatorAssemblyPath },
-                fileSystem: mockFileSystem.Object);
-
-            var validatingVisitor = new ValidatingVisitor(validators);
-            validatingVisitor.VisitRun(new Run
-            {
-                Tool = new Tool
-                {
-                    Driver = new ToolComponent
-                    {
-                        Rules = new[]
-                        {
-                            new ReportingDescriptor
-                            {
-                                Id = "TestRule",
-                                Name = "TestRule"
-                            }
-                        }
-                    }
-                }
-            });
-
-            var fingerprint = new Fingerprint
-            {
-                Secret = "secret",
-                Platform = nameof(AssetPlatform.GitHub),
-            };
-
-            const string updatedAssetFingerprint = "[id=test][platform=GitHub]";
-            var updatedFingerprint = new Fingerprint(updatedAssetFingerprint);
-
-            var result = new Result
-            {
-                RuleId = "TestRule",
-                Fingerprints = new Dictionary<string, string>
-                {
-                    { SearchSkimmer.AssetFingerprint, fingerprint.GetAssetFingerprintText() },
-                    { SearchSkimmer.AssetFingerprintV2, fingerprint.GetAssetFingerprintText(jsonFormat: true) },
-                    { SearchSkimmer.ValidationFingerprint, fingerprint.GetValidationFingerprintText() },
-                    { SearchSkimmer.ValidationFingerprintV2, fingerprint.GetValidationFingerprintText(jsonFormat: true)},
-                },
-                Message = new Message
-                {
-                    Arguments = new List<string>
-                    {
-                        "secret…",
-                        "a valid ",
-                        "",
-                        "legacy format GitHub personal access token",
-                        "",
-                        " (the compromised GitHub account is '[username](https://github.com/username)' which has access to the following orgs '[None]')"
-                    }
-                }
-            };
-
-            result = validatingVisitor.VisitResult(result);
-            result.Fingerprints[SearchSkimmer.AssetFingerprint].Should().Be(updatedAssetFingerprint);
-            result.Fingerprints[SearchSkimmer.ValidationFingerprint].Should().Be(fingerprint.GetValidationFingerprintText());
-            result.Fingerprints[SearchSkimmer.AssetFingerprintV2].Should().Be(updatedFingerprint.GetAssetFingerprintText(jsonFormat: true));
+                ValidatingVisitorTestCase testCase = s_validatingVisitorTestCases[i];
+                Validate(testCase.Original, testCase.Expected);
+            }
         }
 
-        [Fact]
-        public void ValidatingVisitor_ShouldNotThrowAnExcecption()
+        private void Validate(Fingerprint original, Fingerprint expected)
         {
             TestRuleValidator.OverrideIsValidDynamic = (ref Fingerprint fingerprint,
                                                         ref string message,
@@ -139,52 +67,72 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 }
             });
 
-            var fingerprint = new Fingerprint
-            {
-                Host = "some-database-name.database.windows.net:1433",
-                Id = "username",
-                Part = "servers",
-                Resource = "catalog-db][host=tcp:some-database-name.database.windows.net,1433][pwd=password]\\",
-                Platform = nameof(AssetPlatform.GitHub),
-            };
-
-            var updatedFingerprint = new Fingerprint
-            {
-                Host = "some-database-name.database.windows.net:1433",
-                Id = "test", // This value was changed during the "analysis".
-                Part = "servers",
-                Resource = "catalog-db][host=tcp:some-database-name.database.windows.net,1433][pwd=password]\\",
-                Platform = nameof(AssetPlatform.GitHub),
-            };
-
             var result = new Result
             {
                 RuleId = "TestRule",
                 Fingerprints = new Dictionary<string, string>
                 {
-                    { SearchSkimmer.AssetFingerprint, fingerprint.GetAssetFingerprintText() },
-                    { SearchSkimmer.AssetFingerprintV2, fingerprint.GetAssetFingerprintText(jsonFormat: true) },
-                    { SearchSkimmer.ValidationFingerprint, fingerprint.GetValidationFingerprintText() },
-                    { SearchSkimmer.ValidationFingerprintV2, fingerprint.GetValidationFingerprintText(jsonFormat: true)},
+                    { SearchSkimmer.AssetFingerprint, original.GetAssetFingerprintText() },
+                    { SearchSkimmer.AssetFingerprintV2, original.GetAssetFingerprintText(jsonFormat: true) },
+                    { SearchSkimmer.ValidationFingerprint, original.GetValidationFingerprintText() },
+                    { SearchSkimmer.ValidationFingerprintV2, original.GetValidationFingerprintText(jsonFormat: true)},
                 },
                 Message = new Message
                 {
-                    Arguments = new List<string>
-                    {
-                        "secret…",
-                        "a valid ",
-                        "",
-                        "legacy format GitHub personal access token",
-                        "",
-                        " (the compromised GitHub account is '[username](https://github.com/username)' which has access to the following orgs '[None]')"
-                    }
+                    Arguments = new List<string> { "", "", "", "", "", "" }
                 }
             };
 
             result = validatingVisitor.VisitResult(result);
-            result.Fingerprints[SearchSkimmer.AssetFingerprint].Should().Be(updatedFingerprint.GetAssetFingerprintText());
-            result.Fingerprints[SearchSkimmer.ValidationFingerprint].Should().Be(fingerprint.GetValidationFingerprintText());
-            result.Fingerprints[SearchSkimmer.AssetFingerprintV2].Should().Be(updatedFingerprint.GetAssetFingerprintText(jsonFormat: true));
+
+            // AssetFingerprint should be updated.
+            result.Fingerprints[SearchSkimmer.AssetFingerprint].Should().Be(expected.GetAssetFingerprintText());
+            result.Fingerprints[SearchSkimmer.AssetFingerprintV2].Should().Be(expected.GetAssetFingerprintText(jsonFormat: true));
+
+            // ValidationFingerprint should be the same as original.
+            result.Fingerprints[SearchSkimmer.ValidationFingerprint].Should().Be(original.GetValidationFingerprintText());
+            result.Fingerprints[SearchSkimmer.ValidationFingerprintV2].Should().Be(original.GetValidationFingerprintText(jsonFormat: true));
+        }
+
+        private static readonly ValidatingVisitorTestCase[] s_validatingVisitorTestCases = new[]
+        {
+            new ValidatingVisitorTestCase
+            {
+                Original = new Fingerprint
+                {
+                    Secret = "secret",
+                    Platform = nameof(AssetPlatform.GitHub),
+                },
+                Expected = new Fingerprint
+                {
+                    Id = "test",
+                    Secret = "secret",
+                    Platform = nameof(AssetPlatform.GitHub),
+                },
+                Title = "Simple override test."
+            },
+            new ValidatingVisitorTestCase
+            {
+                Original = new Fingerprint
+                {
+                    Secret = "secret[id=id]",
+                    Platform = nameof(AssetPlatform.GitHub),
+                },
+                Expected = new Fingerprint
+                {
+                    Id = "test",
+                    Secret = "secret[id=id]",
+                    Platform = nameof(AssetPlatform.GitHub),
+                },
+                Title = "Broken square bracket fingerprint."
+            }
+        };
+
+        internal struct ValidatingVisitorTestCase
+        {
+            public string Title;
+            public Fingerprint Original;
+            public Fingerprint Expected;
         }
     }
 }


### PR DESCRIPTION
This change fixes the following exceptions:
```
ValidationError:'ArgumentOutOfRangeException' exception raised parsing potentially malformed fingerprint: '[host=[Azure_SQL_Server][Sql_Database_Dns_Suffix],1433][id=[Environment_Name]_{0}_login_{1}][platform=SqlOnPremise][resource=[Environment_Name]]'. Exception message: 'Specified argument was out of the range of valid values.
Parameter name: keyName'
Parameter name: fingerprintText   at Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk.Fingerprint..ctor(String fingerprintText, Boolean validate)
   at Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk.Fingerprint.Merge(String previousFingerprintText)
   at Microsoft.CodeAnalysis.Sarif.PatternMatcher.ValidatingVisitor.VisitResult(Result node)

ValidationError:'ArgumentException' exception raised parsing potentially malformed fingerprint: '[host=some-database-name.database.windows.net,1433][id=username][part=servers][platform=Azure][resource=catalog-db][host=tcp]'. Exception message: 'The 'host' key name is duplicated in the fingerprint.'
Parameter name: fingerprintText   at Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk.Fingerprint..ctor(String fingerprintText, Boolean validate)
   at Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk.Fingerprint.Merge(String previousFingerprintText)
   at Microsoft.CodeAnalysis.Sarif.PatternMatcher.ValidatingVisitor.VisitResult(Result node)
```