### PR TITLE
Updating version to 1.8.0-alpha

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.7.0-alpha.{height}",
+  "version": "1.8.0-alpha.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+\\.\\d+\\.\\d+$"


### PR DESCRIPTION
## Changes

Changing version to `1.8.0-alpha` since we are going to release the version `v1.7.0` from `release/v1.7.0`.
This will enable us to:
- always have the release/v1.7.0 branch to track
- easy to hotfix (we can start a branch from release/v1.7.0, make the fix, and ship)

For significant contributions please make sure you have completed the following items:

* [ ] `ReleaseHistory.md` updated for non-trivial changes
* [ ] Added unit tests
