### PR TITLE
Updating sarif.sdk submodules

### DIFF
--- a/Src/Plugins/Tests.AzureDevOpsConfiguration/AZC101.BuildDefinitionSecurityTests.cs
+++ b/Src/Plugins/Tests.AzureDevOpsConfiguration/AZC101.BuildDefinitionSecurityTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.AzureDevOpsConfigu
 
         protected override string Framework => "netstandard2.1";
 
-        protected override string Service => "BuildDefinitionSecurity";
+        protected override string PluginName => "BuildDefinitionSecurity";
 
         [Fact]
         public void AzureDevOpsConfiguration_EndToEndFunctionalTests()

--- a/Src/Plugins/Tests.AzureDevOpsConfiguration/AZC101.BuildDefinitionSecurityTests.cs
+++ b/Src/Plugins/Tests.AzureDevOpsConfiguration/AZC101.BuildDefinitionSecurityTests.cs
@@ -16,6 +16,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.AzureDevOpsConfigu
 
         protected override string Framework => "netstandard2.1";
 
+        protected override string Service => "BuildDefinitionSecurity";
+
         [Fact]
         public void AzureDevOpsConfiguration_EndToEndFunctionalTests()
             => RunAllTests();

--- a/Src/Plugins/Tests.AzureDevOpsConfiguration/AZC102.ServiceConnectionSecurityTests.cs
+++ b/Src/Plugins/Tests.AzureDevOpsConfiguration/AZC102.ServiceConnectionSecurityTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.AzureDevOpsConfigu
 
         protected override string Framework => "netstandard2.1";
 
-        protected override string Service => "ServiceConnectionSecurity";
+        protected override string PluginName => "ServiceConnectionSecurity";
 
         [Fact]
         public void AzureDevOpsConfiguration_EndToEndFunctionalTests()

--- a/Src/Plugins/Tests.AzureDevOpsConfiguration/AZC102.ServiceConnectionSecurityTests.cs
+++ b/Src/Plugins/Tests.AzureDevOpsConfiguration/AZC102.ServiceConnectionSecurityTests.cs
@@ -16,6 +16,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.AzureDevOpsConfigu
 
         protected override string Framework => "netstandard2.1";
 
+        protected override string Service => "ServiceConnectionSecurity";
+
         [Fact]
         public void AzureDevOpsConfiguration_EndToEndFunctionalTests()
             => RunAllTests();

--- a/Src/Plugins/Tests.AzureDevOpsConfiguration/EndToEndTestsAzureDevOpsConfiguration.cs
+++ b/Src/Plugins/Tests.AzureDevOpsConfiguration/EndToEndTestsAzureDevOpsConfiguration.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-
 using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security;
 
 using Xunit.Abstractions;
@@ -18,14 +15,5 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.AzureDevOpsConfigu
 
         protected override string TestLogResourceNameRoot => $"Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.AzureDevOpsConfiguration.TestData.{TypeUnderTest}";
 
-        protected override string ProductDirectory
-        {
-            get
-            {
-                string path = typeof(EndToEndTestsAzureDevOpsConfiguration).Assembly.Location;
-                path = GitHelper.Default.GetTopLevel(path);
-                return Path.Combine(path, @"src\Plugins\Tests.AzureDevOpsConfiguration");
-            }
-        }
     }
 }

--- a/Src/Plugins/Tests.SalModernization/EndToEndTestsSalModernization.cs
+++ b/Src/Plugins/Tests.SalModernization/EndToEndTestsSalModernization.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.IO;
-
 using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security;
 
 using Xunit.Abstractions;
@@ -17,15 +14,5 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.SalModernization
         }
 
         protected override string TestLogResourceNameRoot => $"Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.SalModernization.TestData.{TypeUnderTest}";
-
-        protected override string ProductDirectory
-        {
-            get
-            {
-                string path = typeof(EndToEndTestsSalModernization).Assembly.Location;
-                path = GitHelper.Default.GetTopLevel(path);
-                return Path.Combine(path, @"src\Plugins\Tests.SalModernization");
-            }
-        }
     }
 }

--- a/Src/Plugins/Tests.SalModernization/SEC105.UpdateSalToCurrentVersion.cs
+++ b/Src/Plugins/Tests.SalModernization/SEC105.UpdateSalToCurrentVersion.cs
@@ -16,6 +16,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.SalModernization
 
         protected override string Framework => "netstandard2.0";
 
+        protected override string Service => "UpdateSalToCurrentVersion";
+
         [Fact]
         public void UpdateSalToCurrentVersion_EndToEndFunctionalTests()
             => RunAllTests();

--- a/Src/Plugins/Tests.SalModernization/SEC105.UpdateSalToCurrentVersion.cs
+++ b/Src/Plugins/Tests.SalModernization/SEC105.UpdateSalToCurrentVersion.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.SalModernization
 
         protected override string Framework => "netstandard2.0";
 
-        protected override string Service => "UpdateSalToCurrentVersion";
+        protected override string PluginName => "UpdateSalToCurrentVersion";
 
         [Fact]
         public void UpdateSalToCurrentVersion_EndToEndFunctionalTests()

