### PR TITLE
Improve Slack mock Tests

### DIFF
--- a/Src/Plugins/Security/SEC101_012.SlackWebhookValidator.cs
+++ b/Src/Plugins/Security/SEC101_012.SlackWebhookValidator.cs
@@ -50,7 +50,13 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             try
             {
                 using var request = new HttpRequestMessage(HttpMethod.Post, uri);
-                request.Content = new StringContent(ScanIdentityGuid, Encoding.UTF8, "application/json");
+                if (options.TryGetValue("TestGuid", out string testingGuid))
+                {
+                    request.Content = new StringContent(testingGuid, Encoding.UTF8, "application/json");
+                } else
+                {
+                    request.Content = new StringContent(ScanIdentityGuid, Encoding.UTF8, "application/json");
+                }
 
                 using HttpResponseMessage response = client
                     .SendAsync(request, HttpCompletionOption.ResponseHeadersRead)

--- a/Src/Plugins/Security/SEC101_012.SlackWebhookValidator.cs
+++ b/Src/Plugins/Security/SEC101_012.SlackWebhookValidator.cs
@@ -53,7 +53,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                 if (options.TryGetValue("TestGuid", out string testingGuid))
                 {
                     request.Content = new StringContent(testingGuid, Encoding.UTF8, "application/json");
-                } else
+                }
+                else
                 {
                     request.Content = new StringContent(ScanIdentityGuid, Encoding.UTF8, "application/json");
                 }

--- a/Src/Plugins/Tests.Security/Validators/SEC101_005.SlackTokenValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/Validators/SEC101_005.SlackTokenValidatorTests.cs
@@ -45,13 +45,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
             const string token = "xoxb-1234";
             string fingerprintText = $"[secret={token}]";
             var dict = new Dictionary<string, string>
-                {
+            {
                     { "token", token },
-                };
+            };
 
             var requestWithToken = new HttpRequestMessage(HttpMethod.Post, uri);
             requestWithToken.Content = new FormUrlEncodedContent(dict);
-
 
             var testCases = new HttpMockTestCase[]
             {
@@ -62,14 +61,14 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     HttpRequestMessages = new List<HttpRequestMessage>() { requestWithToken },
                     // In all cases JSON is formatted in the order receieved from slack.
                     HttpContents = new List<HttpContent>() {
-                                      new StringContent("{\"ok\": true," +
-                                                        "\"url\": \"testteam.slack.com\"," +
-                                                        "\"team\":\"test team\"," +
-                                                        "\"user\": \"testbot\"," +
-                                                        "\"team_id\": \"1234ABCD\"," +
-                                                        "\"user_id\": \"5678EFGH\"," +
-                                                        "\"bot_id\": \"0987ZYXV\"," +
-                                                        "\"is_enterprise_install\": false}",
+                                       new StringContent(@"{""ok"": true,
+                                                        ""url"": ""testteam.slack.com"",
+                                                        ""team"":""test team"",
+                                                        ""user"": ""testbot"",
+                                                        ""team_id"": ""1234ABCD"",
+                                                        ""user_id"": ""5678EFGH"",
+                                                        ""bot_id"": ""0987ZYXV"",
+                                                        ""is_enterprise_install"": false}",
                                                         Encoding.UTF8,
                                                         "application/json").As<HttpContent>(),
                                                         },

--- a/Src/Plugins/Tests.Security/Validators/SEC101_005.SlackTokenValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/Validators/SEC101_005.SlackTokenValidatorTests.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                                       new StringContent("{\"ok\": true," +
                                                         "\"error\": \"account_inactive\"}",
                                                         Encoding.UTF8,
-                                                        "application/json").As<HttpContent>(),  
+                                                        "application/json").As<HttpContent>(),
                                                         },
                     ExpectedValidationState = ValidationState.Expired,
                     ExpectedMessage = string.Empty
@@ -142,8 +142,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     ExpectedMessage = "An unexpected HTTP response code was received: 'InternalServerError'.",
                 },
             };
-
-            
 
             var sb = new StringBuilder();
             var mockHandler = new HttpMockHelper();

