### PR TITLE
Fix false negative when max file size is not set

### DIFF
--- a/Src/ReleaseHistory.md
+++ b/Src/ReleaseHistory.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## *Unreleased*
-- BUG: Fix false negative when `SearchSkimmer` is invoked directly and `MaxFileSizeInKilobytes` is not set. [#637](https://github.com/microsoft/sarif-pattern-matcher/pull/637)
+- BUG: Fix false negative when `SearchSkimmer` is invoked directly and `MaxFileSizeInKilobytes` is not set. This will now default to approximately 10MB. [#637](https://github.com/microsoft/sarif-pattern-matcher/pull/637)
 
 ## *2.0.0-dev*
 

--- a/Src/ReleaseHistory.md
+++ b/Src/ReleaseHistory.md
@@ -1,5 +1,8 @@
 # Release History
 
+## *Unreleased*
+- BUG: Fix false negative when `SearchSkimmer` is invoked directly and `MaxFileSizeInKilobytes` is not set. [#637](https://github.com/microsoft/sarif-pattern-matcher/pull/637)
+
 ## *2.0.0-dev*
 
 - Update `sarif-sdk` submodule to commit [24c773bf194100d11c896ce67581832428304a35](https://github.com/microsoft/sarif-sdk/tree/24c773bf194100d11c896ce67581832428304a35), which corresponds to the NuGet `Sarif.Sdk` 3.0.0-beta1 package release.

--- a/Src/ReleaseHistory.md
+++ b/Src/ReleaseHistory.md
@@ -1,14 +1,12 @@
 # Release History
 
-## *Unreleased*
-- BUG: Fix false negative when `SearchSkimmer` is invoked directly and `MaxFileSizeInKilobytes` is not set. This will now default to approximately 10MB. [#637](https://github.com/microsoft/sarif-pattern-matcher/pull/637)
-
 ## *2.0.0-dev*
 
 - Update `sarif-sdk` submodule to commit [24c773bf194100d11c896ce67581832428304a35](https://github.com/microsoft/sarif-sdk/tree/24c773bf194100d11c896ce67581832428304a35), which corresponds to the NuGet `Sarif.Sdk` 3.0.0-beta1 package release.
 - BUG: Resolve `OutofMemoryException` and `NullReferenceException' failures resulting from a failure to honor file size scan limits set by `--file-size-in-kb` argument and updated Sarif.Sdk submodule to commit [ce8c5cb12d29aa407d0bf98f5fa2c764ec7fb65b](https://github.com/microsoft/sarif-sdk/commit/ce8c5cb12d29aa407d0bf98f5fa2c764ec7fb65b). [#621](https://github.com/microsoft/sarif-pattern-matcher/pull/621)
 - BUG: Resolve SAL Modernization Plugin capture group showing incorrect region properties in SARIF. [#626](https://github.com/microsoft/sarif-pattern-matcher/pull/626)
 - SDK: Sarif.PatternMatcher projects will start using a fixed version of `RE2.Managed` and `Strings.Interop`. [#638](https://github.com/microsoft/sarif-pattern-matcher/pull/638)
+- BUG: Fix false negative when `SearchSkimmer` is invoked directly and `MaxFileSizeInKilobytes` is not set. This will now default to approximately 10MB. [#637](https://github.com/microsoft/sarif-pattern-matcher/pull/637)
 
 ## *v1.10.0*
 

--- a/Src/Sarif.PatternMatcher/AnalyzeContext.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeContext.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
         public string GlobalFileDenyRegex { get; set; }
 
-        public int MaxFileSizeInKilobytes { get; set; } = -1;
+        public int MaxFileSizeInKilobytes { get; set; } = 1024 * 10000;
 
         public bool DisableDynamicValidationCaching { get; set; }
 

--- a/Src/Sarif.PatternMatcher/AnalyzeContext.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeContext.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
         public string GlobalFileDenyRegex { get; set; }
 
-        public int MaxFileSizeInKilobytes { get; set; } = 1024 * 10000;
+        public int MaxFileSizeInKilobytes { get; set; } = 10000;
 
         public bool DisableDynamicValidationCaching { get; set; }
 

--- a/Src/Sarif.PatternMatcher/AnalyzeContext.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeContext.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
         public string GlobalFileDenyRegex { get; set; }
 
-        public int MaxFileSizeInKilobytes { get; set; }
+        public int MaxFileSizeInKilobytes { get; set; } = -1;
 
         public bool DisableDynamicValidationCaching { get; set; }
 

--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -17,7 +17,7 @@ using Microsoft.Strings.Interop;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 {
-    public class SearchSkimmer : Skimmer<>
+    public class SearchSkimmer : Skimmer<AnalyzeContext>
     {
 
         public const string SecretHashSha256Current = "SecretHashSha256/current";

--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -156,8 +156,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 try
                 {
                     // Ensure that the byte of the file does not exceed the limit set by the
-                    // file-size-in-kilobytes argument (which will be 0 if not set, in which
-                    // case all files should be analyzed no matter their size).
+                    // file-size-in-kilobytes argument.
                     long fileSize = _fileSystem.FileInfoLength(filePath);
                     if (DoesTargetFileExceedSizeLimits(fileSize, context.MaxFileSizeInKilobytes))
                     {

--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -17,7 +17,7 @@ using Microsoft.Strings.Interop;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 {
-    public class SearchSkimmer : Skimmer<AnalyzeContext>
+    public class SearchSkimmer : Skimmer<>
     {
 
         public const string SecretHashSha256Current = "SecretHashSha256/current";
@@ -1324,9 +1324,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             // Ensure that the byte of the file does not exceed the limit set by the
             // file-size-in-kilobytes argument (which will be 0 if not set, in which
             // case all files should be analyzed no matter their size).
-            double fileSize = (double)fileLength / 1024;
+            long fileSize = fileLength / 1024;
 
-            return maxFileSize > 0 && fileSize > maxFileSize;
+            return maxFileSize > -1 && fileSize > maxFileSize;
         }
     }
 }

--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -1322,8 +1322,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
         private bool DoesTargetFileExceedSizeLimits(long fileLength, int maxFileSize)
         {
             // Ensure that the byte of the file does not exceed the limit set by the
-            // file-size-in-kilobytes argument (which will be 0 if not set, in which
-            // case all files should be analyzed no matter their size).
+            // file-size-in-kilobytes command line argument, which defaults to ~10MB.
             long fileSize = fileLength / 1024;
 
             return maxFileSize > -1 && fileSize > maxFileSize;

--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -1322,11 +1322,11 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
         private bool DoesTargetFileExceedSizeLimits(long fileLength, int maxFileSize)
         {
             // Ensure that the byte of the file does not exceed the limit set by the
-            // file-size-in-kilobytes argument (which will be -1 if not set, in which
+            // file-size-in-kilobytes argument (which will be 0 if not set, in which
             // case all files should be analyzed no matter their size).
-            long fileSize = fileLength / 1024;
+            double fileSize = (double)fileLength / 1024;
 
-            return maxFileSize > -1 && fileSize > maxFileSize;
+            return maxFileSize > 0 && fileSize > maxFileSize;
         }
     }
 }

--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -156,7 +156,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 try
                 {
                     // Ensure that the byte of the file does not exceed the limit set by the
-                    // file-size-in-kilobytes argument (which will be -1 if not set, in which
+                    // file-size-in-kilobytes argument (which will be 0 if not set, in which
                     // case all files should be analyzed no matter their size).
                     long fileSize = _fileSystem.FileInfoLength(filePath);
                     if (DoesTargetFileExceedSizeLimits(fileSize, context.MaxFileSizeInKilobytes))

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/SearchSkimmerTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/SearchSkimmerTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq.Expressions;
 using System.Text;
 
 using FluentAssertions;
@@ -12,7 +11,6 @@ using FluentAssertions;
 using Microsoft.CodeAnalysis.Sarif.Driver;
 using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk;
 using Microsoft.RE2.Managed;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 
 using Moq;
 

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/SearchSkimmerTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/SearchSkimmerTests.cs
@@ -499,7 +499,10 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             int[] testCases = new int[]
             {
                 (int)uint.MinValue + 1,
-                int.MaxValue,
+                10000,
+                100000,
+                1000000,
+                1024 * 10000 - 1,
                 int.MaxValue,
             };
 


### PR DESCRIPTION
Initial implementation of the maximum file size value defaulted to -1 when not set, this now defaults to 0 and  has resulted in some false negatives.

## Changes
Updated `SearchSkimmer.DoesTargetFileExceedSizeLimits` to use a new default `MaxFileSizeInKilobytes` (roughly equivalent to 10MB). Expanded test coverage to prevent regression.


* [x] `ReleaseHistory.md` updated for non-trivial changes
* [x] Ensured unit tests can now detect regressions related to default `maxFileSize`
