### PR TITLE
Enable response file parsing in driver.

### DIFF
--- a/Src/ReleaseHistory.md
+++ b/Src/ReleaseHistory.md
@@ -16,6 +16,11 @@
 - UER => eliminate unhandled exceptions in rules
 - UEE => eliminate unhandled exceptions in engine
 
+## *v1.9.1*
+
+- FEATURE: Enable response file parsing provided by driver framework. Arguments (e.g., '@Commands.rsp') prefixed with a '@' character will be evaluated as a file path to a text file that contains commands to be injected on the command-line. 
+
+
 ## *v1.9.0*
 
 - Bump MongoDB.Driver from 2.13.1 to 2.15.0 and Microsoft.AspNetCore.Http from 2.1.0 to 2.2.0. [#608](https://github.com/microsoft/sarif-pattern-matcher/pull/608)

--- a/Src/Sarif.PatternMatcher.Cli/ImportAndAnalyzeOptions.cs
+++ b/Src/Sarif.PatternMatcher.Cli/ImportAndAnalyzeOptions.cs
@@ -5,13 +5,13 @@ using CommandLine;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
 {
-    [Verb("import-analyze", HelpText = "Export rules metadata to a markdown file.")]
+    [Verb("import-analyze", HelpText = "Import from and analyze database contents.")]
     internal class ImportAndAnalyzeOptions : AnalyzeOptions
     {
         [Option(
             "host",
             HelpText = "The database host from which we will retrieve data to scan. " +
-                       "Create AppClientId, AppSecrent, and AuthorityId as environment variables.",
+                       "Create AppClientId, AppSecret, and AuthorityId as environment variables.",
             Required = true)]
         public string Host { get; set; }
 

--- a/Src/Sarif.PatternMatcher.Cli/Program.cs
+++ b/Src/Sarif.PatternMatcher.Cli/Program.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 
@@ -20,6 +22,15 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
         {
             Console.OutputEncoding = Encoding.UTF8;
 
+            args = EntryPointUtilities.GenerateArguments(args, FileSystem, new EnvironmentVariables());
+
+            bool isValidHelpCommand =
+                args.Length > 0 &&
+                args[0] == "help" &&
+                ((args.Length == 2 && IsValidVerbName(args[1])) || args.Length == 1);
+
+            bool isVersionCommand = args[0] == "version" && args.Length == 1;
+
             return Parser.Default.ParseArguments<
                 AnalyzeOptions,
                 AnalyzeDatabaseOptions,
@@ -34,7 +45,19 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
                 (ExportRulesMetatadaOptions options) => new ExportRulesMetatadaCommand().Run(options),
                 (ExportSearchDefinitionsOptions options) => new ExportSearchDefinitionsCommand().Run(options),
                 (ValidateOptions options) => new ValidateCommand().Run(options),
-                _ => CommandBase.FAILURE);
+                _ => isValidHelpCommand || isVersionCommand
+                        ? CommandBase.SUCCESS
+                        : CommandBase.FAILURE);
+        }
+
+        private static bool IsValidVerbName(string verb)
+        {
+            return
+                verb == "analyze" ||
+                verb == "analyze-database" ||
+                verb == "export-rules" ||
+                verb == "export-search-definitions" ||
+                verb == "import-analyze";
         }
     }
 }

--- a/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/AnalyzeCommandTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/AnalyzeCommandTests.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
 
             string tempFileName = Path.GetTempFileName();
             string sarifLogFileName = $"{tempFileName}.sarif";
