### PR TITLE
Improving FacebookAppCredentials rule

### DIFF
--- a/Src/Plugins/Security/SEC101.SecurePlaintextSecrets.json
+++ b/Src/Plugins/Security/SEC101.SecurePlaintextSecrets.json
@@ -32,7 +32,8 @@
           "Id": "SEC101/004",
           "Name": "DoNotExposePlaintextSecrets/FacebookAppCredentials",
           "IntrafileRegexes": [ "$SEC101/004.FacebookAppCredentialsId", "$SEC101/004.FacebookAppCredentialsSecret" ],
-          "MessageArguments": { "secretKind": "Facebook App id and secret" }
+          "MessageArguments": { "secretKind": "Facebook App id and secret" },
+          "HelpUri": "https://developers.facebook.com/docs/facebook-login/security/#appsecret"
         },
         {
           "Id": "SEC101/005",

--- a/Src/Plugins/Security/SEC101_004.FacebookAppCredentialsValidator.cs
+++ b/Src/Plugins/Security/SEC101_004.FacebookAppCredentialsValidator.cs
@@ -14,9 +14,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
     public class FacebookAppCredentialsValidator : DynamicValidatorBase
     {
-        internal const string OAuthUri = "https://graph.facebook.com/oauth/access_token?client_id={0}&client_secret={1}&grant_type=client_credentials";
-        internal const string CreatorUri = "https://graph.facebook.com/{0}?access_token={1}&fields=creator_uid";
         internal const string AccountInformationUri = "https://graph.facebook.com/{0}?access_token={1}";
+        internal const string CreatorUri = "https://graph.facebook.com/{0}?access_token={1}&fields=creator_uid";
+        internal const string OAuthUri = "https://graph.facebook.com/oauth/access_token?client_id={0}&client_secret={1}&grant_type=client_credentials";
 
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)
         {

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_004.FacebookAppCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_004.FacebookAppCredentials.sarif
@@ -26,7 +26,7 @@
                   "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
-              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
+              "helpUri": "https://developers.facebook.com/docs/facebook-login/security/#appsecret"
             }
           ]
         }
