### PR TITLE
Expanding HttpMockHelper to be able to mock HttpResponseMessage

### DIFF
--- a/Src/Plugins/Tests.Security/Helpers/HttpMockHelper.cs
+++ b/Src/Plugins/Tests.Security/Helpers/HttpMockHelper.cs
@@ -102,10 +102,10 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Helpers
         public string Title { get; set; }
 
         // Inputs
-        public List<HttpContent> HttpContents { get; set; }
-        public List<HttpStatusCode> HttpStatusCodes { get; set; }
-        public List<HttpRequestMessage> HttpRequestMessages { get; set; }
-        public List<HttpResponseMessage> HttpResponseMessages { get; set; }
+        public IList<HttpContent> HttpContents { get; set; }
+        public IList<HttpStatusCode> HttpStatusCodes { get; set; }
+        public IList<HttpRequestMessage> HttpRequestMessages { get; set; }
+        public IList<HttpResponseMessage> HttpResponseMessages { get; set; }
 
         // Expected Outputs
         public string ExpectedMessage { get; set; }

--- a/Src/Plugins/Tests.Security/Helpers/HttpMockHelper.cs
+++ b/Src/Plugins/Tests.Security/Helpers/HttpMockHelper.cs
@@ -18,13 +18,13 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Helpers
 {
     public class HttpMockHelper : DelegatingHandler
     {
-        public static HttpResponseMessage DefaultOkResponseMessage =
+        public static readonly HttpResponseMessage OKResponse =
             new HttpResponseMessage(HttpStatusCode.OK);
-        public static HttpResponseMessage DefaultNotFoundResponseMessage =
+        public static readonly HttpResponseMessage NotFoundResponse =
             new HttpResponseMessage(HttpStatusCode.NotFound);
-        public static HttpResponseMessage DefaultUnauthorizedResponseMessage =
+        public static readonly HttpResponseMessage UnauthorizedResponse =
             new HttpResponseMessage(HttpStatusCode.Unauthorized);
-        public static HttpResponseMessage DefaultNonAuthoritativeInformationResponseMessage =
+        public static readonly HttpResponseMessage NonAuthoritativeInformationResponse =
             new HttpResponseMessage(HttpStatusCode.NonAuthoritativeInformation);
 
         private readonly List<Tuple<HttpRequestMessage, HttpResponseMessage>> _fakeResponses =

--- a/Src/Plugins/Tests.Security/Helpers/HttpMockHelper.cs
+++ b/Src/Plugins/Tests.Security/Helpers/HttpMockHelper.cs
@@ -18,6 +18,15 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Helpers
 {
     public class HttpMockHelper : DelegatingHandler
     {
+        public static HttpResponseMessage DefaultOkResponseMessage =
+            new HttpResponseMessage(HttpStatusCode.OK);
+        public static HttpResponseMessage DefaultNotFoundResponseMessage =
+            new HttpResponseMessage(HttpStatusCode.NotFound);
+        public static HttpResponseMessage DefaultUnauthorizedResponseMessage =
+            new HttpResponseMessage(HttpStatusCode.Unauthorized);
+        public static HttpResponseMessage DefaultNonAuthoritativeInformationResponseMessage =
+            new HttpResponseMessage(HttpStatusCode.NonAuthoritativeInformation);
+
         private readonly List<Tuple<HttpRequestMessage, HttpResponseMessage>> _fakeResponses =
             new List<Tuple<HttpRequestMessage, HttpResponseMessage>>();
 

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_044.NpmCredentials.ps1
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_044.NpmCredentials.ps1
@@ -44,3 +44,14 @@ registry=https://registry.npmjs.org
 always-auth=true
 username=user2
 _password=invalid_password1
+
+************************************************************
+************************************************************
+************************************************************
+************************************************************
+
+# invalid password example (password should have a number)
+registry=https://registry.npmjs.org
+always-auth=true
+_password=passwordwithoutnumbers
+username=user3

--- a/Src/Plugins/Tests.Security/Validators/SEC101_044.NpmCredentialsValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/Validators/SEC101_044.NpmCredentialsValidatorTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                 {
                     Title = "Endpoint does not require credential (OK status code)",
                     HttpRequestMessages = new List<HttpRequestMessage>{ requestWithNoCredentials },
-                    HttpResponseMessages = new List<HttpResponseMessage>{ HttpMockHelper.DefaultOkResponseMessage },
+                    HttpResponseMessages = new List<HttpResponseMessage>{ HttpMockHelper.OKResponse },
                     ExpectedMessage = string.Empty,
                     ExpectedValidationState = ValidationState.NoMatch,
                 },
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                 {
                     Title = "Endpoint does not require credential (NotFound status code)",
                     HttpRequestMessages = new List<HttpRequestMessage>{ requestWithNoCredentials },
-                    HttpResponseMessages = new List<HttpResponseMessage>{ HttpMockHelper.DefaultNotFoundResponseMessage },
+                    HttpResponseMessages = new List<HttpResponseMessage>{ HttpMockHelper.NotFoundResponse },
                     ExpectedMessage = string.Empty,
                     ExpectedValidationState = ValidationState.NoMatch,
                 },
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                 {
                     Title = "Endpoint does not require credential (NonAuthoritativeInformation status code)",
                     HttpRequestMessages = new List<HttpRequestMessage>{ requestWithNoCredentials },
-                    HttpResponseMessages = new List<HttpResponseMessage>{ HttpMockHelper.DefaultNonAuthoritativeInformationResponseMessage },
+                    HttpResponseMessages = new List<HttpResponseMessage>{ HttpMockHelper.NonAuthoritativeInformationResponse },
                     ExpectedMessage = string.Empty,
                     ExpectedValidationState = ValidationState.NoMatch,
                 },
@@ -83,8 +83,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     HttpRequestMessages = new List<HttpRequestMessage>{ requestWithNoCredentials, requestWithCredentials },
                     HttpResponseMessages = new List<HttpResponseMessage>
                     {
-                        HttpMockHelper.DefaultUnauthorizedResponseMessage,
-                        HttpMockHelper.DefaultOkResponseMessage
+                        HttpMockHelper.UnauthorizedResponse,
+                        HttpMockHelper.OKResponse
                     },
                     ExpectedValidationState = ValidatorBase.ReturnAuthorizedAccess(ref authorizedMessage, asset: host, account: id),
                     ExpectedMessage = authorizedMessage,
@@ -95,8 +95,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     HttpRequestMessages = new List<HttpRequestMessage>{ requestWithNoCredentials, requestWithCredentials },
                     HttpResponseMessages = new List<HttpResponseMessage>
                     {
-                        HttpMockHelper.DefaultUnauthorizedResponseMessage,
-                        HttpMockHelper.DefaultUnauthorizedResponseMessage,
+                        HttpMockHelper.UnauthorizedResponse,
+                        HttpMockHelper.UnauthorizedResponse,
                     },
                     ExpectedValidationState = ValidatorBase.ReturnUnauthorizedAccess(ref unauthorizedMessage, asset: host, account: id),
                     ExpectedMessage = unauthorizedMessage,
@@ -107,8 +107,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     HttpRequestMessages = new List<HttpRequestMessage>{ requestWithNoCredentials, requestWithCredentials },
                     HttpResponseMessages = new List<HttpResponseMessage>
                     {
-                        HttpMockHelper.DefaultUnauthorizedResponseMessage,
-                        HttpMockHelper.DefaultNotFoundResponseMessage
+                        HttpMockHelper.UnauthorizedResponse,
+                        HttpMockHelper.NotFoundResponse
                     },
                     ExpectedValidationState = ValidatorBase.ReturnUnexpectedResponseCode(ref unexpectedMessage,
                                                                                          HttpStatusCode.NotFound,

--- a/Src/Plugins/Tests.Security/Validators/SEC101_044.NpmCredentialsValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/Validators/SEC101_044.NpmCredentialsValidatorTests.cs
@@ -39,10 +39,21 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
             var notFoundResponse = new HttpResponseMessage(HttpStatusCode.NotFound);
             var unauthorizedResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized);
 
-            string authorizedMessage = string.Empty, unauthorizedMessage = string.Empty, unexpectedMessage = string.Empty;
+            string authorizedMessage = null, unauthorizedMessage = null, unexpectedMessage = null, exceptionMessage = null;
 
             var testCases = new HttpMockTestCase[]
             {
+                new HttpMockTestCase
+                {
+                    Title = "HttpClient throwing NullReferenceException",
+                    HttpRequestMessages = new List<HttpRequestMessage>{ null },
+                    HttpResponseMessages = new List<HttpResponseMessage>{ null },
+                    ExpectedValidationState = ValidatorBase.ReturnUnhandledException(ref exceptionMessage,
+                                                                                     new NullReferenceException(),
+                                                                                     asset: host,
+                                                                                     account: id),
+                    ExpectedMessage = exceptionMessage,
+                },
                 new HttpMockTestCase
                 {
                     Title = "Endpoint does not require credential",

--- a/Src/Plugins/Tests.Security/Validators/SEC101_044.NpmCredentialsValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/Validators/SEC101_044.NpmCredentialsValidatorTests.cs
@@ -17,6 +17,9 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validators
 {
+    /// <summary>
+    /// Testing SEC101/044.NpmCredentialsValidator
+    /// </summary>
     public class NpmCredentialsValidatorTests
     {
         [Fact]
@@ -38,6 +41,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
             var authorizedResponse = new HttpResponseMessage(HttpStatusCode.OK);
             var notFoundResponse = new HttpResponseMessage(HttpStatusCode.NotFound);
             var unauthorizedResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized);
+            var nonAuthoritativeInformationResponse = new HttpResponseMessage(HttpStatusCode.NonAuthoritativeInformation);
 
             string authorizedMessage = null, unauthorizedMessage = null, unexpectedMessage = null, exceptionMessage = null;
 
@@ -56,9 +60,25 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                 },
                 new HttpMockTestCase
                 {
-                    Title = "Endpoint does not require credential",
+                    Title = "Endpoint does not require credential (OK status code)",
                     HttpRequestMessages = new List<HttpRequestMessage>{ requestWithNoCredentials },
                     HttpResponseMessages = new List<HttpResponseMessage>{ authorizedResponse },
+                    ExpectedMessage = string.Empty,
+                    ExpectedValidationState = ValidationState.NoMatch,
+                },
+                new HttpMockTestCase
+                {
+                    Title = "Endpoint does not require credential (NotFound status code)",
+                    HttpRequestMessages = new List<HttpRequestMessage>{ requestWithNoCredentials },
+                    HttpResponseMessages = new List<HttpResponseMessage>{ notFoundResponse },
+                    ExpectedMessage = string.Empty,
+                    ExpectedValidationState = ValidationState.NoMatch,
+                },
+                new HttpMockTestCase
+                {
+                    Title = "Endpoint does not require credential (NonAuthoritativeInformation status code)",
+                    HttpRequestMessages = new List<HttpRequestMessage>{ requestWithNoCredentials },
+                    HttpResponseMessages = new List<HttpResponseMessage>{ nonAuthoritativeInformationResponse },
                     ExpectedMessage = string.Empty,
                     ExpectedValidationState = ValidationState.NoMatch,
                 },

--- a/Src/Plugins/Tests.Security/Validators/SEC101_044.NpmCredentialsValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/Validators/SEC101_044.NpmCredentialsValidatorTests.cs
@@ -38,11 +38,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
 
             string fingerprintText = $"[host={host}][id={id}][secret={secret}]";
 
-            var authorizedResponse = new HttpResponseMessage(HttpStatusCode.OK);
-            var notFoundResponse = new HttpResponseMessage(HttpStatusCode.NotFound);
-            var unauthorizedResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized);
-            var nonAuthoritativeInformationResponse = new HttpResponseMessage(HttpStatusCode.NonAuthoritativeInformation);
-
             string authorizedMessage = null, unauthorizedMessage = null, unexpectedMessage = null, exceptionMessage = null;
 
             var testCases = new HttpMockTestCase[]
@@ -62,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                 {
                     Title = "Endpoint does not require credential (OK status code)",
                     HttpRequestMessages = new List<HttpRequestMessage>{ requestWithNoCredentials },
-                    HttpResponseMessages = new List<HttpResponseMessage>{ authorizedResponse },
+                    HttpResponseMessages = new List<HttpResponseMessage>{ HttpMockHelper.DefaultOkResponseMessage },
                     ExpectedMessage = string.Empty,
                     ExpectedValidationState = ValidationState.NoMatch,
                 },
@@ -70,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                 {
                     Title = "Endpoint does not require credential (NotFound status code)",
                     HttpRequestMessages = new List<HttpRequestMessage>{ requestWithNoCredentials },
-                    HttpResponseMessages = new List<HttpResponseMessage>{ notFoundResponse },
+                    HttpResponseMessages = new List<HttpResponseMessage>{ HttpMockHelper.DefaultNotFoundResponseMessage },
                     ExpectedMessage = string.Empty,
                     ExpectedValidationState = ValidationState.NoMatch,
                 },
@@ -78,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                 {
                     Title = "Endpoint does not require credential (NonAuthoritativeInformation status code)",
                     HttpRequestMessages = new List<HttpRequestMessage>{ requestWithNoCredentials },
-                    HttpResponseMessages = new List<HttpResponseMessage>{ nonAuthoritativeInformationResponse },
+                    HttpResponseMessages = new List<HttpResponseMessage>{ HttpMockHelper.DefaultNonAuthoritativeInformationResponseMessage },
                     ExpectedMessage = string.Empty,
                     ExpectedValidationState = ValidationState.NoMatch,
                 },
@@ -88,8 +83,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     HttpRequestMessages = new List<HttpRequestMessage>{ requestWithNoCredentials, requestWithCredentials },
                     HttpResponseMessages = new List<HttpResponseMessage>
                     {
-                        unauthorizedResponse,
-                        authorizedResponse
+                        HttpMockHelper.DefaultUnauthorizedResponseMessage,
+                        HttpMockHelper.DefaultOkResponseMessage
                     },
                     ExpectedValidationState = ValidatorBase.ReturnAuthorizedAccess(ref authorizedMessage, asset: host, account: id),
                     ExpectedMessage = authorizedMessage,
@@ -100,8 +95,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     HttpRequestMessages = new List<HttpRequestMessage>{ requestWithNoCredentials, requestWithCredentials },
                     HttpResponseMessages = new List<HttpResponseMessage>
                     {
-                        unauthorizedResponse,
-                        unauthorizedResponse
+                        HttpMockHelper.DefaultUnauthorizedResponseMessage,
+                        HttpMockHelper.DefaultUnauthorizedResponseMessage,
                     },
                     ExpectedValidationState = ValidatorBase.ReturnUnauthorizedAccess(ref unauthorizedMessage, asset: host, account: id),
                     ExpectedMessage = unauthorizedMessage,
@@ -112,8 +107,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     HttpRequestMessages = new List<HttpRequestMessage>{ requestWithNoCredentials, requestWithCredentials },
                     HttpResponseMessages = new List<HttpResponseMessage>
                     {
-                        unauthorizedResponse,
-                        notFoundResponse
+                        HttpMockHelper.DefaultUnauthorizedResponseMessage,
+                        HttpMockHelper.DefaultNotFoundResponseMessage
                     },
                     ExpectedValidationState = ValidatorBase.ReturnUnexpectedResponseCode(ref unexpectedMessage,
                                                                                          HttpStatusCode.NotFound,

--- a/Src/ReleaseHistory.md
+++ b/Src/ReleaseHistory.md
@@ -38,6 +38,8 @@
   removing invalid characters (`,`, `=`, `|`, `&`, `[`, `]`, `>`) from `Id` and
   `Resource`.
   [#555](https://github.com/microsoft/sarif-pattern-matcher/pull/555)
+- SDK: Expanding `HttpMockHelper` to be able to mock `HttpResponseMessage`.
+  [#557](https://github.com/microsoft/sarif-pattern-matcher/pull/557)
 
 ## *v1.5.0-alpha-0117-g136d47026e*
 

--- a/Src/ReleaseHistory.md
+++ b/Src/ReleaseHistory.md
@@ -38,8 +38,6 @@
   removing invalid characters (`,`, `=`, `|`, `&`, `[`, `]`, `>`) from `Id` and
   `Resource`.
   [#555](https://github.com/microsoft/sarif-pattern-matcher/pull/555)
-- SDK: Expanding `HttpMockHelper` to be able to mock `HttpResponseMessage`.
-  [#557](https://github.com/microsoft/sarif-pattern-matcher/pull/557)
 
 ## *v1.5.0-alpha-0117-g136d47026e*
 


### PR DESCRIPTION
## Changes

This change will enable us to mock `HttpResponseMessage` and it can also replace two fields in the future: `HttpContents` and `HttpStatusCodes`.

Current code coverage:
![image](https://user-images.githubusercontent.com/16199012/133846348-db2ed43a-283b-45d5-bab4-27aa12ad621c.png)

The new version achieves 100% of code coverage:
![image](https://user-images.githubusercontent.com/16199012/133856404-cece26eb-0dd8-443b-b6b3-21947fe698f3.png)


For significant contributions please make sure you have completed the following items:

* [ ] `ReleaseHistory.md` updated for non-trivial changes
* [ ] Added unit tests
