### PR TITLE
Bump MongoDB.Driver from 2.13.1 to 2.15.0 and Microsoft.AspNetCore.Http from 2.1.0 to 2.2.0

### DIFF
--- a/Src/Plugins/Security/Security.csproj
+++ b/Src/Plugins/Security/Security.csproj
@@ -28,18 +28,13 @@
     <PackageReference Include="AWSSDK.IdentityManagement" Version="3.5.0.61" />
     <PackageReference Include="GoogleApi" Version="4.0.4" />
     <PackageReference Include="Microsoft.Security.Utilities" Version="1.1.0" />
-    <PackageReference Include="MongoDB.Driver" Version="2.13.1" />
+    <PackageReference Include="MongoDB.Driver" Version="2.15.0" />
     <PackageReference Include="MySqlConnector" Version="1.2.1" />
     <PackageReference Include="Npgsql" Version="5.0.3" />
     <PackageReference Include="RabbitMQ.Client" Version="6.2.1" />
     <PackageReference Include="System.Data.SqlClient" Version="4.7.0" />
     <PackageReference Include="System.Text.Json" Version="5.0.1" />
     <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
-  </ItemGroup>
-
-  <ItemGroup Label="Component Governance fixes">
-    <!-- MongoDB.Driver -->
-    <PackageReference Include="SharpCompress" Version="0.29.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/ReleaseHistory.md
+++ b/Src/ReleaseHistory.md
@@ -18,7 +18,7 @@
 
 ## Unreleased
 
-- Bump MongoDB.Driver from 2.13.2 to 2.14.0 and Microsoft.AspNetCore.Http from 2.1.0 to 2.2.0. [#608](https://github.com/microsoft/sarif-pattern-matcher/pull/608)
+- Bump MongoDB.Driver from 2.13.1 to 2.15.0 and Microsoft.AspNetCore.Http from 2.1.0 to 2.2.0. [#608](https://github.com/microsoft/sarif-pattern-matcher/pull/608)
 
 ## *v1.8.0*
 

--- a/Src/ReleaseHistory.md
+++ b/Src/ReleaseHistory.md
@@ -18,7 +18,7 @@
 
 ## Unreleased
 
-- Updating MongoDB Package to 2.15.0 and Microsoft.AspNetCore.Http Package to 2.2.0, which fixes the following issues: [CVE-2021-39208](https://nvd.nist.gov/vuln/detail/CVE-2021-39208) and [CVE-2020-1045](https://nvd.nist.gov/vuln/detail/CVE-2020-1045). [#608](https://github.com/microsoft/sarif-pattern-matcher/pull/608)
+- Updating MongoDB package from 2.13.1 to 2.15.0 and Microsoft.AspNetCore.Http package from 2.1.0 to 2.2.0, which fixes the following issues: [CVE-2021-39208](https://nvd.nist.gov/vuln/detail/CVE-2021-39208) and [CVE-2020-1045](https://nvd.nist.gov/vuln/detail/CVE-2020-1045). [#608](https://github.com/microsoft/sarif-pattern-matcher/pull/608)
 
 ## *v1.8.0*
 

--- a/Src/ReleaseHistory.md
+++ b/Src/ReleaseHistory.md
@@ -18,7 +18,7 @@
 
 ## Unreleased
 
-- Updating MongoDB package from 2.13.1 to 2.15.0 and Microsoft.AspNetCore.Http package from 2.1.0 to 2.2.0, which fixes the following issues: [CVE-2021-39208](https://nvd.nist.gov/vuln/detail/CVE-2021-39208) and [CVE-2020-1045](https://nvd.nist.gov/vuln/detail/CVE-2020-1045). [#608](https://github.com/microsoft/sarif-pattern-matcher/pull/608)
+- Bump MongoDB.Driver from 2.13.2 to 2.14.0 and Microsoft.AspNetCore.Http from 2.1.0 to 2.2.0. [#608](https://github.com/microsoft/sarif-pattern-matcher/pull/608)
 
 ## *v1.8.0*
 

--- a/Src/ReleaseHistory.md
+++ b/Src/ReleaseHistory.md
@@ -16,6 +16,10 @@
 - UER => eliminate unhandled exceptions in rules
 - UEE => eliminate unhandled exceptions in engine
 
+## Unreleased
+
+- Updating MongoDB Package to 2.15.0 and Microsoft.AspNetCore.Http Package to 2.2.0, which fixes the following issues: [CVE-2021-39208](https://nvd.nist.gov/vuln/detail/CVE-2021-39208) and [CVE-2020-1045](https://nvd.nist.gov/vuln/detail/CVE-2020-1045). [#608](https://github.com/microsoft/sarif-pattern-matcher/pull/608)
+
 ## *v1.8.0*
 
 - BUG: Resolve `InvalidOperationException` and `IndexOutOfRange` exceptions in `StaticValidatorBase.IsValidStatic` due to unsafe use of HashSet<string> class.

--- a/Src/Sarif.PatternMatcher.Function/Sarif.PatternMatcher.Function.csproj
+++ b/Src/Sarif.PatternMatcher.Function/Sarif.PatternMatcher.Function.csproj
@@ -13,6 +13,7 @@
     <None Remove="Properties\PublishProfiles\**" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.10" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.2" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.11" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,4 +22,4 @@ steps:
     testRunner: VSTest
     testResultsFiles: '**/*.trx'
 
-  - task: ComponentGovernanceComponentDetection@0
+- task: ComponentGovernanceComponentDetection@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,28 +22,4 @@ steps:
     testRunner: VSTest
     testResultsFiles: '**/*.trx'
 
-#- task: PowerShell@2
-#  displayName: Run ProcessCodeCoverage.ps1
-#  inputs:
-#    targetType: filePath
-#    filePath: ./scripts/ProcessCodeCoverage.ps1
-
-#- task: PowerShell@2
-#  displayName: 'Merging TestResults'
-#  inputs:
-#    targetType: 'inline'
-#    script: |
-#      dotnet tool install -g dotnet-reportgenerator-globaltool      
-#      reportgenerator -reports:**/*.coverage.xml -targetdir:TestResults -reporttypes:Cobertura
-
-#- task: PublishCodeCoverageResults@1
-#  inputs:
-#    codeCoverageTool: 'cobertura'
-#    summaryFileLocation: 'TestResults/Cobertura.xml'
-
-# Enable if you need to debug the tests
-#- task: PublishPipelineArtifact@1
-#  condition: always()
-#  inputs:
-#    targetPath: bld/bin/AnyCPU_Debug/Tests.Security/netcoreapp3.1/
-#    artifactName: Tests.Security
+  - task: ComponentGovernanceComponentDetection@0


### PR DESCRIPTION
## Changes

This change will fix the following issues:
- Bump MongoDB.Driver from 2.13.1 to 2.15.0: fixes https://nvd.nist.gov/vuln/detail/CVE-2021-39208
- Microsoft.AspNetCore.Http from 2.1.0 to 2.2.0: fixes https://nvd.nist.gov/vuln/detail/CVE-2020-1045

As you can see, you cannot see Microsoft.AspNetCore.Http version 2.1.0 in the changes because it is a reference from the package Microsoft.NET.Sdk.Functions -> Microsoft.Azure.WebJobs.Extensions.Http -> Microsoft.AspNetCore.Http

For significant contributions please make sure you have completed the following items:

* [ ] `ReleaseHistory.md` updated for non-trivial changes
* [ ] Added unit tests