@@ -89,51 +89,6 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "d9117d…",
-              "an apparent ",
-              "",
-              "Facebook App id and secret",
-              "",
-              " (no validation occurred as it was not enabled. Pass '--dynamic-validation' on the command-line to validate this match)"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_004.FacebookAppCredentials.ps1",
-                  "uriBaseId": "SRC_ROOT"
-                },
-                "region": {
-                  "startLine": 16,
-                  "startColumn": 16,
-                  "endLine": 16,
-                  "endColumn": 48,
-                  "charOffset": 496,
-                  "charLength": 32,
-                  "snippet": {
-                    "text": "d9117d87046fc24205e4240e6bc9963a"
-                  }
-                }
-              }
-            }
-          ],
-          "fingerprints": {
-            "AssetFingerprint/v1": "[id=111111111111111][platform=Facebook]",
-            "ValidationFingerprint/v1": "[id=111111111111111][secret=d9117d87046fc24205e4240e6bc9963a]",
-            "ValidationFingerprintHash/v1": "6133f949044be752a1f3bfa8d317f3ceac2a6846f6335a05537fed2538cb8c21",
-            "AssetFingerprint/v2": "{\"id\":\"111111111111111\",\"platform\":\"Facebook\"}",
-            "ValidationFingerprint/v2": "{\"id\":\"111111111111111\",\"secret\":\"d9117d87046fc24205e4240e6bc9963a\"}"
-          },
-          "rank": 54.9
-        },
-        {
-          "ruleId": "SEC101/004",
-          "ruleIndex": 0,
-          "level": "note",
-          "message": {
-            "id": "Default",
-            "arguments": [
               "c9117d…",
               "an apparent ",
               "",
@@ -171,51 +126,6 @@
             "ValidationFingerprint/v2": "{\"id\":\"222222222222222\",\"secret\":\"c9117d87046fc24205e4240e6bc9963a\"}"
           },
           "rank": 54.56
-        },
-        {
-          "ruleId": "SEC101/004",
-          "ruleIndex": 0,
-          "level": "note",
-          "message": {
-            "id": "Default",
-            "arguments": [
-              "d9117d…",
-              "an apparent ",
-              "",
-              "Facebook App id and secret",
-              "",
-              " (no validation occurred as it was not enabled. Pass '--dynamic-validation' on the command-line to validate this match)"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_004.FacebookAppCredentials.ps1",
-                  "uriBaseId": "SRC_ROOT"
-                },
-                "region": {
-                  "startLine": 16,
-                  "startColumn": 16,
-                  "endLine": 16,
-                  "endColumn": 48,
-                  "charOffset": 496,
-                  "charLength": 32,
-                  "snippet": {
-                    "text": "d9117d87046fc24205e4240e6bc9963a"
-                  }
-                }
-              }
-            }
-          ],
-          "fingerprints": {
-            "AssetFingerprint/v1": "[id=222222222222222][platform=Facebook]",
-            "ValidationFingerprint/v1": "[id=222222222222222][secret=d9117d87046fc24205e4240e6bc9963a]",
-            "ValidationFingerprintHash/v1": "7eefc0366e9305553607b834a83c478c5402771ac4b66f6aa640bc5cd60678e0",
-            "AssetFingerprint/v2": "{\"id\":\"222222222222222\",\"platform\":\"Facebook\"}",
-            "ValidationFingerprint/v2": "{\"id\":\"222222222222222\",\"secret\":\"d9117d87046fc24205e4240e6bc9963a\"}"
-          },
-          "rank": 54.9
         },
         {
           "ruleId": "SEC101/004",
@@ -269,51 +179,6 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "d9117d…",
-              "an apparent ",
-              "",
-              "Facebook App id and secret",
-              "",
-              " (no validation occurred as it was not enabled. Pass '--dynamic-validation' on the command-line to validate this match)"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_004.FacebookAppCredentials.ps1",
-                  "uriBaseId": "SRC_ROOT"
-                },
-                "region": {
-                  "startLine": 16,
-                  "startColumn": 16,
-                  "endLine": 16,
-                  "endColumn": 48,
-                  "charOffset": 496,
-                  "charLength": 32,
-                  "snippet": {
-                    "text": "d9117d87046fc24205e4240e6bc9963a"
-                  }
-                }
-              }
-            }
-          ],
-          "fingerprints": {
-            "AssetFingerprint/v1": "[id=333333333333333][platform=Facebook]",
-            "ValidationFingerprint/v1": "[id=333333333333333][secret=d9117d87046fc24205e4240e6bc9963a]",
-            "ValidationFingerprintHash/v1": "ab42010cea95835b07ba2ed24ccb247c9a1f76b7575000c198b8b02cb7e948a2",
-            "AssetFingerprint/v2": "{\"id\":\"333333333333333\",\"platform\":\"Facebook\"}",
-            "ValidationFingerprint/v2": "{\"id\":\"333333333333333\",\"secret\":\"d9117d87046fc24205e4240e6bc9963a\"}"
-          },
-          "rank": 54.9
-        },
-        {
-          "ruleId": "SEC101/004",
-          "ruleIndex": 0,
-          "level": "note",
-          "message": {
-            "id": "Default",
-            "arguments": [
               "c9117d…",
               "an apparent ",
               "",
@@ -359,51 +224,6 @@
           "message": {
             "id": "Default",
             "arguments": [
-              "d9117d…",
-              "an apparent ",
-              "",
-              "Facebook App id and secret",
-              "",
-              " (no validation occurred as it was not enabled. Pass '--dynamic-validation' on the command-line to validate this match)"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_004.FacebookAppCredentials.ps1",
-                  "uriBaseId": "SRC_ROOT"
-                },
-                "region": {
-                  "startLine": 16,
-                  "startColumn": 16,
-                  "endLine": 16,
-                  "endColumn": 48,
-                  "charOffset": 496,
-                  "charLength": 32,
-                  "snippet": {
-                    "text": "d9117d87046fc24205e4240e6bc9963a"
-                  }
-                }
-              }
-            }
-          ],
-          "fingerprints": {
-            "AssetFingerprint/v1": "[id=444444444444444][platform=Facebook]",
-            "ValidationFingerprint/v1": "[id=444444444444444][secret=d9117d87046fc24205e4240e6bc9963a]",
-            "ValidationFingerprintHash/v1": "b8f5b238ef000eabd87a6e9d59bc42b49de56df2641f394865789b669e6c8f79",
-            "AssetFingerprint/v2": "{\"id\":\"444444444444444\",\"platform\":\"Facebook\"}",
-            "ValidationFingerprint/v2": "{\"id\":\"444444444444444\",\"secret\":\"d9117d87046fc24205e4240e6bc9963a\"}"
-          },
-          "rank": 54.9
-        },
-        {
-          "ruleId": "SEC101/004",
-          "ruleIndex": 0,
-          "level": "note",
-          "message": {
-            "id": "Default",
-            "arguments": [
               "c9117d…",
               "an apparent ",
               "",
@@ -441,51 +261,6 @@
             "ValidationFingerprint/v2": "{\"id\":\"555555555555555\",\"secret\":\"c9117d87046fc24205e4240e6bc9963a\"}"
           },
           "rank": 54.56
-        },
-        {
-          "ruleId": "SEC101/004",
-          "ruleIndex": 0,
-          "level": "note",
-          "message": {
-            "id": "Default",
-            "arguments": [
-              "d9117d…",
-              "an apparent ",
-              "",
-              "Facebook App id and secret",
-              "",
-              " (no validation occurred as it was not enabled. Pass '--dynamic-validation' on the command-line to validate this match)"
-            ]
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_004.FacebookAppCredentials.ps1",
-                  "uriBaseId": "SRC_ROOT"
-                },
-                "region": {
-                  "startLine": 16,
-                  "startColumn": 16,
-                  "endLine": 16,
-                  "endColumn": 48,
-                  "charOffset": 496,
-                  "charLength": 32,
-                  "snippet": {
-                    "text": "d9117d87046fc24205e4240e6bc9963a"
-                  }
-                }
-              }
-            }
-          ],
-          "fingerprints": {
-            "AssetFingerprint/v1": "[id=555555555555555][platform=Facebook]",
-            "ValidationFingerprint/v1": "[id=555555555555555][secret=d9117d87046fc24205e4240e6bc9963a]",
-            "ValidationFingerprintHash/v1": "021d88efa3a5cf281f7b228a44c43c20a139ab6b2994040cb37b49743a4ca6d7",
-            "AssetFingerprint/v2": "{\"id\":\"555555555555555\",\"platform\":\"Facebook\"}",
-            "ValidationFingerprint/v2": "{\"id\":\"555555555555555\",\"secret\":\"d9117d87046fc24205e4240e6bc9963a\"}"
-          },
-          "rank": 54.9
         }
       ],
       "columnKind": "utf16CodeUnits"

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_004.FacebookAppCredentials.ps1
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_004.FacebookAppCredentials.ps1
@@ -13,4 +13,8 @@ FacebookTestAppSecret=c9117d87046fc24205e4240e6bc9963a
 }
 
 facebookId 555555555555555
