### PR TITLE
Creating stable references of RE2 and Strings.Interop when packing binaries

### DIFF
--- a/Src/Plugins/Security/Security.csproj
+++ b/Src/Plugins/Security/Security.csproj
@@ -38,7 +38,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\RE2.Managed\RE2.Managed.csproj" />
     <ProjectReference Include="..\..\Sarif.PatternMatcher.Sdk\Sarif.PatternMatcher.Sdk.csproj" />
   </ItemGroup>
 

--- a/Src/ReleaseHistory.md
+++ b/Src/ReleaseHistory.md
@@ -5,6 +5,7 @@
 - Update `sarif-sdk` submodule to commit [24c773bf194100d11c896ce67581832428304a35](https://github.com/microsoft/sarif-sdk/tree/24c773bf194100d11c896ce67581832428304a35), which corresponds to the NuGet `Sarif.Sdk` 3.0.0-beta1 package release.
 - BUG: Resolve `OutofMemoryException` and `NullReferenceException' failures resulting from a failure to honor file size scan limits set by `--file-size-in-kb` argument and updated Sarif.Sdk submodule to commit [ce8c5cb12d29aa407d0bf98f5fa2c764ec7fb65b](https://github.com/microsoft/sarif-sdk/commit/ce8c5cb12d29aa407d0bf98f5fa2c764ec7fb65b). [#621](https://github.com/microsoft/sarif-pattern-matcher/pull/621)
 - BUG: Resolve SAL Modernization Plugin capture group showing incorrect region properties in SARIF. [#626](https://github.com/microsoft/sarif-pattern-matcher/pull/626)
+- SDK: Sarif.PatternMatcher projects will start using a fixed version of `RE2.Managed` and `Strings.Interop`. [#638](https://github.com/microsoft/sarif-pattern-matcher/pull/638)
 
 ## *v1.10.0*
 

--- a/Src/Sarif.PatternMatcher.Sdk/Sarif.PatternMatcher.Sdk.csproj
+++ b/Src/Sarif.PatternMatcher.Sdk/Sarif.PatternMatcher.Sdk.csproj
@@ -14,7 +14,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\RE2.Managed\RE2.Managed.csproj" />
+    <ProjectReference Include="..\RE2.Managed\RE2.Managed.csproj" Condition="'$(Configuration)'=='Debug'" />
     <ProjectReference Include="..\sarif-sdk\src\Sarif\Sarif.csproj" />
+    
+    <PackageReference Include="RE2.Managed" Version="1.10.0" Condition="'$(Configuration)'=='Release'" />
   </ItemGroup>
 </Project>

--- a/Src/Sarif.PatternMatcher/Sarif.PatternMatcher.csproj
+++ b/Src/Sarif.PatternMatcher/Sarif.PatternMatcher.csproj
@@ -11,14 +11,17 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+
+    <PackageReference Include="RE2.Managed" Version="1.10.0" Condition="'$(Configuration)'=='Release'" />
+    <PackageReference Include="Strings.Interop" Version="1.10.0" Condition="'$(Configuration)'=='Release'" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\RE2.Managed\RE2.Managed.csproj" />
+    <ProjectReference Include="..\RE2.Managed\RE2.Managed.csproj" Condition="'$(Configuration)'=='Debug'" />
     <ProjectReference Include="..\sarif-sdk\src\Sarif.Driver\Sarif.Driver.csproj" />
     <ProjectReference Include="..\sarif-sdk\src\Sarif\Sarif.csproj" />
     <ProjectReference Include="..\Sarif.PatternMatcher.Sdk\Sarif.PatternMatcher.Sdk.csproj" />
-    <ProjectReference Include="..\Strings.Interop\Strings.Interop.csproj" />
+    <ProjectReference Include="..\Strings.Interop\Strings.Interop.csproj" Condition="'$(Configuration)'=='Debug'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Changes

This change will allow us to create packages using stable versions that we already released.

Current behavior: Every new package requires a new version of RE2 and Strings.Interop.
<img width="260" alt="image" src="https://user-images.githubusercontent.com/16199012/185958689-1de0bb02-a829-4621-a315-ae126685e0c3.png">

New behavior: Every new package will require version 1.10, which is the last version that we released.
<img width="254" alt="image" src="https://user-images.githubusercontent.com/16199012/185955661-9847e384-59cb-42c6-9a65-07e8ec5e67db.png">

## Why do we need this change?

To be able to run this tool and the legacy version side by side, both tools need to use the same references. We cannot have a moving reference because it will generate an exception when loading the second binary (FileNotFound due to binary version mismatch).

## How do we test?

Referencing the old style and testing the new style of the package to see if everything works.