### PR TITLE
Make search definitions argument required.

### DIFF
--- a/Src/Sarif.PatternMatcher.Cli/Program.cs
+++ b/Src/Sarif.PatternMatcher.Cli/Program.cs
@@ -65,9 +65,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
                         : CommandBase.FAILURE);
         }
 
-        private static int RunAnalyzeCommand(AnalyzeOptions options)
+        internal static int RunAnalyzeCommand(AnalyzeOptions options)
         {
-            InstantiatedAnalyzeCommand = new AnalyzeCommand();
+            InstantiatedAnalyzeCommand = new AnalyzeCommand(fileSystem: FileSystem);
             return InstantiatedAnalyzeCommand.Run(options);
         }
 

--- a/Src/Sarif.PatternMatcher.Cli/Program.cs
+++ b/Src/Sarif.PatternMatcher.Cli/Program.cs
@@ -21,6 +21,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
         [ThreadStatic]
         internal static Exception RuntimeException;
 
+        [ThreadStatic]
+        internal static AnalyzeCommand InstantiatedAnalyzeCommand;
+
         internal static int Main(string[] args)
         {
             Console.OutputEncoding = Encoding.UTF8;
@@ -53,13 +56,19 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
               .MapResult(
                 (AnalyzeDatabaseOptions options) => new AnalyzeDatabaseCommand().Run(options),
                 (ImportAndAnalyzeOptions options) => new ImportAndAnalyzeCommand().Run(options),
-                (AnalyzeOptions options) => new AnalyzeCommand(FileSystem).Run(options),
+                (AnalyzeOptions options) => RunAnalyzeCommand(options),
                 (ExportRulesMetatadaOptions options) => new ExportRulesMetatadaCommand().Run(options),
                 (ExportSearchDefinitionsOptions options) => new ExportSearchDefinitionsCommand().Run(options),
                 (ValidateOptions options) => new ValidateCommand().Run(options),
                 _ => isValidHelpCommand || isVersionCommand
                         ? CommandBase.SUCCESS
                         : CommandBase.FAILURE);
+        }
+
+        private static int RunAnalyzeCommand(AnalyzeOptions options)
+        {
+            InstantiatedAnalyzeCommand = new AnalyzeCommand();
+            return InstantiatedAnalyzeCommand.Run(options);
         }
 
         private static bool IsValidVerbName(string verb)

--- a/Src/Sarif.PatternMatcher.Cli/Program.cs
+++ b/Src/Sarif.PatternMatcher.Cli/Program.cs
@@ -65,6 +65,13 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
                         : CommandBase.FAILURE);
         }
 
+        internal static void ClearUnitTestData()
+        {
+            FileSystem = null;
+            RuntimeException = null;
+            InstantiatedAnalyzeCommand = null;
+        }
+
         internal static int RunAnalyzeCommand(AnalyzeOptions options)
         {
             InstantiatedAnalyzeCommand = new AnalyzeCommand(fileSystem: FileSystem);

--- a/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
@@ -301,8 +301,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             context.DynamicValidation = options.DynamicValidation;
             context.GlobalFileDenyRegex = options.FileNameDenyRegex;
             context.FileSizeInKilobytes = options.FileSizeInKilobytes;
-            context.DisableDynamicValidationCaching = options.DisableDynamicValidationCaching;
             context.MaxMemoryInKilobytes = options.MaxMemoryInKilobytes;
+            context.DisableDynamicValidationCaching = options.DisableDynamicValidationCaching;
 
             return context;
         }

--- a/Src/Sarif.PatternMatcher/AnalyzeOptions.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeOptions.cs
@@ -16,6 +16,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             'd',
             "search-definitions",
             Separator = ';',
+            Required = true,
             HelpText = "A path to a file containing one or more search definitions to drive analysis.")]
         public IEnumerable<string> SearchDefinitionsPaths { get; set; }
 

--- a/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/AnalyzeCommandTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/AnalyzeCommandTests.cs
@@ -29,6 +29,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
                     $"-o", Guid.NewGuid().ToString(),
             };
 
+            Program.ClearUnitTestData();
             int result = Program.Main(args);
             result.Should().Be(CommandBase.FAILURE);
 

--- a/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/AnalyzeCommandTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/AnalyzeCommandTests.cs
@@ -32,6 +32,10 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
             int result = Program.Main(args);
             result.Should().Be(CommandBase.FAILURE);
 
+            // This validation is sufficient because the null check for an
+            // instantiated analyze command verifies that we failed the 
+            // CommandLine parsing code and error out before attempting
+            // analysis.
             Program.InstantiatedAnalyzeCommand.Should().BeNull();
         }
 

--- a/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/AnalyzeCommandTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/AnalyzeCommandTests.cs
@@ -7,6 +7,8 @@ using System.IO;
 
 using FluentAssertions;
 
+using Microsoft.CodeAnalysis.Sarif.Driver;
+
 using Moq;
 
 using Newtonsoft.Json;