-facebookSecret d9117d87046fc24205e4240e6bc9963a
+facebookSecret c9117d87046fc24205e4240e6bc9963a
+
+## Invalid passowrd (does not have any digit)
+facebookId 555555555555555
+facebookSecret deaddeaddeaddeaddeaddeaddeaddead

--- a/Src/Plugins/Tests.Security/Validators/SEC101_004.FacebookAppCredentialsValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/Validators/SEC101_004.FacebookAppCredentialsValidatorTests.cs
@@ -1,0 +1,166 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+
+using FluentAssertions;
+
+using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Helpers;
+using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk;
+
+using Newtonsoft.Json;
+
+using Xunit;
+
+using static Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.FacebookAppCredentialsValidator;
+
+namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validators
+{
+    public class FacebookAppCredentialsValidatorTests
+    {
+        [Fact]
+        public void FacebookAppCredentialsValidator_MockHttp()
+        {
+            const string id = "id";
+            const string name = "name";
+            const string secret = "secret";
+            const string creatorId = "creatorId";
+            const string tokenType = "tokenType";
+            const string accessToken = "accessToken";
+
+            string fingerprintText = $"[id={id}][secret={secret}]";
+
+            string unauthorizedMessage = null, unexpectedStatusCodeMessage = null, authorizedMessage = null;
+
+            var accessTokenObject = new AccessTokenObject
+            {
+                TokenType = tokenType,
+                AccessToken = accessToken
+            };
+
+            var creatorObject = new CreatorObject
+            {
+                Id = id,
+                CreatorUid = creatorId,
+            };
+
+            var accountNameObject = new AccountObject
+            {
+                Id = id,
+                Name = name
+            };
+
+            string oauthUri = string.Format(OAuthUri, id, secret);
+            string creatorUri = string.Format(CreatorUri, id, accessToken);
+            string accountInformationUri = string.Format(AccountInformationUri, creatorId, accessToken);
+
+            var oauthRequest = new HttpRequestMessage(HttpMethod.Get, oauthUri);
+            var creatorRequest = new HttpRequestMessage(HttpMethod.Get, creatorUri);
+            var accountInformationRequest = new HttpRequestMessage(HttpMethod.Get, accountInformationUri);
+
+            var testCases = new HttpMockTestCase[]
+            {
+                new HttpMockTestCase
+                {
+                    Title = "Testing Invalid Secret",
+                    HttpStatusCodes = new List<HttpStatusCode>() { HttpStatusCode.BadRequest },
+                    HttpRequestMessages = new List<HttpRequestMessage>() { oauthRequest },
+                    HttpContents = new List<HttpContent> { null },
+                    ExpectedValidationState = ValidatorBase.ReturnUnauthorizedAccess(ref unauthorizedMessage, asset: id),
+                    ExpectedMessage = unauthorizedMessage
+                },
+                new HttpMockTestCase
+                {
+                    Title = "Testing Unknown StatusCode",
+                    HttpStatusCodes = new List<HttpStatusCode>() { HttpStatusCode.NotFound },
+                    HttpRequestMessages = new List<HttpRequestMessage>() { oauthRequest },
+                    HttpContents = new List<HttpContent> { null },
+                    ExpectedValidationState = ValidatorBase.ReturnUnexpectedResponseCode(ref unexpectedStatusCodeMessage,
+                                                                                         HttpStatusCode.NotFound,
+                                                                                         asset: id),
+                    ExpectedMessage = unexpectedStatusCodeMessage
+                },
+                new HttpMockTestCase
+                {
+                    Title = "Testing Valid Secret but BadRequest StatusCode",
+                    HttpStatusCodes = new List<HttpStatusCode>() { HttpStatusCode.OK, HttpStatusCode.BadRequest },
+                    HttpRequestMessages = new List<HttpRequestMessage>() { oauthRequest, creatorRequest },
+                    HttpContents = new List<HttpContent>
+                    {
+                        new StringContent(JsonConvert.SerializeObject(accessTokenObject)),
+                        null
+                    },
+                    ExpectedValidationState = ValidatorBase.ReturnUnauthorizedAccess(ref unauthorizedMessage, asset: id),
+                    ExpectedMessage = unauthorizedMessage
+                },
+                new HttpMockTestCase
+                {
+                    Title = "Testing Valid Secret but BadRequest StatusCode",
+                    HttpStatusCodes = new List<HttpStatusCode>() { HttpStatusCode.OK, HttpStatusCode.OK, HttpStatusCode.BadRequest },
+                    HttpRequestMessages = new List<HttpRequestMessage>() { oauthRequest, creatorRequest, accountInformationRequest },
+                    HttpContents = new List<HttpContent>
+                    {
+                        new StringContent(JsonConvert.SerializeObject(accessTokenObject)),
+                        new StringContent(JsonConvert.SerializeObject(creatorObject)),
+                        null
+                    },
+                    ExpectedValidationState = ValidatorBase.ReturnUnauthorizedAccess(ref unauthorizedMessage, asset: id),
+                    ExpectedMessage = unauthorizedMessage
+                },
+                new HttpMockTestCase
+                {
+                    Title = "Testing Valid Secret",
+                    HttpStatusCodes = new List<HttpStatusCode>() { HttpStatusCode.OK, HttpStatusCode.OK, HttpStatusCode.OK },
+                    HttpRequestMessages = new List<HttpRequestMessage>() { oauthRequest, creatorRequest, accountInformationRequest },
+                    HttpContents = new List<HttpContent>
+                    {
+                        new StringContent(JsonConvert.SerializeObject(accessTokenObject)),
+                        new StringContent(JsonConvert.SerializeObject(creatorObject)),
+                        new StringContent(JsonConvert.SerializeObject(accountNameObject))
+                    },
+                    ExpectedValidationState = ValidatorBase.ReturnAuthorizedAccess(ref authorizedMessage, asset: $"{id}:{name}"),
+                    ExpectedMessage = authorizedMessage
+                },
+            };
+
+            var sb = new StringBuilder();
+            var mockHandler = new HttpMockHelper();
+            var facebookAppCredentialsValidator = new FacebookAppCredentialsValidator();
+            foreach (HttpMockTestCase testCase in testCases)
+            {
+                for (int i = 0; i < testCase.HttpStatusCodes.Count; i++)
+                {
+                    mockHandler.Mock(testCase.HttpRequestMessages[i], testCase.HttpStatusCodes[i], testCase.HttpContents[i]);
+                }
+
+                string message = string.Empty;
+                ResultLevelKind resultLevelKind = default;
+                var fingerprint = new Fingerprint(fingerprintText);
+                var keyValuePairs = new Dictionary<string, string>();
+
+                using var httpClient = new HttpClient(mockHandler);
+                facebookAppCredentialsValidator.SetHttpClient(httpClient);
+
+                ValidationState currentState = facebookAppCredentialsValidator.IsValidDynamic(ref fingerprint,
+                                                                                              ref message,
+                                                                                              keyValuePairs,
+                                                                                              ref resultLevelKind);
+                if (currentState != testCase.ExpectedValidationState)
+                {
+                    sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
+                }
+
+                if (!message.Equals(testCase.ExpectedMessage))
+                {
+                    sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
+                }
+                mockHandler.Clear();
+            }
+
+            sb.Length.Should().Be(0, sb.ToString());
+        }
+    }
+}

