### PR TITLE
Adding telegram bot token validator

### DIFF
--- a/Src/Plugins/Security/SEC101.SecurePlaintextSecrets.json
+++ b/Src/Plugins/Security/SEC101.SecurePlaintextSecrets.json
@@ -467,7 +467,8 @@
           "Id": "SEC101/049",
           "Name": "DoNotExposePlaintextSecrets/TelegramBotToken",
           "ContentsRegex": "$SEC101/049.TelegramBotToken",
-          "MessageArguments": { "secretKind": "Telegram bot token" }
+          "MessageArguments": { "secretKind": "Telegram bot token" },
+          "HelpUri": "https://core.telegram.org/bots#generating-an-authentication-token"
         },
         {
           "Id": "SEC101/102",

--- a/Src/Plugins/Security/SEC101.SecurePlaintextSecrets.json
+++ b/Src/Plugins/Security/SEC101.SecurePlaintextSecrets.json
@@ -464,6 +464,12 @@
           "MessageArguments": { "secretKind": "Crates API key" }
         },
         {
+          "Id": "SEC101/049",
+          "Name": "DoNotExposePlaintextSecrets/TelegramBotToken",
+          "ContentsRegex": "$SEC101/049.TelegramBotToken",
+          "MessageArguments": { "secretKind": "Telegram bot token" }
+        },
+        {
           "Id": "SEC101/102",
           "Name": "DoNotExposePlaintextSecrets/AdoPat",
           "MatchLengthToDecode": 52,

--- a/Src/Plugins/Security/SEC101_049.TelegramBotTokenValidator.cs
+++ b/Src/Plugins/Security/SEC101_049.TelegramBotTokenValidator.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+
+using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk;
+using Microsoft.RE2.Managed;
+
+using Newtonsoft.Json;
+
+namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
+{
+    public class TelegramBotTokenValidator : DynamicValidatorBase
+    {
+        // https://core.telegram.org/bots/api#getme
+        internal const string MeApiUri = "https://api.telegram.org/bot{0:secret}/getMe";
+
+        protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)
+        {
+            FlexMatch secret = groups["secret"];
+
+            var validationResult = new ValidationResult
+            {
+                Fingerprint = new Fingerprint
+                {
+                    Secret = secret.Value,
+                    Platform = nameof(AssetPlatform.Telegram),
+                },
+                ValidationState = ValidationState.Unknown,
+            };
+
+            return new[] { validationResult };
+        }
+
+        protected override ValidationState IsValidDynamicHelper(ref Fingerprint fingerprint,
+                                                                ref string message,
+                                                                IDictionary<string, string> options,
+                                                                ref ResultLevelKind resultLevelKind)
+        {
+            string secret = fingerprint.Secret;
+            string uri = string.Format(MeApiUri, secret);
+
+            try
+            {
+                HttpClient client = CreateOrRetrieveCachedHttpClient();
+
+                using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+
+                using HttpResponseMessage response = client
+                    .SendAsync(request, HttpCompletionOption.ResponseHeadersRead)
+                    .GetAwaiter()
+                    .GetResult();
+
+                switch (response.StatusCode)
+                {
+                    case HttpStatusCode.OK:
+                    {
+                        string content = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+                        ResultRoot resultRoot = JsonConvert.DeserializeObject<ResultRoot>(content);
+
+                        message = $"The compromised Telegram bot account is '{resultRoot?.Result?.Username}'.";
+                        return ValidationState.Authorized;
+                    }
+
+                    case HttpStatusCode.Forbidden:
+                    case HttpStatusCode.Unauthorized:
+                    {
+                        return ValidationState.Unauthorized;
+                    }
+
+                    default:
+                    {
+                        return ReturnUnexpectedResponseCode(ref message, response.StatusCode);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                return ReturnUnhandledException(ref message, e);
+            }
+        }
+
+        internal class Result
+        {
+            [JsonProperty("username")]
+            public string Username { get; set; }
+
+            [JsonProperty("can_join_groups")]
+            public bool CanJoinGroups { get; set; }
+
+            [JsonProperty("can_read_all_group_messages")]
+            public bool CanReadAllGroupMessages { get; set; }
+
+            [JsonProperty("supports_inline_queries")]
+            public bool SupportsInlineQueries { get; set; }
+        }
+
+        internal class ResultRoot
+        {
+            [JsonProperty("ok")]
+            public bool Ok { get; set; }
+
+            [JsonProperty("result")]
+            public Result Result { get; set; }
+        }
+    }
+}

--- a/Src/Plugins/Security/SEC101_049.TelegramBotTokenValidator.cs
+++ b/Src/Plugins/Security/SEC101_049.TelegramBotTokenValidator.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
     public class TelegramBotTokenValidator : DynamicValidatorBase
     {
         // https://core.telegram.org/bots/api#getme
-        internal const string MeApiUri = "https://api.telegram.org/bot{0:secret}/getMe";
+        internal const string GetMeApi = "https://api.telegram.org/bot{0:secret}/getMe";
 
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)
         {
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                                                 ref ResultLevelKind resultLevelKind)
         {
             string secret = fingerprint.Secret;
-            string uri = string.Format(MeApiUri, secret);
+            string uri = string.Format(GetMeApi, secret);
 
             try
             {

--- a/Src/Plugins/Security/SEC101_049.TelegramBotTokenValidator.cs
+++ b/Src/Plugins/Security/SEC101_049.TelegramBotTokenValidator.cs
@@ -61,7 +61,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                         string content = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
                         ResultRoot resultRoot = JsonConvert.DeserializeObject<ResultRoot>(content);
 
-                        message = $"The compromised Telegram bot account is '{resultRoot?.Result?.Username}'.";
+                        fingerprint.Id = resultRoot?.Result?.Username;
+                        message = $"The compromised Telegram bot account is '{fingerprint.Id}'.";
                         return ValidationState.Authorized;
                     }
 

--- a/Src/Plugins/Security/Security.SharedStrings.txt
+++ b/Src/Plugins/Security/Security.SharedStrings.txt
@@ -130,4 +130,5 @@
   $SEC101/044.NpmCredentialsPassword=(?si)(?:(?:(?:registry\s*=\s*https:\/\/(?P<host>[^\s]+)(?:$|\s))|(?:_password\s*=\s*(?P<secret>[^\s]+)(?:$|\s)))(?:.{0,200})?){2}
   $SEC101/045.PostmanApiKey=(?:[^P]|^)(?P<secret>PMAK-[0-9a-z]{24}-[0-9a-z]{34})(?:[^0-9a-z]|$)
   $SEC101/047.CratesApiKey=(?i)(?:[^c]|^)(?P<secret>cio[0-9a-z]{32})(?:[^0-9a-z]|$)
+  $SEC101/049.TelegramBotToken=bot(?P<secret>[0-9]{6,12}:AA(?i)[0-9a-z\-_]{32,33})(?:[^0-9a-z\-_])
   $SEC101/102.AdoPat=(?:[^2-7a-z]|^)(?P<secret>[2-7a-z]{52})(?:[^2-7a-z]|$) 

--- a/Src/Plugins/Security/Security.SharedStrings.txt
+++ b/Src/Plugins/Security/Security.SharedStrings.txt
@@ -130,5 +130,5 @@
   $SEC101/044.NpmCredentialsPassword=(?si)(?:(?:(?:registry\s*=\s*https:\/\/(?P<host>[^\s]+)(?:$|\s))|(?:_password\s*=\s*(?P<secret>[^\s]+)(?:$|\s)))(?:.{0,200})?){2}
   $SEC101/045.PostmanApiKey=(?:[^P]|^)(?P<secret>PMAK-[0-9a-z]{24}-[0-9a-z]{34})(?:[^0-9a-z]|$)
   $SEC101/047.CratesApiKey=(?i)(?:[^c]|^)(?P<secret>cio[0-9a-z]{32})(?:[^0-9a-z]|$)
-  $SEC101/049.TelegramBotToken=bot(?P<secret>[0-9]{6,12}:AA(?i)[0-9a-z\-_]{32,33})(?:[^0-9a-z\-_])
+  $SEC101/049.TelegramBotToken=bot(?P<secret>[0-9]{6,12}:AA(?i)[0-9a-z\-_]{32,33})(?:[^0-9a-z\-_]|$)
   $SEC101/102.AdoPat=(?:[^2-7a-z]|^)(?P<secret>[2-7a-z]{52})(?:[^2-7a-z]|$) 

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_049.TelegramBotToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_049.TelegramBotToken.sarif
@@ -26,7 +26,7 @@
                   "text": "'{0}' is {1}{2}{3}{4}{5}."
                 }
               },
-              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
+              "helpUri": "https://core.telegram.org/bots#generating-an-authentication-token"
             }
           ]
         }

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_049.TelegramBotToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_049.TelegramBotToken.sarif
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "testhost",
+          "organization": "Microsoft Corporation",
+          "product": "Microsoft.TestHost",
+          "fullName": "testhost 15.0.0.0",
+          "version": "15.0.0.0",
+          "semanticVersion": "15.0.0",
+          "rules": [
+            {
+              "id": "SEC101/049",
+              "name": "DoNotExposePlaintextSecrets/TelegramBotToken",
+              "fullDescription": {
+                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
+              },
+              "messageStrings": {
+                "NotApplicable_InvalidMetadata": {
+                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                },
+                "Default": {
+                  "text": "'{0}' is {1}{2}{3}{4}{5}."
+                }
+              },
+              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
+            }
+          ]
+        }
+      },
+      "invocations": [
+        {
+          "executionSuccessful": true
+        }
+      ],
+      "results": [
+        {
+          "ruleId": "SEC101/049",
+          "ruleIndex": 0,
+          "level": "note",
+          "message": {
+            "id": "Default",
+            "arguments": [
+              "123456…",
+              "an apparent ",
+              "",
+              "Telegram bot token",
+              "",
+              " (no validation occurred as it was not enabled. Pass '--dynamic-validation' on the command-line to validate this match)"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_049.TelegramBotToken.ps1",
+                  "uriBaseId": "SRC_ROOT"
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 29,
+                  "endLine": 1,
+                  "endColumn": 70,
+                  "charOffset": 28,
+                  "charLength": 41,
+                  "snippet": {
+                    "text": "123456:AAC-DEF1234ghIkl-zyx57W2v1u123ew11"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "AssetFingerprint/v1": "[platform=Telegram]",
+            "ValidationFingerprint/v1": "[secret=123456:AAC-DEF1234ghIkl-zyx57W2v1u123ew11]",
+            "ValidationFingerprintHash/v1": "1283c54bfbe29ccec21207197d084f6d8cf3871750861281529a59f0c044ee96",
+            "AssetFingerprint/v2": "{\"platform\":\"Telegram\"}",
+            "ValidationFingerprint/v2": "{\"secret\":\"123456:AAC-DEF1234ghIkl-zyx57W2v1u123ew11\"}"
+          },
+          "rank": 63.9
+        }
+      ],
+      "columnKind": "utf16CodeUnits"
+    }
+  ]
+}

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_049.TelegramBotToken.ps1
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/Inputs/SEC101_049.TelegramBotToken.ps1
@@ -1,0 +1,1 @@
+https://api.telegram.org/bot123456:AAC-DEF1234ghIkl-zyx57W2v1u123ew11/getMe

