### PR TITLE
Create HttpMockTestCase

### DIFF
--- a/Src/Plugins/Tests.Security/Helpers/HttpMockHelper.cs
+++ b/Src/Plugins/Tests.Security/Helpers/HttpMockHelper.cs
@@ -8,6 +8,8 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk;
+
 using Moq;
 using Moq.Protected;
 
@@ -62,5 +64,19 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Helpers
                     Content = fakeResponse.Item3
                 });
         }
+    }
+
+    public struct HttpMockTestCase
+    {
+        public string Title { get; set; }
+
+        // Inputs
+        public List<HttpContent> HttpContents { get; set; }
+        public List<HttpStatusCode> HttpStatusCodes { get; set; }
+        public List<HttpRequestMessage> HttpRequestMessages { get; set; }
+
+        // Expected Outputs
+        public string ExpectedMessage { get; set; }
+        public ValidationState ExpectedValidationState { get; set; }
     }
 }


### PR DESCRIPTION
Creates a struct to be re-used across the codebase for mocking http tests.