### PR TITLE
Adding Url rule to ReleaseHistory

### DIFF
--- a/Src/ReleaseHistory.md
+++ b/Src/ReleaseHistory.md
@@ -19,6 +19,7 @@
 ## Unreleased
 
 - Bump MongoDB.Driver from 2.13.1 to 2.15.0 and Microsoft.AspNetCore.Http from 2.1.0 to 2.2.0. [#608](https://github.com/microsoft/sarif-pattern-matcher/pull/608)
+- NR: Adding Url rule in the plugin `ReviewPotentiallySensitiveData`. [#611](https://github.com/microsoft/sarif-pattern-matcher/pull/611)
 
 ## *v1.8.0*
 


### PR DESCRIPTION
This change will update the ReleaseHistory file, adding the Url rule that was developed in the PR #611