--- a/Src/Plugins/Tests.Security/Validators/SEC101_049.TelegramBotTokenValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/Validators/SEC101_049.TelegramBotTokenValidatorTests.cs
@@ -1,0 +1,125 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+
+using FluentAssertions;
+
+using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Helpers;
+using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk;
+
+using Newtonsoft.Json;
+
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validators
+{
+    /// <summary>
+    /// Testing SEC101/049.TelegramBotTokenValidator
+    /// </summary>
+    public class TelegramBotTokenValidatorTests
+    {
+        [Fact]
+        public void TelegramBotTokenValidator_MockHttpTests()
+        {
+            const string fingerprintText = "[secret=secret]";
+            var fingerprint = new Fingerprint(fingerprintText);
+
+            string unexpectedResponseCodeMessage = null, nullRefResponseMessage = null;
+            string secret = fingerprint.Secret;
+            string uri = string.Format(TelegramBotTokenValidator.MeApiUri, secret);
+
+            var resultRoot = new TelegramBotTokenValidator.ResultRoot
+            {
+                Result = new TelegramBotTokenValidator.Result
+                {
+                    Username = "username"
+                }
+            };
+
+            var request = new HttpRequestMessage(HttpMethod.Post, uri);
+            var okResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonConvert.SerializeObject(resultRoot))
+            };
+
+            var testCases = new HttpMockTestCase[]
+            {
+                new HttpMockTestCase
+                {
+                    Title = "Null Ref Exception",
+                    HttpRequestMessages = new List<HttpRequestMessage>{ null },
+                    HttpResponseMessages = new List<HttpResponseMessage>{ null },
+                    ExpectedValidationState = ValidatorBase.ReturnUnhandledException(ref nullRefResponseMessage, new NullReferenceException()),
+                    ExpectedMessage = nullRefResponseMessage,
+                },
+                new HttpMockTestCase
+                {
+                    Title = "Testing Valid Credentials",
+                    HttpRequestMessages = new[]{ request },
+                    HttpResponseMessages = new[]{ okResponse },
+                    ExpectedMessage = $"The compromised Telegram bot account is '{resultRoot?.Result?.Username}'.",
+                    ExpectedValidationState = ValidationState.Authorized,
+                },
+                new HttpMockTestCase
+                {
+                    Title = "Testing Invalid Credentials (Forbidden StatusCode)",
+                    HttpRequestMessages = new[]{ request },
+                    HttpResponseMessages = new[]{ HttpMockHelper.ForbiddenResponse },
+                    ExpectedValidationState = ValidationState.Unauthorized,
+                },
+                new HttpMockTestCase
+                {
+                    Title = "Testing Invalid Credentials (Unauthorized StatusCode)",
+                    HttpRequestMessages = new[]{ request },
+                    HttpResponseMessages = new[]{ HttpMockHelper.UnauthorizedResponse },
+                    ExpectedValidationState = ValidationState.Unauthorized,
+                },
+                new HttpMockTestCase
+                {
+                    Title = "Testing NotFound StatusCode",
+                    HttpRequestMessages = new[]{ request },
+                    HttpResponseMessages = new[]{ HttpMockHelper.InternalServerErrorResponse },
+                    ExpectedValidationState = ValidatorBase.ReturnUnexpectedResponseCode(ref unexpectedResponseCodeMessage, HttpStatusCode.InternalServerError),
+                    ExpectedMessage = unexpectedResponseCodeMessage
+                },
+            };
+
+            var sb = new StringBuilder();
+            var httpMock = new HttpMockHelper();
+            var validator = new TelegramBotTokenValidator();
+            foreach (HttpMockTestCase testCase in testCases)
+            {
+                string message = null;
+                ResultLevelKind resultLevelKind = default;
+                var keyValuePairs = new Dictionary<string, string>();
+
+                httpMock.Mock(testCase.HttpRequestMessages[0], testCase.HttpResponseMessages[0]);
+                using var httpClient = new HttpClient(httpMock);
+                validator.SetHttpClient(httpClient);
+
+                ValidationState currentState = validator.IsValidDynamic(ref fingerprint,
+                                                                        ref message,
+                                                                        keyValuePairs,
+                                                                        ref resultLevelKind);
+                if (currentState != testCase.ExpectedValidationState)
+                {
+                    sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
+                }
+
+                if (message != testCase.ExpectedMessage)
+                {
+                    sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
+                }
+
+                httpMock.Clear();
+            }
+
+            sb.Length.Should().Be(0, sb.ToString());
+        }
+    }
+}

