### PR TITLE
Create Mock Http tests for Slack Tokens

### DIFF
--- a/Src/Plugins/Security/SEC101_005.SlackTokenValidator.cs
+++ b/Src/Plugins/Security/SEC101_005.SlackTokenValidator.cs
@@ -91,10 +91,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     return ReturnUnexpectedResponseCode(ref message, response.StatusCode);
                 }
 
-                string content = response.Content
-                                         .ReadAsStringAsync()
-                                         .GetAwaiter()
-                                         .GetResult();
+                string content = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
 
                 AuthTestResponse authResponse = JsonSerializer.Deserialize<AuthTestResponse>(content);
 
@@ -108,7 +105,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                 if (!string.IsNullOrEmpty(authResponse.Error))
                 {
                     message = $"An unexpected error was observed " +
-                              $"attempting to validate token: '{authResponse.Error}'";
+                              $"attempting to validate the token: '{authResponse.Error}'";
                     return ValidationState.Unknown;
                 }
 

--- a/Src/Plugins/Security/SEC101_005.SlackTokenValidator.cs
+++ b/Src/Plugins/Security/SEC101_005.SlackTokenValidator.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                 {
                     case "token_revoked":
                     case "account_inactive": { return ValidationState.Expired; }
-                    case "invalid_auth": { return ReturnUnauthorizedAccess(ref message, fingerprint.Secret); }
+                    case "invalid_auth": { return ValidationState.Unauthorized; }
                 }
 
                 if (!string.IsNullOrEmpty(authResponse.Error))

--- a/Src/Plugins/Security/SEC101_005.SlackTokenValidator.cs
+++ b/Src/Plugins/Security/SEC101_005.SlackTokenValidator.cs
@@ -109,7 +109,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 
                 message = BuildAuthTestResponseMessage(authResponse);
                 return ValidationState.Authorized;
-            } catch (Exception e)
+            }
+            catch (Exception e)
             {
                 return ReturnUnhandledException(ref message, e);
             }

--- a/Src/Plugins/Security/SEC101_005.SlackTokenValidator.cs
+++ b/Src/Plugins/Security/SEC101_005.SlackTokenValidator.cs
@@ -93,23 +93,18 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 
                 AuthTestResponse authResponse = JsonSerializer.Deserialize<AuthTestResponse>(content);
 
-                if (content.Contains("invalid_auth"))
-                {
-                    return ValidationState.Unauthorized;
-                }
-
                 switch (authResponse.Error)
                 {
                     case "token_revoked":
                     case "account_inactive": { return ValidationState.Expired; }
-                    case "invalid_auth": { return ReturnAuthorizedAccess(ref message, fingerprint.Secret); }
+                    case "invalid_auth": { return ReturnUnauthorizedAccess(ref message, fingerprint.Secret); }
                 }
 
                 if (!string.IsNullOrEmpty(authResponse.Error))
                 {
                     message = $"An unexpected error was observed " +
                               $"attempting to validate token: '{authResponse.Error}'";
-                    return ReturnUnknownAuthorization(ref message, fingerprint.Secret);
+                    return ValidationState.Unknown;
                 }
 
                 message = BuildAuthTestResponseMessage(authResponse);

--- a/Src/Plugins/Security/SEC101_005.SlackTokenValidator.cs
+++ b/Src/Plugins/Security/SEC101_005.SlackTokenValidator.cs
@@ -86,6 +86,11 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     .GetAwaiter()
                     .GetResult();
 
+                if (response.StatusCode != HttpStatusCode.OK)
+                {
+                    return ReturnUnexpectedResponseCode(ref message, response.StatusCode);
+                }
+
                 string content = response.Content
                                          .ReadAsStringAsync()
                                          .GetAwaiter()

--- a/Src/Plugins/Tests.Security/Validators/SEC101_005.SlackTokenValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/Validators/SEC101_005.SlackTokenValidatorTests.cs
@@ -2,10 +2,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Net.Http;
+using System.Net;
+using System.Text;
 
 using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk;
 
 using Xunit;
+using FluentAssertions;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validators
 {
@@ -29,6 +33,107 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                                                ref message,
                                                keyValuePairs,
                                                ref resultLevelKind);
