### PR TITLE
Using latest windows SDK to compile RE2 libraries

### DIFF
--- a/Src/RE2.Native/RE2.Native.x64.vcxproj
+++ b/Src/RE2.Native/RE2.Native.x64.vcxproj
@@ -21,7 +21,7 @@
     <ProjectGuid>{70AC46A2-605B-4E9A-8414-D510A4797424}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>RE2Native</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <TargetName>RE2.Native.x64</TargetName>
     <TargetExt>.dll</TargetExt>

--- a/Src/RE2.Native/RE2.Native.x86.vcxproj
+++ b/Src/RE2.Native/RE2.Native.x86.vcxproj
@@ -21,7 +21,7 @@
     <ProjectGuid>{70AC46A2-605B-4E9A-8414-D510A479742C}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>RE2Native</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <TargetName>RE2.Native.x86</TargetName>
     <TargetExt>.dll</TargetExt>

--- a/Src/RE2.Native/re2.x64.vcxproj
+++ b/Src/RE2.Native/re2.x64.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <_ProjectFileVersion>10.0.20506.1</_ProjectFileVersion>
     <ProjectGuid>{F0D53C69-F483-3ABA-8EB9-E41CF742CAB4}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <Keyword>Win32Proj</Keyword>
     <Platform>x64</Platform>
     <ProjectName>re2.x64</ProjectName>

--- a/Src/RE2.Native/re2.x86.vcxproj
+++ b/Src/RE2.Native/re2.x86.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <_ProjectFileVersion>10.0.20506.1</_ProjectFileVersion>
     <ProjectGuid>{F0D53C69-F483-3ABA-8EB9-E41CF742CAB5}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <Keyword>Win32Proj</Keyword>
     <Platform>x64</Platform>
     <ProjectName>re2.x86</ProjectName>


### PR DESCRIPTION
## Changes

This change will allow us to use the latest windows SDK installed instead of hardcoding a specific version.


For significant contributions please make sure you have completed the following items:

* [ ] `ReleaseHistory.md` updated for non-trivial changes
* [ ] Added unit tests