@@ -17,6 +19,22 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
 {
     public class AnalyzeCommandTests
     {
+        [Fact]
+        public void AnalyzeCommand_DefinitionsArgumentIsRequired()
+        {
+            string[] args = new[]
+            {
+                    "analyze",
+                    Guid.NewGuid().ToString(),
+                    $"-o", Guid.NewGuid().ToString(),
+            };
+
+            int result = Program.Main(args);
+            result.Should().Be(CommandBase.FAILURE);
+
+            Program.InstantiatedAnalyzeCommand.Should().BeNull();
+        }
+
         [Fact]
         public void AnalyzeCommand_SingleLineRuleBasic()
         {
@@ -138,7 +156,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
                 };
 
                 int result = Program.Main(args);
-                result.Should().Be(0);
+                result.Should().Be(CommandBase.SUCCESS);
 
                 sarifLog = JsonConvert.DeserializeObject<SarifLog>(File.ReadAllText(sarifLogFileName));
             }

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/AnalyzeCommandTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/AnalyzeCommandTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             {
                 var optionAttribute = (OptionAttribute)property.GetCustomAttribute(typeof(OptionAttribute));
                 if (optionAttribute == null || optionAttribute.Default == null)
-                { 
+                {
                     continue;
                 }
 

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/AnalyzeCommandTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/AnalyzeCommandTests.cs
@@ -5,7 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
+
+using CommandLine;
 
 using FluentAssertions;
 
@@ -23,6 +26,42 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 {
     public class AnalyzeCommandTests
     {
+        [Fact]
+        public void AnalyzeCommand_DefinitionsArgumentIsRequired()
+        {
+            string specifier = $"{Guid.NewGuid()}.txt";
+
+            AnalyzeOptions options = CreateDefaultAnalyzeOptions();
+
+            options.TargetFileSpecifiers = new[] { specifier };
+
+            var command = new AnalyzeCommand();
+
+            int result = command.Run(options);
+            result.Should().Be(CommandBase.FAILURE);
+
+            // This validation works because if 
+            command.RuntimeErrors.Should().Be(RuntimeConditions.InvalidCommandLineOption);
+        }
+
+        private static AnalyzeOptions CreateDefaultAnalyzeOptions()
+        {
+            var result = new AnalyzeOptions();
+            Type analyzeOptionsType = typeof(AnalyzeOptions);
+
+            foreach (PropertyInfo property in analyzeOptionsType.GetProperties())
+            {
+                var optionAttribute = (OptionAttribute)property.GetCustomAttribute(typeof(OptionAttribute));
+                if (optionAttribute == null || optionAttribute.Default == null)
+                { 
+                    continue; 
+                }
+
+                property.SetValue(result, optionAttribute.Default);
+            }
+            return result;
+        }
+
         [Fact]
         public void AnalyzeCommand_SimpleAnalysis()
         {
@@ -62,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             var definitions = new SearchDefinitions()
             {
                 Definitions = new List<SearchDefinition>(new[]
-                            {
+                {
                     new SearchDefinition()
                     {
                         Name = "MinimalRule", Id = "Test1002",

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/AnalyzeCommandTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/AnalyzeCommandTests.cs
@@ -26,24 +26,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 {
     public class AnalyzeCommandTests
     {
-        [Fact]
-        public void AnalyzeCommand_DefinitionsArgumentIsRequired()
-        {
-            string specifier = $"{Guid.NewGuid()}.txt";
-
-            AnalyzeOptions options = CreateDefaultAnalyzeOptions();
-
-            options.TargetFileSpecifiers = new[] { specifier };
-
-            var command = new AnalyzeCommand();
-
-            int result = command.Run(options);
-            result.Should().Be(CommandBase.FAILURE);
-
-            // This validation works because if 
-            command.RuntimeErrors.Should().Be(RuntimeConditions.InvalidCommandLineOption);
-        }
-
         private static AnalyzeOptions CreateDefaultAnalyzeOptions()
         {
             var result = new AnalyzeOptions();
@@ -467,7 +449,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             var definitions = new SearchDefinitions()
             {
                 Definitions = new List<SearchDefinition>(new[]
-                            {
+                {
                     new SearchDefinition()
                     {
                         Name = "MinimalRule", Id = "Test1002",

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/AnalyzeCommandTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/AnalyzeCommandTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 var optionAttribute = (OptionAttribute)property.GetCustomAttribute(typeof(OptionAttribute));
                 if (optionAttribute == null || optionAttribute.Default == null)
                 { 
-                    continue; 
+                    continue;
                 }
 
                 property.SetValue(result, optionAttribute.Default);


### PR DESCRIPTION
I previously added a new helper to the SARIF Driver SDK to report out when no plugins are configured. Today it occurred to me that the right fix is simply to make this command-line argument required. Oops. So let's review this change and then I'll go rip out that other helper again. 

The heart of this change is simply to add `Required = true` to the `OptionAttribute` backing the search definitions argument. I've added a unit test. This change includes a useful test method I intend to exercise later.

Also, I've incidentally updated SARIF-SDK submodule.