### PR TITLE
Fixing package vulnerability from GoogleApi

### DIFF
--- a/Src/Plugins/Security/SEC101_003.GoogleApiKeyValidator.cs
+++ b/Src/Plugins/Security/SEC101_003.GoogleApiKeyValidator.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 
+using GoogleApi.Entities.Maps.Common;
 using GoogleApi.Entities.Maps.Directions.Request;
 using GoogleApi.Exceptions;
 
@@ -58,8 +59,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             var request = new DirectionsRequest
             {
                 Key = apiKey,
-                Origin = new GoogleApi.Entities.Common.Location("Seattle"),
-                Destination = new GoogleApi.Entities.Common.Location("Portland"),
+                Origin = new LocationEx(new GoogleApi.Entities.Common.Address("Seattle")),
+                Destination = new LocationEx(new GoogleApi.Entities.Common.Address("Portland")),
             };
 
             try

--- a/Src/Plugins/Security/Security.csproj
+++ b/Src/Plugins/Security/Security.csproj
@@ -26,7 +26,7 @@
   <ItemGroup>
     <PackageReference Include="aliyun-net-sdk-core" Version="1.5.10" />
     <PackageReference Include="AWSSDK.IdentityManagement" Version="3.5.0.61" />
-    <PackageReference Include="GoogleApi" Version="3.10.5" />
+    <PackageReference Include="GoogleApi" Version="4.0.4" />
     <PackageReference Include="MongoDB.Driver" Version="2.13.1" />
     <PackageReference Include="MySqlConnector" Version="1.2.1" />
     <PackageReference Include="Npgsql" Version="5.0.3" />


### PR DESCRIPTION
## Changes

Updating GoogleApi to latest version that uses a safe package of `Portable.BouncyCastle`:
https://github.com/bcgit/bc-csharp/wiki/CVE-2020-15522

For significant contributions please make sure you have completed the following items:

* [ ] `ReleaseHistory.md` updated for non-trivial changes
* [ ] Added unit tests