-            SarifLog sarifLog = null, sarifLogFromResponseFile = null;
+            SarifLog sarifLog = null;
 
             try
             {

--- a/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/AnalyzeCommandTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/AnalyzeCommandTests.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
 
             string tempFileName = Path.GetTempFileName();
             string sarifLogFileName = $"{tempFileName}.sarif";
-            SarifLog sarifLog = null;
+            SarifLog sarifLog = null, sarifLogFromResponseFile = null;
 
             try
             {

--- a/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/ProgramTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/ProgramTests.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
             int result = Program.Main(args);
 
             result.Should().Be(
-                expectedResult,                               
+                expectedResult,
                 $"response files consisted of '{flattenedResponseFile}'");
         }
 

--- a/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/ProgramTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/ProgramTests.cs
@@ -1,0 +1,127 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using Castle.Core.Internal;
+
+using CommandLine;
+
+using FluentAssertions;
+
+using Microsoft.CodeAnalysis.Sarif.Driver;
+
+using Moq;
+
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
+{
+    public class ProgramTests
+    {
+        [Fact]
+        public void Program_ResponseFileWorks()
+        {
+            // Ensure that simple commands, such as help and version
+            // work properly (as evident by a success response code).
+            TestResponseFile(new string[] { "help" });
+            TestResponseFile(new string[] { "version" });
+
+            // Our mocking strategy assumes that a single mocked called to File.ReadAllLines
+            // returns the response file contents. To validate this assumptions, we'll 
+            // force a failure case to prove that the previous successes are valid.
+            TestResponseFile(new string[] { Guid.NewGuid().ToString() }, CommandBase.FAILURE);
+        }
+
+        [Fact]
+        public void Program_ResponseFileHelpCommandWorksForAllVerbs()
+        {
+            // Crawl all types looking for command verbs and ensure that each one of
+            // them is a valid argument to include in a response file.
+            foreach (string verbName in GetVerbNames())
+            {
+                TestResponseFile(new string[] { $"help {verbName}" });
+            }
+
+            // Explicitly provoke a failure to build confidence in prior
+            // successful tests.
+            TestResponseFile(
+                new string[] { $"help {Guid.NewGuid()}" }, CommandBase.FAILURE);
+        }
+
+        [Fact]
+        public void Program_ResponseFileMultilineHelpCommandWorksForAllVerbs()
+        {
+            // Crawl all types looking for command verbs and ensure that each one of
+            // them is a valid argument to include in a response file.
+            foreach (string verbName in GetVerbNames())
+            {
+                TestResponseFile(new string[] { "help", verbName });
+            }
+
+            // Explicitly provoke a failure to build confidence in prior
+            // successful tests.
+            TestResponseFile(
+                new string[] { $"help {Guid.NewGuid()}" }, CommandBase.FAILURE);
+        }
+
+        [Fact]
+        public void Program_VerbListMatcheExpected()
+        {
+            GetVerbNames().Count.Should().Be(5);
+
+            // We expect:
+            // 'analyze'
+            // 'analyze-database'
+            // import-analyze'
+            // 'export-rules'
+            // 'export-search-definitions'
+        }
+
+        private static void TestResponseFile(string[] responseFileContents,
+                                             int expectedResult = CommandBase.SUCCESS)
+        {
+            string responseFilePath = "@ResponseFile.rsp";
+
+            var mockFileSystem = new Mock<IFileSystem>();
+
+            // Returns the mocked response file contents.
+            mockFileSystem.Setup(x => x.FileReadAllLines(It.IsAny<string>()))
+                .Returns<string>((path) =>
+                {
+                    return responseFileContents;
+                });
+
+            Program.FileSystem = mockFileSystem.Object;
+
+            string[] args = new[] { responseFilePath };
+            string flattenedResponseFile = string.Join(' ', responseFileContents);
+            int result = Program.Main(args);
+
+            result.Should().Be(
+                expectedResult,                               
+                $"response files consisted of '{flattenedResponseFile}'");
+        }
+
+        private static IList<string> GetVerbNames()
+        {
+            var verbNames = new List<string>();
+
+            Assembly assembly = typeof(Program).Assembly;
+            foreach (Type type in assembly.GetTypes())
+            {
+                VerbAttribute verbAttribute = type.GetAttribute<VerbAttribute>();
+                if (verbAttribute == null) { continue; }
+
+                verbNames.Add(verbAttribute.Name);
+            }
+
+            // We pick up this verb from the driver framework.
+            verbNames.Add("analyze");
+
+            return verbNames;
+        }
+    }
+}

--- a/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/ProgramTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/ProgramTests.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 
-using Castle.Core.Internal;
-
 using CommandLine;
 
 using FluentAssertions;
@@ -112,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
             Assembly assembly = typeof(Program).Assembly;
             foreach (Type type in assembly.GetTypes())
             {
-                VerbAttribute verbAttribute = type.GetAttribute<VerbAttribute>();
+                VerbAttribute verbAttribute = type.GetCustomAttribute<VerbAttribute>();
                 if (verbAttribute == null) { continue; }
 
                 verbNames.Add(verbAttribute.Name);

--- a/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/ProgramTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/ProgramTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
         }
 
         [Fact]
-        public void Program_VerbListMatcheExpected()
+        public void Program_VerbListCountIsExpected()
         {
             GetVerbNames().Count.Should().Be(5);
 

--- a/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/ProgramTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/ProgramTests.cs
@@ -3,11 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 using CommandLine;
 
 using FluentAssertions;
+
+using Kusto.Cloud.Platform.Utils;
 
 using Microsoft.CodeAnalysis.Sarif.Driver;
 
@@ -66,16 +69,22 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
         }
 
         [Fact]
-        public void Program_VerbListCountIsExpected()
+        public void Program_VerbListIsExpected()
         {
-            GetVerbNames().Count.Should().Be(5);
+            string[] actual = GetVerbNames().ToArray();
+            Array.Sort(actual);
 
-            // We expect:
-            // 'analyze'
-            // 'analyze-database'
-            // import-analyze'
-            // 'export-rules'
-            // 'export-search-definitions'
+            // Keep these in sorted order.
+            string[] expected = new string[]
+            {
+                "analyze",
+                "analyze-database",
+                "export-rules",
+                "export-search-definitions",
+                "import-analyze",
+            };
+
+            actual.Should().BeEquivalentTo(expected);
         }
 
         private static void TestResponseFile(string[] responseFileContents,


### PR DESCRIPTION
This change enables response file processing as provided by the driver framework. This change additionally enables a behavior previously requested by the Guardian team: to provide a zero (success) result code when a user initiates any valid command. Currently, due to our specific use pattern for CommandLibrary, the tool returns a result code of '1' on any help command. 

After this change, any argument prefixed with the '@' will interpreted as a file name. That file, if it exists, will be loaded. Each line in that file will be expanded into an argument that will be injected into the command-line (for example all env vars will be expanded).

 spam.exe @MyResponseFile.rsp

The driver code for the argument expansion is in the Sarif Driver [EntryPointUtilities](https://github.com/microsoft/sarif-sdk/blob/fc9a9dfb865096b5aaa9fa3651854670940f7459/src/Sarif.Driver/Sdk/EntryPointUtilities.cs#L12) code.

@marmegh @shaopeng-gh @cfaucon @EasyRhinoMSFT @eddynaka 