### PR TITLE
Fix Ado Configuration Scanner rules

### DIFF
--- a/Src/Plugins/AzureDevOpsConfiguration/AZC101.BuildDefinitionSecurity.json
+++ b/Src/Plugins/AzureDevOpsConfiguration/AZC101.BuildDefinitionSecurity.json
@@ -12,7 +12,7 @@
         {
           "Id": "AZC101/240",
           "Name": "DontMakeSecretsAvailableToForkedBuilds",
-          "Message": "[Build Definition Id:{0:scanTarget}]({1:targetPath}) in organization '{2:org}' project '{3:project}' was found {4:issueDesc} {5:description} {6:recommendation}.",
+          "Message": "[Build Definition Id:{0:scanTarget}]({1:scanTargetPath}) in organization '{2:org}' project '{3:project}' was found {4:issueDesc} {5:description} {6:recommendation}.",
           "Description": "Do not make secrets available to builds for fork of public repository.",
           "IntrafileRegexes": [
             "$AZC101.BuildDefinitionEntityType",

--- a/Src/Plugins/AzureDevOpsConfiguration/AZC102.ServiceConnectionSecurity.json
+++ b/Src/Plugins/AzureDevOpsConfiguration/AZC102.ServiceConnectionSecurity.json
@@ -12,7 +12,7 @@
         {
           "Id": "AZC102/150",
           "Name": "AuthZDontUseClassicConnections",
-          "Message": "[Service connection Id:{0:scanTarget}]({1:targetPath}) in organization '{2:org}' project '{3:project}' was found {4:issueDesc}\r\n{5:description}\r\n{6:recommendation}.",
+          "Message": "[Service connection Id:{0:scanTarget}]({1:scanTargetPath}) in organization '{2:org}' project '{3:project}' was found {4:issueDesc}\r\n{5:description}\r\n{6:recommendation}.",
           "Description": "Do not use classic Azure service connections to access a subscription.",
           "IntrafileRegexes": [
             "$AZC102.ServiceConnectionEntityType",

--- a/Src/Plugins/AzureDevOpsConfiguration/AzureDevOpsConfiguration.SharedStrings.txt
+++ b/Src/Plugins/AzureDevOpsConfiguration/AzureDevOpsConfiguration.SharedStrings.txt
@@ -17,15 +17,15 @@
 
 # Common patterns for file allow and deny lists.
 #
-$BuildDefinitionFiles=(?i)(^https?:\/\/dev.azure.com).*(\/_apis\/build\/definitions\/)|(azc101\.builddefinition\..*json$)
-$ServiceConnectionFiles=(?i)(^https?:\/\/dev.azure.com).*(\/_apis\/contribution\/HierarchyQuery)|(azc102\.serviceconnection\..*json$)
+$BuildDefinitionFiles=(?i)(^https?:\/\/dev\.azure\.com).*(\/_apis\/build\/definitions\/)|(azc101\.builddefinition\..*json$)
+$ServiceConnectionFiles=(?i)(^https?:\/\/dev\.azure\.com).*(\/_settings\/adminservices)|(azc102[_\d]*\.serviceconnection\..*json$)
 
-$AdoOrganzationName=(?i)"_originatingUri"\s*:\s*"https?:\/\/(dev\.azure\.com\/)?(?P<org>.*?)(\/|\.visualstudio\.com)
+$AdoOrganzationName=(?i)"_accountName"\s*:\s*"(?P<org>.*?)"
 $AdoProjectName=(?i)"_projectId"\s*:\s*"(?P<project>.*?)"
 
-$AZC101.BuildDefinitionEntityType=(?i)(?P<type>"EtlEntity"\s*:\s*"builddefinitions")
-$AZC102.ServiceConnectionEntityType=(?i)(?P<type>"EtlEntity"\s*:\s*"serviceendpoints")
+$AZC101.BuildDefinitionEntityType=(?i)(?P<type>"uri"\s*:\s*"vstfs:///Build/Definition/)
+$AZC102.ServiceConnectionEntityType=(?i)(?P<type>"serviceEndpointProjectReferences")
 
 $AZC101/240.PullRequestTriggertype=(?i)(?P<triggertype>"triggerType"\s*:\s*"pullRequest")
-$AZC101/240.ForkedEnabled=(?i)(?P<fork>"forks"\s*:\s*{\s*"enabled"\s*:\s*true\s*,\s*"allowSecrets"\s*:\s*true\s*})
-$AZC102/150.AzureClassicType=(?i)(?P<sctype>"type"\s*:\s*"azure")
+$AZC101/240.ForkedEnabled=(?i)(?P<secret>"forks"\s*:\s*{\s*"enabled"\s*:\s*true\s*,\s*"allowSecrets"\s*:\s*true\s*})
+$AZC102/150.AzureClassicType=(?i)(?P<secret>"type"\s*:\s*"azure")

--- a/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/BuildDefinitionSecurity/ExpectedOutputs/AZC101.builddefinition.DontMakeSecretsAvailableToForkedBuilds.sarif
+++ b/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/BuildDefinitionSecurity/ExpectedOutputs/AZC101.builddefinition.DontMakeSecretsAvailableToForkedBuilds.sarif
@@ -45,8 +45,8 @@
             "id": "Default",
             "arguments": [
               "AZC101.builddefinition.DontMakeSecretsAvailableToForkedBuilds.json",
-              "",
-              "test-org",
+              "C:\\GitHub.com\\sarif-pattern-matcher\\src\\Plugins\\Tests.AzureDevOpsConfiguration\\TestData\\BuildDefinitionSecurity\\Inputs\\AZC101.builddefinition.DontMakeSecretsAvailableToForkedBuilds.json",
+              "test-org.visualstudio.com",
               "33df262c-872a-d2c5-a674-cd60cb6e11ef",
               "its build pipeline secrets available for builds of forks.",
               "For GitHub public repositories, it is possible that people from outside the organization can create forks and run builds on the forked repo. In such a case, if this setting is wrongly left enabled, outsiders can get access to build pipeline secrets that were meant to be internal.",
@@ -61,14 +61,14 @@
                   "uriBaseId": "SRC_ROOT"
                 },
                 "region": {
-                  "startLine": 2,
-                  "startColumn": 2,
-                  "endLine": 159,
-                  "endColumn": 52,
-                  "charOffset": 4,
-                  "charLength": 5494,
+                  "startLine": 27,
+                  "startColumn": 4,
+                  "endLine": 30,
+                  "endColumn": 5,
+                  "charOffset": 530,
+                  "charLength": 64,
                   "snippet": {
-                    "text": "\"EtlEntity\": \"builddefinitions\",\r\n\t\"EtlIngestDate\": \"2019-07-19T21:43:08.2172009Z\",\r\n\t\"options\": [\r\n\t\t{\r\n\t\t\t\"enabled\": false,\r\n\t\t\t\"definition\": {\r\n\t\t\t\t\"id\": \"51a3ca5a-403c-48a1-aef2-ba852325a43e\"\r\n\t\t\t},\r\n\t\t\t\"inputs\": {}\r\n\t\t}\r\n\t],\r\n\t\"triggers\": [\r\n\t\t{\r\n\t\t\t\"branchFilters\": [],\r\n\t\t\t\"pathFilters\": [],\r\n\t\t\t\"settingsSourceType\": 2,\r\n\t\t\t\"batchChanges\": false,\r\n\t\t\t\"maxConcurrentBuildsPerBranch\": 1,\r\n\t\t\t\"triggerType\": \"continuousIntegration\"\r\n\t\t},\r\n\t\t{\r\n\t\t\t\"settingsSourceType\": 2,\r\n\t\t\t\"branchFilters\": [\r\n\t\t\t\t\"+master\"\r\n\t\t\t],\r\n\t\t\t\"forks\": {\r\n\t\t\t\t\"enabled\": true,\r\n\t\t\t\t\"allowSecrets\": true\r\n\t\t\t},\r\n\t\t\t\"pathFilters\": [],\r\n\t\t\t\"requireCommentsForNonTeamMembersOnly\": false,\r\n\t\t\t\"isCommentRequiredForPullRequest\": false,\r\n\t\t\t\"triggerType\": \"pullRequest\"\r\n\t\t}\r\n\t],\r\n\t\"variables\": {\r\n\t\t\"system.debug\": {\r\n\t\t\t\"value\": \"true\",\r\n\t\t\t\"allowOverride\": true\r\n\t\t},\r\n\t\t\"VERSION\": {\r\n\t\t\t\"value\": \"1.0\"\r\n\t\t}\r\n\t},\r\n\t\"properties\": {},\r\n\t\"tags\": [],\r\n\t\"_links\": {\r\n\t\t\"self\": {\r\n\t\t\t\"href\": \"https://dev.azure.com/test-org/33df262c-872a-d2c5-a674-cd60cb6e11ef/_apis/build/Definitions/17?revision=3\"\r\n\t\t},\r\n\t\t\"web\": {\r\n\t\t\t\"href\": \"https://dev.azure.com/test-org/33df262c-872a-d2c5-a674-cd60cb6e11ef/_build/definition?definitionId=17\"\r\n\t\t},\r\n\t\t\"editor\": {\r\n\t\t\t\"href\": \"https://dev.azure.com/test-org/33df262c-872a-d2c5-a674-cd60cb6e11ef/_build/designer?id=17&_a=edit-build-definition\"\r\n\t\t},\r\n\t\t\"badge\": {\r\n\t\t\t\"href\": \"https://dev.azure.com/test-org/33df262c-872a-d2c5-a674-cd60cb6e11ef/_apis/build/status/17\"\r\n\t\t}\r\n\t},\r\n\t\"jobAuthorizationScope\": \"projectCollection\",\r\n\t\"jobTimeoutInMinutes\": 60,\r\n\t\"jobCancelTimeoutInMinutes\": 5,\r\n\t\"badgeEnabled\": true,\r\n\t\"process\": {\r\n\t\t\"yamlFilename\": \"ci/continuous-build.yml\",\r\n\t\t\"type\": 2\r\n\t},\r\n\t\"repository\": {\r\n\t\t\"properties\": {\r\n\t\t\t\"apiUrl\": \"https://api.github.com/repos/testcompany/azure-pipelines-artifact-caching-tasks\",\r\n\t\t\t\"branchesUrl\": \"https://api.github.com/repos/testcompany/azure-pipelines-artifact-caching-tasks/branches\",\r\n\t\t\t\"cloneUrl\": \"https://github.com/testcompany/azure-pipelines-artifact-caching-tasks.git\",\r\n\t\t\t\"connectedServiceId\": \"f29d632a-77d6-4c4c-aa50-6937a5c06b03\",\r\n\t\t\t\"defaultBranch\": \"master\",\r\n\t\t\t\"fullName\": \"testcompany/azure-pipelines-artifact-caching-tasks\",\r\n\t\t\t\"hasAdminPermissions\": \"False\",\r\n\t\t\t\"isFork\": \"False\",\r\n\t\t\t\"isPrivate\": \"False\",\r\n\t\t\t\"lastUpdated\": \"05/14/2019 10:58:18\",\r\n\t\t\t\"manageUrl\": \"https://github.com/testcompany/azure-pipelines-artifact-caching-tasks\",\r\n\t\t\t\"nodeId\": \"MDLwOlJlcX9zaXRvcnktNjkxNjr2OHM=\",\r\n\t\t\t\"ownerId\": \"1234567\",\r\n\t\t\t\"orgName\": \"testcompany\",\r\n\t\t\t\"refsUrl\": \"https://api.github.com/repos/testcompany/azure-pipelines-artifact-caching-tasks/git/refs\",\r\n\t\t\t\"shortName\": \"azure-pipelines-artifact-caching-tasks\",\r\n\t\t\t\"ownerAvatarUrl\": \"https://avatars2.githubusercontent.com/u/1234567?v=4\",\r\n\t\t\t\"archived\": \"False\",\r\n\t\t\t\"externalId\": \"123456789\",\r\n\t\t\t\"safeId\": \"testcompany/azure-pipelines-artifact-caching-tasks\",\r\n\t\t\t\"safeOwnerId\": \"1234567\",\r\n\t\t\t\"safeOwnerName\": \"testcompany\",\r\n\t\t\t\"safeRepository\": \"testcompany/azure-pipelines-artifact-caching-tasks\",\r\n\t\t\t\"ownerIsAUser\": \"False\",\r\n\t\t\t\"checkoutNestedSubmodules\": \"false\",\r\n\t\t\t\"cleanOptions\": \"0\",\r\n\t\t\t\"fetchDepth\": \"0\",\r\n\t\t\t\"gitLfsSupport\": \"false\",\r\n\t\t\t\"reportBuildStatus\": \"true\",\r\n\t\t\t\"skipSyncSource\": \"false\",\r\n\t\t\t\"labelSourcesFormat\": \"$(build.buildNumber)\",\r\n\t\t\t\"labelSources\": \"0\"\r\n\t\t},\r\n\t\t\"id\": \"testcompany/azure-pipelines-artifact-caching-tasks\",\r\n\t\t\"type\": \"GitHub\",\r\n\t\t\"name\": \"testcompany/azure-pipelines-artifact-caching-tasks\",\r\n\t\t\"url\": \"https://github.com/testcompany/azure-pipelines-artifact-caching-tasks.git\",\r\n\t\t\"defaultBranch\": \"master\",\r\n\t\t\"clean\": \"false\",\r\n\t\t\"checkoutSubmodules\": false\r\n\t},\r\n\t\"quality\": \"definition\",\r\n\t\"authoredBy\": {\r\n\t\t\"displayName\": \"Yong Yan\",\r\n\t\t\"url\": \"https://vssps.dev.azure.com/e/testcompany/_apis/Identities/077dcb0a-3503-40fb-a793-85d2efdf8c96\",\r\n\t\t\"_links\": {\r\n\t\t\t\"avatar\": {\r\n\t\t\t\t\"href\": \"https://dev.azure.com/test-org/_apis/GraphProfile/MemberAvatars/aad.NEUzMzA2NmYtNDBjMy43MzNlLFkxZaEtMjCiNTBvYTdhMzds\"\r\n\t\t\t}\r\n\t\t},\r\n\t\t\"id\": \"77ee3796-43c3-4a07-bfa9-1a9157b6a252\",\r\n\t\t\"uniqueName\": \"etdenn@testcompany.com\",\r\n\t\t\"imageUrl\": \"https://dev.azure.com/test-org/_apis/GraphProfile/MemberAvatars/aad.NEUzMzA2NmYtNDBjMy43MzNlLFkxZaEtMjCiNTBvYTdhMzds\",\r\n\t\t\"descriptor\": \"aad.NEUzMzA2NmYtNDBjMy43MzNlLFkxZaEtMjCiNTBvYTdhMzds\"\r\n\t},\r\n\t\"drafts\": [],\r\n\t\"queue\": {\r\n\t\t\"_links\": {\r\n\t\t\t\"self\": {\r\n\t\t\t\t\"href\": \"https://dev.azure.com/test-org/_apis/build/Queues/46\"\r\n\t\t\t}\r\n\t\t},\r\n\t\t\"id\": 46,\r\n\t\t\"url\": \"https://dev.azure.com/test-org/_apis/build/Queues/46\",\r\n\t\t\"pool\": null\r\n\t},\r\n\t\"id\": 17,\r\n\t\"name\": \"TestCompany.azure-pipelines-artifact-caching-tasks\",\r\n\t\"url\": \"https://dev.azure.com/test-org/33df262c-872a-d2c5-a674-cd60cb6e11ef/_apis/build/Definitions/17?revision=3\",\r\n\t\"uri\": \"vstfs:///Build/Definition/17\",\r\n\t\"path\": \"\\\\\",\r\n\t\"type\": \"build\",\r\n\t\"queueStatus\": \"enabled\",\r\n\t\"revision\": 3,\r\n\t\"createdDate\": \"2019-05-14T16:26:54.1Z\",\r\n\t\"project\": {\r\n\t\t\"id\": \"33df262c-872a-d2c5-a674-cd60cb6e11ef\",\r\n\t\t\"name\": \"azure-pipelines-artifact-caching-tasks\",\r\n\t\t\"url\": \"https://dev.azure.com/test-org/_apis/projects/33df262c-872a-d2c5-a674-cd60cb6e11ef\",\r\n\t\t\"state\": \"wellFormed\",\r\n\t\t\"revision\": 75,\r\n\t\t\"visibility\": \"public\",\r\n\t\t\"lastUpdateTime\": \"2019-02-06T16:56:10.827Z\"\r\n\t},\r\n\t\"_projectId\": \"33df262c-872a-d2c5-a674-cd60cb6e11ef\",\r\n\t\"_accountName\": \"test-org.visualstudio.com\",\r\n\t\"_sessionId\": \"95a60ee3-737f-4955-87a2-f0a2ada4dc58-test-org_AzureDevOpsHourly-1\",\r\n\t\"_originatingUri\": \"https://dev.azure.com/test-org"
+                    "text": "\"forks\": {\r\n\t\t\t\t\"enabled\": true,\r\n\t\t\t\t\"allowSecrets\": true\r\n\t\t\t}"
                   }
                 }
               }
@@ -76,12 +76,12 @@
           ],
           "fingerprints": {
             "AssetFingerprint/v1": "",
-            "ValidationFingerprint/v1": "[secret=8DFB5CD68EF3AD7A78D10284591F8D81ADD57FFDD8646DE80E846C63C95032DE]",
-            "ValidationFingerprintHash/v1": "a5982fe308422353bb65ef8ed4a9715cedbcafb085e840eb025b3cee018b34c6",
+            "ValidationFingerprint/v1": "[secret=\"forks\": {\r\n\t\t\t\t\"enabled\": true,\r\n\t\t\t\t\"allowSecrets\": true\r\n\t\t\t}]",
+            "ValidationFingerprintHash/v1": "917d3587f19eadf26d647ea712818f54b3554eeaddea19886b596ea5a6a8d5f6",
             "AssetFingerprint/v2": "{}",
-            "ValidationFingerprint/v2": "{\"secret\":\"8DFB5CD68EF3AD7A78D10284591F8D81ADD57FFDD8646DE80E846C63C95032DE\"}"
+            "ValidationFingerprint/v2": "{\"secret\":\"\\\"forks\\\": {\\r\\n\\t\\t\\t\\t\\\"enabled\\\": true,\\r\\n\\t\\t\\t\\t\\\"allowSecrets\\\": true\\r\\n\\t\\t\\t}\"}"
           },
-          "rank": 53.78
+          "rank": 60.36
         }
       ],
       "columnKind": "utf16CodeUnits"

--- a/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/ServiceConnectionSecurity/ExpectedOutputs/AZC102.serviceconnection.DontUseClassicConnections.sarif
+++ b/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/ServiceConnectionSecurity/ExpectedOutputs/AZC102.serviceconnection.DontUseClassicConnections.sarif
@@ -45,8 +45,8 @@
             "id": "Default",
             "arguments": [
               "AZC102.serviceconnection.DontUseClassicConnections.json",
-              "",
-              "testorg",
+              "C:\\GitHub.com\\sarif-pattern-matcher\\src\\Plugins\\Tests.AzureDevOpsConfiguration\\TestData\\ServiceConnectionSecurity\\Inputs\\AZC102.serviceconnection.DontUseClassicConnections.json",
+              "testorg.visualstudio.com",
               "f0f0a9fa-a2ad-47bc-b6f0-2c080f9a420f",
               " is Azure Classic service connection.",
               "You should use Azure resource Manager type service connection as the ARM model provides several security enhancements such as: stronger access control (RBAC), better auditing, ARM-based deployment/governance, access to managed identities, access to key vault for secrets, AAD-based authentication, support for tags and resource groups for easier security management, etc.",
@@ -61,14 +61,14 @@
                   "uriBaseId": "SRC_ROOT"
                 },
                 "region": {
-                  "startLine": 14,
+                  "startLine": 21,
                   "startColumn": 2,
-                  "endLine": 67,
-                  "endColumn": 37,
-                  "charOffset": 553,
-                  "charLength": 2004,
+                  "endLine": 21,
+                  "endColumn": 17,
+                  "charOffset": 892,
+                  "charLength": 15,
                   "snippet": {
-                    "text": "\"EtlEntity\": \"serviceendpoints\",\r\n\t\"EtlIngestDate\": \"2021-08-31T17:47:16.4417481Z\",\r\n\t\"EtlDiscoveryDate\": \"2021-08-31T17:47:16.1777943Z\",\r\n\t\"EtlIdentity\": \"yy@testcompany.com\",\r\n\t\"EtlRecordSha\": \"231f1d0ccebf1dbb0c20945d70f2b60693e6aa412e08e52eae120c3bfda9b724\",\r\n\t\"id\": \"27843de2-2bea-45ab-b677-27ea718b557e\",\r\n\t\"name\": \"test-service\",\r\n\t\"type\": \"azure\",\r\n\t\"url\": \"https://management.azure.com/\",\r\n\t\"createdBy\": {\r\n\t\t\"displayName\": \"Yong Yan\",\r\n\t\t\"url\": \"https://spsprodwcus0.vssps.visualstudio.com/Abc0d6a57-7ea8-4b16-ba2a-86cfb778f6b4/_apis/Identities/fd421bfc-8eee-40f2-bcb0-64e08c5e6115\",\r\n\t\t\"_links\": {\r\n\t\t\t\"avatar\": {\r\n\t\t\t\t\"href\": \"https://testorg.visualstudio.com/_apis/GraphProfile/MemberAvatars/aad.NmVmZ4AENjGtMGViYy03ZWQ1LTk0MzkhZTQ0NMI4MjQ0ZGJl\"\r\n\t\t\t}\r\n\t\t},\r\n\t\t\"id\": \"fd421bfc-8eee-40f2-bcb0-64e08c5e6115\",\r\n\t\t\"uniqueName\": \"yy@testcompany.com\",\r\n\t\t\"imageUrl\": \"https://testorg.visualstudio.com/_apis/GraphProfile/MemberAvatars/aad.NmVmZ4AENjGtMGViYy03ZWQ1LTk0MzkhZTQ0NMI4MjQ0ZGJl\",\r\n\t\t\"descriptor\": \"aad.NmVmZ4AENjGtMGViYy03ZWQ1LTk0MzkhZTQ0NMI4MjQ0ZGJl\"\r\n\t},\r\n\t\"description\": \"\",\r\n\t\"authorization\": {\r\n\t\t\"parameters\": {\r\n\t\t\t\"tenantid\": \"8791732d-6b82-4be1-a353-35dc64da977f\",\r\n\t\t\t\"serviceprincipalid\": \"5c40a626-036e-4606-a08f-a7f2165e2ce0\",\r\n\t\t\t\"authenticationType\": \"spnKey\",\r\n\t\t\t\"scope\": \"/subscriptions/5004ae11-7a14-44c4-8496-7f8ca83668c7/resourcegroups/testproj\"\r\n\t\t},\r\n\t\t\"scheme\": \"ServicePrincipal\"\r\n\t},\r\n\t\"isShared\": false,\r\n\t\"isReady\": true,\r\n\t\"operationStatus\": {\r\n\t\t\"state\": \"Ready\",\r\n\t\t\"statusMessage\": \"\"\r\n\t},\r\n\t\"owner\": \"Library\",\r\n\t\"serviceEndpointProjectReferences\": [\r\n\t\t{\r\n\t\t\t\"projectReference\": {\r\n\t\t\t\t\"id\": \"f0f0a9fa-a2ad-47bc-b6f0-2c080f9a420f\",\r\n\t\t\t\t\"name\": \"TestProject\"\r\n\t\t\t},\r\n\t\t\t\"name\": \"test-service\",\r\n\t\t\t\"description\": \"\"\r\n\t\t}\r\n\t],\r\n\t\"_projectId\": \"f0f0a9fa-a2ad-47bc-b6f0-2c080f9a420f\",\r\n\t\"_projectName\": \"TestProject\",\r\n\t\"_accountName\": \"testorg.visualstudio.com\",\r\n\t\"_sessionId\": \"a77630da-0003-44e5-980c-9eaf8fe6f26a\",\r\n\t\"_originatingUri\": \"https://testorg"
+                    "text": "\"type\": \"azure\""
                   }
                 }
               }
