### PR TITLE
Enabling native code coverage

### DIFF
--- a/Scripts/BuildAndTest.ps1
+++ b/Scripts/BuildAndTest.ps1
@@ -90,7 +90,7 @@ if (-not $NoTest) {
         $CodeCoverageCommand = ""
     }
 
-    dotnet test $RepoRoot\Src\SarifPatternMatcher.sln -c $Configuration --no-build $CodeCoverageCommand --settings $RepoRoot\Src\SarifPatternMatcher.runsettings /p:IncludeTestAssembly=false
+    dotnet test $RepoRoot\Src\SarifPatternMatcher.sln -c $Configuration --logger trx --no-build $CodeCoverageCommand --settings $RepoRoot\Src\SarifPatternMatcher.runsettings /p:IncludeTestAssembly=false
 
     if ($LASTEXITCODE -ne 0) {
         Exit-WithFailureMessage $ScriptName "Test of SarifPatternMatcher failed."

--- a/Src/SarifPatternMatcher.runsettings
+++ b/Src/SarifPatternMatcher.runsettings
@@ -10,8 +10,28 @@
         <Configuration>
           <CodeCoverage>
             <ModulePaths>
-              <Exclude>Test*.dll</Exclude>
+              <Include>
+                <ModulePath>.*\Security.dll$</ModulePath>
+                <ModulePath>.*\RE2.Managed.dll$</ModulePath>
+                <ModulePath>.*\Strings.Interop.dll$</ModulePath>
+                <ModulePath>.*\SalModernization.dll$</ModulePath>
+                <ModulePath>.*\Sarif.PatternMatcher.dll$</ModulePath>
+                <ModulePath>.*\Sarif.PatternMatcher.Cli.dll$</ModulePath>
+                <ModulePath>.*\Sarif.PatternMatcher.Sdk.dll$</ModulePath>
+                <ModulePath>.*\Sarif.PatternMatcher.Function.dll$</ModulePath>
+              </Include>
             </ModulePaths>
+
+             <!-- We recommend you do not change the following values: -->
+
+            <!-- Set this to True to collect coverage information for functions marked with the "SecuritySafeCritical" attribute. Instead of writing directly into a memory location from such functions, code coverage inserts a probe that redirects to another function, which in turns writes into memory. -->
+            <UseVerifiableInstrumentation>True</UseVerifiableInstrumentation>
+            <!-- When set to True, collects coverage information from child processes that are launched with low-level ACLs, for example, UWP apps. -->
+            <AllowLowIntegrityProcesses>True</AllowLowIntegrityProcesses>
+            <!-- When set to True, collects coverage information from child processes that are launched by test or production code. -->
+            <CollectFromChildProcesses>True</CollectFromChildProcesses>
+            <!-- When set to True, restarts the IIS process and collects coverage information from it. -->
+            <CollectAspDotNet>False</CollectAspDotNet>
           </CodeCoverage>
         </Configuration>
       </DataCollector>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,24 +17,10 @@ steps:
     filename: 'BuildAndTest.cmd'
     arguments: '-Configuration Release -EnableCoverage'
 
-- task: PowerShell@2
-  displayName: Run ProcessCodeCoverage.ps1
+- task: PublishTestResults@2
   inputs:
-    targetType: filePath
-    filePath: ./scripts/ProcessCodeCoverage.ps1
-
-- task: PowerShell@2
-  displayName: 'Merging TestResults'
-  inputs:
-    targetType: 'inline'
-    script: |
-      dotnet tool install -g dotnet-reportgenerator-globaltool      
-      reportgenerator -reports:**/*.coverage.xml -targetdir:TestResults -reporttypes:Cobertura -assemblyFilters:"-xunit*;-moq*;-sarif.driver*;-sarif.converters*;-sarif.dll;-test.utilities.sarif.dll;-*webjobs*;-octokit*;-bouncycastle*;-mysqlconnector*;-test*"
-
-- task: PublishCodeCoverageResults@1
-  inputs:
-    codeCoverageTool: 'cobertura'
-    summaryFileLocation: 'TestResults/Cobertura.xml'
+    testRunner: VSTest
+    testResultsFiles: '**/*.trx'
 
 # Enable if you need to debug the tests
 #- task: PublishPipelineArtifact@1


### PR DESCRIPTION
## Changes

- disabled previous code coverage that was relying on coverlet
- enabled code coverage in azure pipelines, showing how much we cover.

For significant contributions please make sure you have completed the following items:

* [ ] `ReleaseHistory.md` updated for non-trivial changes
* [ ] Added unit tests