--- a/Src/Plugins/Tests.Security/Validators/SEC101_004.FacebookAppCredentialsValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/Validators/SEC101_004.FacebookAppCredentialsValidatorTests.cs
@@ -19,6 +19,9 @@ using static Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Facebo
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validators
 {
+    /// <summary>
+    /// Testing SEC101/004.FacebookAppCredentialsValidator
+    /// </summary>
     public class FacebookAppCredentialsValidatorTests
     {
         [Fact]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,24 +22,24 @@ steps:
     testRunner: VSTest
     testResultsFiles: '**/*.trx'
 
-- task: PowerShell@2
-  displayName: Run ProcessCodeCoverage.ps1
-  inputs:
-    targetType: filePath
-    filePath: ./scripts/ProcessCodeCoverage.ps1
+#- task: PowerShell@2
+#  displayName: Run ProcessCodeCoverage.ps1
+#  inputs:
+#    targetType: filePath
+#    filePath: ./scripts/ProcessCodeCoverage.ps1
 
-- task: PowerShell@2
-  displayName: 'Merging TestResults'
-  inputs:
-    targetType: 'inline'
-    script: |
-      dotnet tool install -g dotnet-reportgenerator-globaltool      
-      reportgenerator -reports:**/*.coverage.xml -targetdir:TestResults -reporttypes:Cobertura
+#- task: PowerShell@2
+#  displayName: 'Merging TestResults'
+#  inputs:
+#    targetType: 'inline'
+#    script: |
+#      dotnet tool install -g dotnet-reportgenerator-globaltool      
+#      reportgenerator -reports:**/*.coverage.xml -targetdir:TestResults -reporttypes:Cobertura
 
-- task: PublishCodeCoverageResults@1
-  inputs:
-    codeCoverageTool: 'cobertura'
-    summaryFileLocation: 'TestResults/Cobertura.xml'
+#- task: PublishCodeCoverageResults@1
+#  inputs:
+#    codeCoverageTool: 'cobertura'
+#    summaryFileLocation: 'TestResults/Cobertura.xml'
 
 # Enable if you need to debug the tests
 #- task: PublishPipelineArtifact@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,25 @@ steps:
     testRunner: VSTest
     testResultsFiles: '**/*.trx'
 
+- task: PowerShell@2
+  displayName: Run ProcessCodeCoverage.ps1
+  inputs:
+    targetType: filePath
+    filePath: ./scripts/ProcessCodeCoverage.ps1
+
+- task: PowerShell@2
+  displayName: 'Merging TestResults'
+  inputs:
+    targetType: 'inline'
+    script: |
+      dotnet tool install -g dotnet-reportgenerator-globaltool      
+      reportgenerator -reports:**/*.coverage.xml -targetdir:TestResults -reporttypes:Cobertura
+
+- task: PublishCodeCoverageResults@1
+  inputs:
+    codeCoverageTool: 'cobertura'
+    summaryFileLocation: 'TestResults/Cobertura.xml'
+
 # Enable if you need to debug the tests
 #- task: PublishPipelineArtifact@1
 #  condition: always()


### PR DESCRIPTION
## Changes
- Required fields should not require `TryGetValue` call (this will throw the `KeyNotFound` exception if the key does not exist)
- Added `HelpUri` pointing to Facebook page with guidance

For significant contributions please make sure you have completed the following items:

* [ ] `ReleaseHistory.md` updated for non-trivial changes
* [ ] Added unit tests