@@ -76,12 +76,12 @@
           ],
           "fingerprints": {
             "AssetFingerprint/v1": "",
-            "ValidationFingerprint/v1": "[secret=E34B3A6FB186364738B59A87873EC3525EC61A1524E2314E11186769F2044AF8]",
-            "ValidationFingerprintHash/v1": "5e24f70a08b729db8a976f9196e4a6566d52d7ec1bdee5ef677e444dd2b54938",
+            "ValidationFingerprint/v1": "[secret=\"type\": \"azure\"]",
+            "ValidationFingerprintHash/v1": "21104afac53ac5993c33d2318dff5325302f73856df10eca3e24260619f241e0",
             "AssetFingerprint/v2": "{}",
-            "ValidationFingerprint/v2": "{\"secret\":\"E34B3A6FB186364738B59A87873EC3525EC61A1524E2314E11186769F2044AF8\"}"
+            "ValidationFingerprint/v2": "{\"secret\":\"\\\"type\\\": \\\"azure\\\"\"}"
           },
-          "rank": 53.81
+          "rank": 46.29
         }
       ],
       "columnKind": "utf16CodeUnits"


### PR DESCRIPTION
## Changes

- Get correct region/context region by specify 'secret' named group.
- Fix service connection rule's allowed file name regex.
- Fix target Uri parameter name in message argument.


* [ ] `ReleaseHistory.md` updated for non-trivial changes
* [x ] Added unit tests
