### PR TITLE
Loosen probing logic to look for files directly alongside client exe.

### DIFF
--- a/Src/ReleaseHistory.md
+++ b/Src/ReleaseHistory.md
@@ -2,6 +2,7 @@
 
 ## *2.0.0-dev*
 
+- Update search definitions probing logic to look for file alongside the client tool.
 - Update `sarif-sdk` submodule to commit [24c773bf194100d11c896ce67581832428304a35](https://github.com/microsoft/sarif-sdk/tree/24c773bf194100d11c896ce67581832428304a35), which corresponds to the NuGet `Sarif.Sdk` 3.0.0-beta1 package release.
 - BUG: Resolve `OutofMemoryException` and `NullReferenceException' failures resulting from a failure to honor file size scan limits set by `--file-size-in-kb` argument and updated Sarif.Sdk submodule to commit [ce8c5cb12d29aa407d0bf98f5fa2c764ec7fb65b](https://github.com/microsoft/sarif-sdk/commit/ce8c5cb12d29aa407d0bf98f5fa2c764ec7fb65b). [#621](https://github.com/microsoft/sarif-pattern-matcher/pull/621)
 - BUG: Resolve SAL Modernization Plugin capture group showing incorrect region properties in SARIF. [#626](https://github.com/microsoft/sarif-pattern-matcher/pull/626)

--- a/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
@@ -33,9 +33,23 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
             var skimmers = new HashSet<Skimmer<AnalyzeContext>>();
 
-            // TODO exception handling for bad search definitions files
-            foreach (string searchDefinitionsPath in searchDefinitionsPaths)
+            foreach (string inputSearchDefinitionsPath in searchDefinitionsPaths)
             {
+                string searchDefinitionsPath = inputSearchDefinitionsPath;
+
+                if (!fileSystem.FileExists(searchDefinitionsPath))
+                {
+                    string coreToolDirectory = typeof(AnalyzeContext).Assembly.Location;
+                    coreToolDirectory = Path.GetDirectoryName(coreToolDirectory);
+                    searchDefinitionsPath = Path.GetFileName(searchDefinitionsPath);
+                    searchDefinitionsPath = Path.Combine(coreToolDirectory, searchDefinitionsPath);
+
+                    if (!fileSystem.FileExists(searchDefinitionsPath))
+                    {
+                        throw new ArgumentException($"Could not locate specified definitions path: '{inputSearchDefinitionsPath}'");
+                    }
+                }
+
                 string searchDefinitionsText =
                     fileSystem.FileReadAllText(searchDefinitionsPath);
 

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/AnalyzeCommandTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/AnalyzeCommandTests.cs
@@ -90,11 +90,11 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 var mockFileSystem = new Mock<IFileSystem>();
 
                 mockFileSystem
-                    .Setup(x => x.FileReadAllText(expectedProbingPath)).Returns("{}")
-                    .Callback((string path) => { consultedPath = path; });
+                    .Setup(x => x.FileExists(expectedProbingPath)).Returns(true);
 
                 mockFileSystem
-                    .Setup(x => x.FileExists(expectedProbingPath)).Returns(true);
+                    .Setup(x => x.FileReadAllText(expectedProbingPath)).Returns("{}")
+                    .Callback((string path) => { consultedPath = path; });
 
                 // Acquire skimmers for searchers
                 ISet<Skimmer<AnalyzeContext>> skimmers = PatternMatcher.AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(
@@ -144,6 +144,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             var testLogger = new TestLogger();
 
             var mockFileSystem = new Mock<IFileSystem>();
+            mockFileSystem.Setup(x => x.FileExists(searchDefinitionsPath)).Returns(true);
             mockFileSystem.Setup(x => x.FileReadAllText(searchDefinitionsPath)).Returns(definitionsText);
 
             // Acquire skimmers for searchers
@@ -211,6 +212,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             var testLogger = new TestLogger();
 
             var mockFileSystem = new Mock<IFileSystem>();
+            mockFileSystem.Setup(x => x.FileExists(searchDefinitionsPath)).Returns(true);
             mockFileSystem.Setup(x => x.FileReadAllText(searchDefinitionsPath)).Returns(definitionsText);
 
             // Acquire skimmers for searchers
@@ -445,6 +447,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             var testLogger = new TestLogger();
 
             var mockFileSystem = new Mock<IFileSystem>();
+            mockFileSystem.Setup(x => x.FileExists(searchDefinitionsPath)).Returns(true);
             mockFileSystem.Setup(x => x.FileReadAllText(searchDefinitionsPath)).Returns(definitionsText);
 
             // Acquire skimmers for searchers
@@ -519,6 +522,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             var testLogger = new TestLogger();
 
             var mockFileSystem = new Mock<IFileSystem>();
+            mockFileSystem.Setup(x => x.FileExists(searchDefinitionsPath)).Returns(true);
             mockFileSystem.Setup(x => x.FileReadAllText(searchDefinitionsPath)).Returns(definitionsText);
 
             // Acquire skimmers for searchers
@@ -580,6 +584,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             var testLogger = new TestLogger();
 
             var mockFileSystem = new Mock<IFileSystem>();
+            mockFileSystem.Setup(x => x.FileExists(searchDefinitionsPath)).Returns(true);
             mockFileSystem.Setup(x => x.FileReadAllText(searchDefinitionsPath)).Returns(definitionsText);
 
             // Acquire skimmers for searchers


### PR DESCRIPTION
We now look for any definitions file, by name, in the binary execution directory.

@cfaucon 