### PR TITLE
Updating codeql to v2

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,7 @@ jobs:
       uses: microsoft/setup-msbuild@v1.0.2
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: csharp
 
@@ -45,4 +45,4 @@ jobs:
         .\BuildAndTest.cmd -NoFormat -NoTest
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
## Changes

Updating CodeQL Action from v1 to v2.

## Why?

- Sometimes, CodeQL is throwing exceptions
- CodeQL Action v1 will be deprecated on December 7th, 2022.