--- a/Src/Plugins/Tests.Security/Validators/SEC101_005.SlackTokenValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/Validators/SEC101_005.SlackTokenValidatorTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
             string fingerprintText = $"[secret={token}]";
             var dict = new Dictionary<string, string>
             {
-                    { "token", token },
+                { "token", token },
             };
 
             var requestWithToken = new HttpRequestMessage(HttpMethod.Post, uri);

--- a/Src/Plugins/Tests.Security/Validators/SEC101_012.SlackWebhookValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/Validators/SEC101_012.SlackWebhookValidatorTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
             string uri = $"https://hooks.slack.com/services/{id}/{secret}";
             string fingerprintText = $"[id={id}][secret={secret}]";
             string TestGuid = Guid.NewGuid().ToString();
-            
+
             var webhookRequest = new HttpRequestMessage(HttpMethod.Post, uri);
             webhookRequest.Content = new StringContent(TestGuid, Encoding.UTF8, "application/json");
 
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
 
             var sb = new StringBuilder();
             var mockHandler = new HttpMockHelper();
-           
+
             foreach (HttpMockTestCase testCase in testCases)
             {
                 for (int i = 0; i < testCase.HttpStatusCodes.Count; i++)

--- a/Src/Plugins/Tests.Security/Validators/SEC101_012.SlackWebhookValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/Validators/SEC101_012.SlackWebhookValidatorTests.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+
+using FluentAssertions;
+
+using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Helpers;
+using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk;
+
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validators
+{
+    public class SlackWebhookValidatorTests
+    {
+        [Fact]
+        public void SlackWebhookValidator_Test()
+        {
+            string fingerprintText = "";
+            if (string.IsNullOrEmpty(fingerprintText))
+            {
+                return;
+            }
+
+            string message = null;
+            ResultLevelKind resultLevelKind = default;
+            var fingerprint = new Fingerprint(fingerprintText);
+            var keyValuePairs = new Dictionary<string, string>();
+
+            var slackWebhookValidator = new SlackWebhookValidator();
+            slackWebhookValidator.IsValidDynamic(ref fingerprint,
+                                               ref message,
+                                               keyValuePairs,
+                                               ref resultLevelKind);
+        }
+
+        [Fact]
+        public void SlackWebhookValidatorMockHttp_Test()
+        {
+
+            const string id = "6789";
+            const string secret = "xoxb-1234";
+            string uri = $"https://hooks.slack.com/services/{id}/{secret}";
+            string fingerprintText = $"[id={id}][secret={secret}]";
+            string TestGuid = Guid.NewGuid().ToString();
+            
+            var webhookRequest = new HttpRequestMessage(HttpMethod.Post, uri);
+            webhookRequest.Content = new StringContent(TestGuid, Encoding.UTF8, "application/json");
+
+            var slackWebhookValidator = new SlackWebhookValidator();
+            string tmpMessage = string.Empty;
+
+            var testCases = new HttpMockTestCase[]
+            {
+                new HttpMockTestCase
+                {
+                    Title = "Testing Valid Webhook",
+                    // We authenticated and a bogus payload was read
+                    HttpStatusCodes = new List<HttpStatusCode>() { HttpStatusCode.BadRequest },
+                    HttpRequestMessages = new List<HttpRequestMessage>() { webhookRequest },
+                    HttpContents = new List<HttpContent>() { null },
+                    ExpectedValidationState = ValidationState.Authorized,
+                    ExpectedMessage = string.Empty
+                },
+                new HttpMockTestCase
+                {
+                    Title = "Testing Invalid App id",
+                    HttpStatusCodes = new List<HttpStatusCode>() { HttpStatusCode.NotFound },
+                    HttpRequestMessages = new List<HttpRequestMessage>() { webhookRequest },
+                    HttpContents = new List<HttpContent>() { null },
+                    ExpectedValidationState = ValidationState.UnknownHost,
+                    ExpectedMessage = "The specified Slack app could not be found."
+                },
+                new HttpMockTestCase
+                {
+                    Title = "Testing Invalid Webhook",
+                    HttpStatusCodes = new List<HttpStatusCode>() { HttpStatusCode.Forbidden },
+                    HttpRequestMessages = new List<HttpRequestMessage>() { webhookRequest },
+                    HttpContents = new List<HttpContent>() { null },
+                    ExpectedValidationState = ValidationState.Unauthorized,
+                    ExpectedMessage = string.Empty
+                },
+                new HttpMockTestCase
+                {
+                    Title = "Testing Unexpected Response Code",
+                    HttpStatusCodes = new List<HttpStatusCode>() { HttpStatusCode.InternalServerError },
+                    HttpRequestMessages = new List<HttpRequestMessage>() { webhookRequest },
+                    HttpContents = new List<HttpContent>() { null },
+                    ExpectedValidationState = ValidatorBase.ReturnUnexpectedResponseCode(ref tmpMessage, HttpStatusCode.InternalServerError, account: id),
+                    ExpectedMessage = tmpMessage
+                },
+            };
+
+            var sb = new StringBuilder();
+            var mockHandler = new HttpMockHelper();
+           
+            foreach (HttpMockTestCase testCase in testCases)
+            {
+                for (int i = 0; i < testCase.HttpStatusCodes.Count; i++)
+                {
+                    mockHandler.Mock(testCase.HttpRequestMessages[i], testCase.HttpStatusCodes[i], testCase.HttpContents[i]);
+                }
+
+                string message = string.Empty;
+                ResultLevelKind resultLevelKind = default;
+                var fingerprint = new Fingerprint(fingerprintText);
+                var keyValuePairs = new Dictionary<string, string>();
+                keyValuePairs["TestGuid"] = TestGuid;
+
+                using var httpClient = new HttpClient(mockHandler);
+                slackWebhookValidator.SetHttpClient(httpClient);
+
+                ValidationState currentState = slackWebhookValidator.IsValidDynamic(ref fingerprint,
+                                                                                  ref message,
+                                                                                  keyValuePairs,
+                                                                                  ref resultLevelKind);
+                if (currentState != testCase.ExpectedValidationState)
+                {
+                    sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
+                }
+
+                if (!message.Equals(testCase.ExpectedMessage))
+                {
+                    sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
+                }
+                mockHandler.Clear();
+            }
+
+            sb.Length.Should().Be(0, sb.ToString());
+        }
+    }
+}

--- a/Src/Plugins/Tests.Security/Validators/SEC101_012.SlackWebhookValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/Validators/SEC101_012.SlackWebhookValidatorTests.cs
@@ -19,27 +19,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
     public class SlackWebhookValidatorTests
     {
         [Fact]
-        public void SlackWebhookValidator_Test()
-        {
-            string fingerprintText = "";
-            if (string.IsNullOrEmpty(fingerprintText))
-            {
-                return;
-            }
-
-            string message = null;
-            ResultLevelKind resultLevelKind = default;
-            var fingerprint = new Fingerprint(fingerprintText);
-            var keyValuePairs = new Dictionary<string, string>();
-
-            var slackWebhookValidator = new SlackWebhookValidator();
-            slackWebhookValidator.IsValidDynamic(ref fingerprint,
-                                               ref message,
-                                               keyValuePairs,
-                                               ref resultLevelKind);
-        }
-
-        [Fact]
         public void SlackWebhookValidatorMockHttp_Test()
         {
 
@@ -116,9 +95,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                 slackWebhookValidator.SetHttpClient(httpClient);
 
                 ValidationState currentState = slackWebhookValidator.IsValidDynamic(ref fingerprint,
-                                                                                  ref message,
-                                                                                  keyValuePairs,
-                                                                                  ref resultLevelKind);
+                                                                                    ref message,
+                                                                                    keyValuePairs,
+                                                                                    ref resultLevelKind);
                 if (currentState != testCase.ExpectedValidationState)
                 {
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");


### PR DESCRIPTION
## Changes

* Update Slack Token validator to use global `MockHttpTestCase` struct.
* Add mock validator for Slack Webhooks

For significant contributions please make sure you have completed the following items:

* [ ] `ReleaseHistory.md` updated for non-trivial changes
* [ ] Added unit tests
