### PR TITLE
Aligning package reference

### DIFF
--- a/Src/Plugins/Tests.Security/EndToEndTests.cs
+++ b/Src/Plugins/Tests.Security/EndToEndTests.cs
@@ -104,8 +104,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                 {
                     TargetUri = new Uri(filePath, UriKind.Absolute),
                     FileContents = logContents,
-                    Logger = logger,
-                    MaxFileSizeInKilobytes = 1024,
+                    Logger = logger
                 };
 
                 using (context)

--- a/Src/ReleaseHistory.md
+++ b/Src/ReleaseHistory.md
@@ -8,7 +8,7 @@
 - SDK: Sarif.PatternMatcher projects will start using a fixed version of `RE2.Managed` and `Strings.Interop`. [#638](https://github.com/microsoft/sarif-pattern-matcher/pull/638)
 - Bump Microsoft.Security.Utilities from 1.1.0 to 1.3.0. [#642](https://github.com/microsoft/sarif-pattern-matcher/pull/642)
 - BUG: Fix false negative when `SearchSkimmer` is invoked directly and `MaxFileSizeInKilobytes` is not set. This will now default to approximately 10MB. [#637](https://github.com/microsoft/sarif-pattern-matcher/pull/637)
-- Dependency alignment of `Newtonsoft.Json` to 12.0.3. [#644](https://github.com/microsoft/sarif-pattern-matcher/pull/644)
+- BUG: Loosen `Newtonsoft.Json` minimum version requirement to 12.0.3 for `Sarif.PatternMatcher` project. [#644](https://github.com/microsoft/sarif-pattern-matcher/pull/644)
 
 ## *v1.10.0*
 

--- a/Src/ReleaseHistory.md
+++ b/Src/ReleaseHistory.md
@@ -8,6 +8,7 @@
 - SDK: Sarif.PatternMatcher projects will start using a fixed version of `RE2.Managed` and `Strings.Interop`. [#638](https://github.com/microsoft/sarif-pattern-matcher/pull/638)
 - Bump Microsoft.Security.Utilities from 1.1.0 to 1.3.0. [#642](https://github.com/microsoft/sarif-pattern-matcher/pull/642)
 - BUG: Fix false negative when `SearchSkimmer` is invoked directly and `MaxFileSizeInKilobytes` is not set. This will now default to approximately 10MB. [#637](https://github.com/microsoft/sarif-pattern-matcher/pull/637)
+- Dependency alignment of `Newtonsoft.Json` to 12.0.3. [#644](https://github.com/microsoft/sarif-pattern-matcher/pull/644)
 
 ## *v1.10.0*
 

--- a/Src/Sarif.PatternMatcher.Cli/Sarif.PatternMatcher.Cli.csproj
+++ b/Src/Sarif.PatternMatcher.Cli/Sarif.PatternMatcher.Cli.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.5" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Data.SqlClient" Version="4.7.0" />
   </ItemGroup>
 

--- a/Src/Sarif.PatternMatcher.Sdk/Sarif.PatternMatcher.Sdk.csproj
+++ b/Src/Sarif.PatternMatcher.Sdk/Sarif.PatternMatcher.Sdk.csproj
@@ -14,9 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\RE2.Managed\RE2.Managed.csproj" Condition="'$(Configuration)'=='Debug'" />
     <ProjectReference Include="..\sarif-sdk\src\Sarif\Sarif.csproj" />
     
-    <PackageReference Include="RE2.Managed" Version="1.10.0" Condition="'$(Configuration)'=='Release'" />
+    <PackageReference Include="RE2.Managed" Version="1.10.0" />
   </ItemGroup>
 </Project>

--- a/Src/Sarif.PatternMatcher/Sarif.PatternMatcher.csproj
+++ b/Src/Sarif.PatternMatcher/Sarif.PatternMatcher.csproj
@@ -10,18 +10,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
 
-    <PackageReference Include="RE2.Managed" Version="1.10.0" Condition="'$(Configuration)'=='Release'" />
-    <PackageReference Include="Strings.Interop" Version="1.10.0" Condition="'$(Configuration)'=='Release'" />
+    <PackageReference Include="RE2.Managed" Version="1.10.0" />
+    <PackageReference Include="Strings.Interop" Version="1.10.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\RE2.Managed\RE2.Managed.csproj" Condition="'$(Configuration)'=='Debug'" />
     <ProjectReference Include="..\sarif-sdk\src\Sarif.Driver\Sarif.Driver.csproj" />
     <ProjectReference Include="..\sarif-sdk\src\Sarif\Sarif.csproj" />
     <ProjectReference Include="..\Sarif.PatternMatcher.Sdk\Sarif.PatternMatcher.Sdk.csproj" />
-    <ProjectReference Include="..\Strings.Interop\Strings.Interop.csproj" Condition="'$(Configuration)'=='Debug'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Changes

This change will align the newtonsoft.json package to be the same as internal references.
Consumers of the library must use a more secure version (13.0.1).

It also changes the Sarif.PatternMatcher projects to depend on RE2.Managed/Strings.Interop package to prevent some warnings when building in the cmd/vs.