### PR TITLE
Exposing automationId, automationGuid, and postUri in the analyze command.

### DIFF
--- a/Src/Plugins/Tests.Security/Validators/SEC101_007.GitHubAppCredentialsValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/Validators/SEC101_007.GitHubAppCredentialsValidatorTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                 var fingerprint = new Fingerprint(fingerprintText);
                 var keyValuePairs = new Dictionary<string, string>();
 
-                using var httpClient = new HttpClient(HttpMockHelper.Mock(testCase.HttpStatusCode, testCase.HttpContent));
+                using var httpClient = new HttpClient(Helpers.HttpMockHelper.Mock(testCase.HttpStatusCode, testCase.HttpContent));
                 gitHubAppCredentialsValidator.SetHttpClient(httpClient);
 
                 ValidationState currentState = gitHubAppCredentialsValidator.IsValidDynamic(ref fingerprint,

--- a/Src/Plugins/Tests.Security/Validators/SEC101_046.DiscordApiCredentialsValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/Validators/SEC101_046.DiscordApiCredentialsValidatorTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                 var fingerprint = new Fingerprint(fingerprintText);
                 var keyValuePairs = new Dictionary<string, string>();
 
-                using var httpClient = new HttpClient(HttpMockHelper.Mock(testCase.HttpStatusCode, testCase.HttpContent));
+                using var httpClient = new HttpClient(Helpers.HttpMockHelper.Mock(testCase.HttpStatusCode, testCase.HttpContent));
                 discordApiCredentialsValidator.SetHttpClient(httpClient);
 
                 ValidationState currentState = discordApiCredentialsValidator.IsValidDynamic(ref fingerprint,

--- a/Src/Plugins/Tests.Security/Validators/SEC101_047.CratesApiKeyValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/Validators/SEC101_047.CratesApiKeyValidatorTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                 var fingerprint = new Fingerprint(fingerprintText);
                 var keyValuePairs = new Dictionary<string, string>();
 
-                using var httpClient = new HttpClient(HttpMockHelper.Mock(testCase.HttpStatusCodes[0], null));
+                using var httpClient = new HttpClient(Helpers.HttpMockHelper.Mock(testCase.HttpStatusCodes[0], null));
                 cratesApiKeyValidator.SetHttpClient(httpClient);
 
                 ValidationState currentState = cratesApiKeyValidator.IsValidDynamic(ref fingerprint,

--- a/Src/ReleaseHistory.md
+++ b/Src/ReleaseHistory.md
@@ -16,6 +16,12 @@
 - UER => eliminate unhandled exceptions in rules
 - UEE => eliminate unhandled exceptions in engine
 
+## *Unreleased*
+
+- SDK: Exposing `automationId`, `automationGuid`, and `postUri` in the
+  `analyze` command.
+  [#586](https://github.com/microsoft/sarif-pattern-matcher/pull/586)
+
 ## *v1.5.0*
 
 - FPC: Improving RabbitMQ regex (removing new lines and spaces) from secret.


### PR DESCRIPTION
## Changes
Updating the sarif-sdk submodule will enable us to expose three new parameters for the `analyze` command: `postUri`, `automationId`, and `automationGuid`.

Below is one example of the new command-line arguments:
```bash
❯ .\spam.exe analyze c:\temp\ -o c:\test.sarif --force -d C:\Rules.json --automationId "Test" --automationGuid BC6CCB9F-16C8-4656-A227-C7B5F34864FA --postUri http://localhost:7072/api/upload-content
```

For significant contributions please make sure you have completed the following items:

* [x] `ReleaseHistory.md` updated for non-trivial changes
* [ ] Added unit tests