--- a/Src/Plugins/Tests.Security/EndToEndTests.cs
+++ b/Src/Plugins/Tests.Security/EndToEndTests.cs
@@ -28,15 +28,15 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 
         protected abstract string RuleId { get; }
 
-        protected abstract string Service { get; }
-
         protected abstract string Framework { get; }
+
+        protected abstract string PluginName { get; }
 
         protected override string TestLogResourceNameRoot => $"Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.TestData.{TypeUnderTest}";
 
         protected override string TestBinaryTestDataDirectory => Path.Combine(ProductRootDirectory, "src", "Plugins", TestBinaryName, "TestData");
 
-        protected override string ProductTestDataDirectory => Path.Combine(TestBinaryTestDataDirectory, Service);
+        protected override string ProductTestDataDirectory => Path.Combine(TestBinaryTestDataDirectory, PluginName);
 
         protected override IDictionary<string, string> ConstructTestOutputsFromInputResources(IEnumerable<string> inputResourceNames, object parameter)
         {

--- a/Src/Plugins/Tests.Security/EndToEndTests.cs
+++ b/Src/Plugins/Tests.Security/EndToEndTests.cs
@@ -28,22 +28,28 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 
         protected abstract string RuleId { get; }
 
+        protected abstract string Service { get; }
+
         protected abstract string Framework { get; }
 
         protected override string TestLogResourceNameRoot => $"Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.TestData.{TypeUnderTest}";
 
-        protected override string ProductDirectory => Path.Combine(base.ProductDirectory, @"Plugins\Tests.Security");
+        protected override string TestBinaryTestDataDirectory => Path.Combine(ProductRootDirectory, "src", "Plugins", TestBinaryName, "TestData");
+
+        protected override string ProductTestDataDirectory => Path.Combine(TestBinaryTestDataDirectory, Service);
 
         protected override IDictionary<string, string> ConstructTestOutputsFromInputResources(IEnumerable<string> inputResourceNames, object parameter)
         {
             var results = new Dictionary<string, string>();
             var dict = new Dictionary<string, Task<string>>();
 
+            const string input = "Inputs.";
+
             foreach (string inputResourceName in inputResourceNames)
             {
-                string secret = inputResourceName.Substring("Inputs.".Length);
+                string name = inputResourceName.Substring(inputResourceName.IndexOf(input) + input.Length);
 
-                dict[secret] = Task.Factory.StartNew(() => ConstructTestOutputFromInputResource(inputResourceName, parameter));
+                dict[name] = Task.Factory.StartNew(() => ConstructTestOutputFromInputResource(inputResourceName, parameter));
             }
 
             Task.WaitAll(dict.Values.ToArray());
@@ -60,6 +66,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
         {
             string logContents = GetResourceText(inputResourceName);
 
+            const string input = "Inputs.";
+            string fileName = inputResourceName.Substring(inputResourceName.IndexOf(input) + input.Length);
             string productBinaryName = TestBinaryName.Substring("Tests.".Length);
 
             string regexDefinitions = Path.Combine(
@@ -70,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             string filePath = Path.Combine(
                 ProductTestDataDirectory,
                 @"Inputs\",
-                inputResourceName.Substring("inputs.".Length));
+                fileName);
 
             IFileSystem fileSystem = FileSystem.Instance;
 

--- a/Src/Plugins/Tests.Security/SEC101.SecurePlaintextSecretsTests.cs
+++ b/Src/Plugins/Tests.Security/SEC101.SecurePlaintextSecretsTests.cs
@@ -16,6 +16,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 
         protected override string Framework => "netstandard2.1";
 
+        protected override string Service => "SecurePlaintextSecrets";
+
         [Fact]
         public void SecurePlaintextSecrets_EndToEndFunctionalTests()
             => RunAllTests();

--- a/Src/Plugins/Tests.Security/SEC101.SecurePlaintextSecretsTests.cs
+++ b/Src/Plugins/Tests.Security/SEC101.SecurePlaintextSecretsTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 
         protected override string Framework => "netstandard2.1";
 
-        protected override string Service => "SecurePlaintextSecrets";
+        protected override string PluginName => "SecurePlaintextSecrets";
 
         [Fact]
         public void SecurePlaintextSecrets_EndToEndFunctionalTests()

--- a/Src/Plugins/Tests.Security/SEC102.ReviewPotentiallySensitiveDataTests.cs
+++ b/Src/Plugins/Tests.Security/SEC102.ReviewPotentiallySensitiveDataTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 
         protected override string Framework => "netstandard2.1";
 
-        protected override string Service => "ReviewPotentiallySensitiveData";
+        protected override string PluginName => "ReviewPotentiallySensitiveData";
 
         [Fact]
         public void ReviewPotentiallySensitiveData_EndToEndFunctionalTests()

--- a/Src/Plugins/Tests.Security/SEC102.ReviewPotentiallySensitiveDataTests.cs
+++ b/Src/Plugins/Tests.Security/SEC102.ReviewPotentiallySensitiveDataTests.cs
@@ -16,6 +16,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 
         protected override string Framework => "netstandard2.1";
 
+        protected override string Service => "ReviewPotentiallySensitiveData";
+
         [Fact]
         public void ReviewPotentiallySensitiveData_EndToEndFunctionalTests()
             => RunAllTests();

--- a/Src/Plugins/Tests.Security/SEC103.ReviewPotentiallySensitiveFilesTests.cs
+++ b/Src/Plugins/Tests.Security/SEC103.ReviewPotentiallySensitiveFilesTests.cs
@@ -16,6 +16,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 
         protected override string Framework => "netstandard2.1";
 
+        protected override string Service => "ReviewPotentiallySensitiveFiles";
+
         [Fact]
         public void ReviewPotentiallySensitiveFiles_EndToEndFunctionalTests()
             => RunAllTests();

--- a/Src/Plugins/Tests.Security/SEC103.ReviewPotentiallySensitiveFilesTests.cs
+++ b/Src/Plugins/Tests.Security/SEC103.ReviewPotentiallySensitiveFilesTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 
         protected override string Framework => "netstandard2.1";
 
-        protected override string Service => "ReviewPotentiallySensitiveFiles";
+        protected override string PluginName => "ReviewPotentiallySensitiveFiles";
 
         [Fact]
         public void ReviewPotentiallySensitiveFiles_EndToEndFunctionalTests()

--- a/Src/Plugins/Tests.Security/SEC104.UseSecureApiTests.cs
+++ b/Src/Plugins/Tests.Security/SEC104.UseSecureApiTests.cs
@@ -16,6 +16,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 
         protected override string Framework => "netstandard2.1";
 
+        protected override string Service => "UseSecureApi";
+
         [Fact]
         public void UseSecureApi_EndToEndFunctionalTests()
             => RunAllTests();

--- a/Src/Plugins/Tests.Security/SEC104.UseSecureApiTests.cs
+++ b/Src/Plugins/Tests.Security/SEC104.UseSecureApiTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 
         protected override string Framework => "netstandard2.1";
 
-        protected override string Service => "UseSecureApi";
+        protected override string PluginName => "UseSecureApi";
 
         [Fact]
         public void UseSecureApi_EndToEndFunctionalTests()

--- a/Src/ReleaseHistory.md
+++ b/Src/ReleaseHistory.md
@@ -19,6 +19,7 @@
 ## Unreleased
 
 - Bump MongoDB.Driver from 2.13.1 to 2.15.0 and Microsoft.AspNetCore.Http from 2.1.0 to 2.2.0. [#608](https://github.com/microsoft/sarif-pattern-matcher/pull/608)
+- Bump SARIF.SDK from 2.4.13 to 2.4.15. [#612](https://github.com/microsoft/sarif-pattern-matcher/pull/612)
 
 ## *v1.8.0*
 

--- a/Src/ReleaseHistory.md
+++ b/Src/ReleaseHistory.md
@@ -19,7 +19,7 @@
 ## Unreleased
 
 - Bump MongoDB.Driver from 2.13.1 to 2.15.0 and Microsoft.AspNetCore.Http from 2.1.0 to 2.2.0. [#608](https://github.com/microsoft/sarif-pattern-matcher/pull/608)
-- Bump SARIF.SDK from 2.4.13 to 2.4.15. [#612](https://github.com/microsoft/sarif-pattern-matcher/pull/612)
+- Bump Sarif.Sdk from 2.4.13 to [2.4.15](https://github.com/microsoft/sarif-sdk/blob/v2.4.15/src/ReleaseHistory.md) by updating submodule to commit [9f0eed7549736b28d59a2e93f443ba47e3bd978e](https://github.com/microsoft/sarif-sdk/commit/9f0eed7549736b28d59a2e93f443ba47e3bd978e). [#612](https://github.com/microsoft/sarif-pattern-matcher/pull/612)
 
 ## *v1.8.0*
 

--- a/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/AnalyzeCommandTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/AnalyzeCommandTests.cs
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
             string searchDefinitionsPath = @$"c:\{Guid.NewGuid()}.json";
 
             var mockFileSystem = new Mock<IFileSystem>();
-
+            mockFileSystem.Setup(x => x.DirectoryExists(rootDirectory)).Returns(true);
             mockFileSystem.Setup(x => x.DirectoryEnumerateFiles(rootDirectory,
                                                                 scanTargetName,
                                                                 It.IsAny<SearchOption>()))


### PR DESCRIPTION
## Changes

This change will update the sarif sdk submodules to point to the latest released that we made (2.4.15).

Here you can find the difference between the submodules change:
https://github.com/microsoft/sarif-sdk/compare/b2c7e399cfaf1fde47b336bbb4976f723263efa3...9f0eed7549736b28d59a2e93f443ba47e3bd978e

* [x] `ReleaseHistory.md` updated for non-trivial changes
* [ ] Added unit tests