+        }
+
+        [Fact]
+        public void SlackTokenValidatorMockHttp_Test()
+        {
+            var testCases = new[]
+            {
+                new
+                {
+                    Title = "Testing Valid Token",
+                    HttpStatusCode = HttpStatusCode.OK,
+                    // In all cases JSON is formatted in the order receieved from slack.
+                    HttpContent = new StringContent("{\"ok\": true," +
+                                                    "\"url\": \"testteam.slack.com\"," +
+                                                    "\"team\":\"test team\"," +
+                                                    "\"user\": \"testbot\"," +
+                                                    "\"team_id\": \"1234ABCD\"," +
+                                                    "\"user_id\": \"5678EFGH\"," +
+                                                    "\"bot_id\": \"0987ZYXV\"," +
+                                                    "\"is_enterprise_install\": false}",
+                                                    Encoding.UTF8,
+                                                    "application/json").As<HttpContent>(),
+                    ExpectedValidationState = ValidationState.Authorized,
+                    ExpectedMessage = "Bot token (id: 0987ZYXV) was authenticated to channel 'testteam.slack.com',  team 'test team' (id: 1234ABCD),  user 'testbot' (id: 5678EFGH).  The token is not associated with an enterprise installation."
+                },
+                new
+                {
+                    Title = "Testing Invalid Token",
+                    HttpStatusCode = HttpStatusCode.OK,
+                    HttpContent = new StringContent("{\"ok\": true," +
+                                                    "\"error\": \"invalid_auth\"}",
+                                                    Encoding.UTF8,
+                                                    "application/json").As<HttpContent>(),
+                    ExpectedValidationState = ValidationState.Unauthorized,
+                    ExpectedMessage = "The provided secret is not authorized to access 'xoxb-1234'."
+                },
+                new
+                {
+                    Title = "Testing Revoked Token",
+                    HttpStatusCode = HttpStatusCode.OK,
+                    HttpContent = new StringContent("{\"ok\": true," +
+                                                    "\"error\": \"token_revoked\"}",
+                                                     Encoding.UTF8,
+                                                     "application/json").As<HttpContent>(),
+                    ExpectedValidationState = ValidationState.Expired,
+                    ExpectedMessage = string.Empty
+                },
+                new
+                {
+                    Title = "Testing Inactive Token",
+                    HttpStatusCode = HttpStatusCode.OK,
+                    HttpContent = new StringContent("{\"ok\": true," +
+                                                    "\"error\": \"account_inactive\"}",
+                                                    Encoding.UTF8,
+                                                    "application/json").As<HttpContent>(),
+                    ExpectedValidationState = ValidationState.Expired,
+                    ExpectedMessage = string.Empty
+                },
+                new
+                {
+                    Title = "Testing Unknown Slack Error",
+                    HttpStatusCode = HttpStatusCode.OK,
+                    HttpContent = new StringContent("{\"ok\": true," +
+                                                    "\"error\": \"unknown_error\"}",
+                                                    Encoding.UTF8,
+                                                    "application/json").As<HttpContent>(),
+                    ExpectedValidationState = ValidationState.Unknown,
+                    ExpectedMessage = "An unexpected error was observed attempting to validate token: 'unknown_error'"
+                },
+            };
+
+            const string fingerprintText = "[secret=xoxb-1234]";
+
+            var sb = new StringBuilder();
+            foreach (var testCase in testCases)
+            {
+                string message = string.Empty;
+                ResultLevelKind resultLevelKind = default;
+                var fingerprint = new Fingerprint(fingerprintText);
+                var keyValuePairs = new Dictionary<string, string>();
+
+                MockHelper.ResetStaticInstance<SlackTokenValidator>();
+                using var httpClient = new HttpClient(MockHelper.MockHttpMessageHandler(testCase.HttpStatusCode, testCase.HttpContent));
+                SlackTokenValidator.Instance.SetHttpClient(httpClient);
+
+                ValidationState currentState = SlackTokenValidator.IsValidDynamic(ref fingerprint,
+                                                                                         ref message,
+                                                                                         keyValuePairs,
+                                                                                         ref resultLevelKind);
+                if (currentState != testCase.ExpectedValidationState)
+                {
+                    sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
+                }
+
+                if (!message.Equals(testCase.ExpectedMessage))
+                {
+                    sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
+                }
+            }
+
+            sb.Length.Should().Be(0, sb.ToString());
         }
     }
 }

--- a/Src/Plugins/Tests.Security/Validators/SEC101_005.SlackTokenValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/Validators/SEC101_005.SlackTokenValidatorTests.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                                                     Encoding.UTF8,
                                                     "application/json").As<HttpContent>(),
                     ExpectedValidationState = ValidationState.Unknown,
-                    ExpectedMessage = "An unexpected error was observed attempting to validate token: 'unknown_error'"
+                    ExpectedMessage = "An unexpected error was observed attempting to validate the token: 'unknown_error'"
                 },
                 new
                 {

--- a/Src/Plugins/Tests.Security/Validators/SEC101_005.SlackTokenValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/Validators/SEC101_005.SlackTokenValidatorTests.cs
@@ -2,14 +2,15 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Net.Http;
 using System.Net;
+using System.Net.Http;
 using System.Text;
+
+using FluentAssertions;
 
 using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk;
 
 using Xunit;
-using FluentAssertions;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validators
 {

--- a/Src/Plugins/Tests.Security/Validators/SEC101_005.SlackTokenValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/Validators/SEC101_005.SlackTokenValidatorTests.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                                                     Encoding.UTF8,
                                                     "application/json").As<HttpContent>(),
                     ExpectedValidationState = ValidationState.Unauthorized,
-                    ExpectedMessage = "The provided secret is not authorized to access 'xoxb-1234'."
+                    ExpectedMessage = string.Empty
                 },
                 new
                 {

--- a/Src/Plugins/Tests.Security/Validators/SEC101_005.SlackTokenValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/Validators/SEC101_005.SlackTokenValidatorTests.cs
@@ -103,6 +103,14 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     ExpectedValidationState = ValidationState.Unknown,
                     ExpectedMessage = "An unexpected error was observed attempting to validate token: 'unknown_error'"
                 },
+                new
+                {
+                    Title = "Testing Unknown Status code",
+                    HttpStatusCode = HttpStatusCode.InternalServerError,
+                    HttpContent = (HttpContent)null,
+                    ExpectedValidationState = ValidationState.Unknown,
+                    ExpectedMessage = "An unexpected HTTP response code was received: 'InternalServerError'.",
+                },
             };
 
             const string fingerprintText = "[secret=xoxb-1234]";


### PR DESCRIPTION
* Converts `SlackTokenValidator` from using `WebClient` to `HttpClient`
* Adds Mock Http calls to `SlackTokenValidatorTests` to properly test all code paths. 