--- a/Src/Plugins/Tests.Security/Validators/SEC101_049.TelegramBotTokenValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/Validators/SEC101_049.TelegramBotTokenValidatorTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
 
             string unexpectedResponseCodeMessage = null, nullRefResponseMessage = null;
             string secret = fingerprint.Secret;
-            string uri = string.Format(TelegramBotTokenValidator.MeApiUri, secret);
+            string uri = string.Format(TelegramBotTokenValidator.GetMeApi, secret);
 
             var resultRoot = new TelegramBotTokenValidator.ResultRoot
             {

--- a/Src/ReleaseHistory.md
+++ b/Src/ReleaseHistory.md
@@ -16,6 +16,11 @@
 - UER => eliminate unhandled exceptions in rules
 - UEE => eliminate unhandled exceptions in engine
 
+## *Unreleased*
+
+- NR: Adding TelegramBotToken rule with dynamic validation.
+  [#587](https://github.com/microsoft/sarif-pattern-matcher/pull/587)
+
 ## *v1.5.0*
 
 - FPC: Improving RabbitMQ regex (removing new lines and spaces) from secret.

--- a/Src/Sarif.PatternMatcher.Sdk/AssetPlatform.cs
+++ b/Src/Sarif.PatternMatcher.Sdk/AssetPlatform.cs
@@ -151,6 +151,11 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk
         Stripe,
 
         /// <summary>
+        /// Telegram platform.
+        /// </summary>
+        Telegram,
+
+        /// <summary>
         /// Twilio platform.
         /// </summary>
         Twilio,


### PR DESCRIPTION
## Changes
This is a new rule which will look for telegram bot tokens. If any match is found, the dynamic validation will be able to check if this is still live or not, updating the `finngerprint.id` with the username of the bot if available.

For significant contributions please make sure you have completed the following items:

* [x] `ReleaseHistory.md` updated for non-trivial changes
* [x] Added unit tests
