### PR TITLE
Add base64-encoding helper to assist with certain credential FP elimination.

### DIFF
--- a/Src/Sarif.PatternMatcher.Sdk/StaticValidatorBase.cs
+++ b/Src/Sarif.PatternMatcher.Sdk/StaticValidatorBase.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk
                     continue;
                 }
 
-                string fingerprintText = $"{validationResult.Fingerprint.ToString()}";
+                string fingerprintText = $"{validationResult.Fingerprint}";
 
                 if (perFileFingerprintCache.Contains(fingerprintText))
                 {

--- a/Src/Sarif.PatternMatcher.Sdk/StaticValidatorBase.cs
+++ b/Src/Sarif.PatternMatcher.Sdk/StaticValidatorBase.cs
@@ -70,5 +70,16 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk
         ///
         /// <returns>Return an enumerable ValidationResult collection.</returns>
         protected abstract IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups);
+
+        /// <summary>
+        /// Evaluates secret to determine whether is a false positive or if it perhaps
+        /// is a true positive but one that belongs to another security model.
+        /// </summary>
+        /// <param name="secret">Text for a secret to be evaluated for accuracy and associated with current security model.</param>
+        /// <returns>'True' if the secret should be excluded from current analysis, otheriwise 'false'.</returns>
+        protected virtual bool IsFalsePositiveOrBelongsToOtherSecurityModel(string secret)
+        {
+            return false;
+        }
     }
 }

--- a/Src/Sarif.PatternMatcher.Sdk/ValidatorBase.cs
+++ b/Src/Sarif.PatternMatcher.Sdk/ValidatorBase.cs
@@ -90,6 +90,34 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk
         /// </summary>
         protected IDictionary<Fingerprint, Tuple<ValidationState, ResultLevelKind, string>> FingerprintToResultCache { get; }
 
+        public static bool IsBase64EncodingOfPrintableCharacters(string secret)
+        {
+            byte[] secretBytes = null;
+
+            try
+            {
+                secretBytes = Convert.FromBase64String(secret);
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+
+            foreach (byte secretByte in secretBytes)
+            {
+                // https://www.asciihex.com/ascii-printable-characters
+
+                int byteValue = Convert.ToInt32(secretByte);
+
+                if (byteValue < 32 || byteValue > 126)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
         public static bool ContainsDigitAndChar(string matchedPattern)
         {
             bool oneDigit = false, oneLetter = false;

--- a/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
@@ -37,6 +37,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             {
                 string searchDefinitionsPath = Path.GetFullPath(inputSearchDefinitionsPath);
 
+                // INTERESTING BREAKPOINT: debugging definitions JSON load/other failures.
+                // Set conditional breakpoint on 'searchDefinitionsPath' to narrow focus.
+
                 if (!fileSystem.FileExists(searchDefinitionsPath))
                 {
                     throw new ArgumentException($"Could not locate specified definitions path: '{searchDefinitionsPath}'");

--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -787,6 +787,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             {
                 string contentsRegex = matchExpression.IntrafileRegexes[i];
 
+                Debug.Assert(!contentsRegex.StartsWith("$"), $"Unexpanded regex variable: {contentsRegex}");
+
                 if (!_engine.Matches(contentsRegex, searchText, out List<Dictionary<string, FlexMatch>> matches))
                 {
                     if (matchExpression.IntrafileRegexMetadata[i] == RegexMetadata.Optional)

--- a/Src/Test.UnitTests.Sarif.PatternMatcher.Sdk/StaticValidatorBaseTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher.Sdk/StaticValidatorBaseTests.cs
@@ -34,11 +34,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 MaxDegreeOfParallelism = Environment.ProcessorCount * 2,
             };
 
-            var perFileFingerprintHash = new HashSet<string>();
-
             Parallel.For(0, 100, (_) =>
             {
                 Interlocked.Increment(ref id);
+
+                // This is a thread-affinitized piece of data.
+                var perFileFingerprintHash = new HashSet<string>();
 
                 for (int iterations = 0; iterations < 100; iterations++)
                 {
@@ -56,6 +57,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                                 Value = Guid.NewGuid().ToString()
                             };
                     }
+
                     testStaticValidator.IsValidStatic(groups, perFileFingerprintHash);
                 }
             });


### PR DESCRIPTION
Introduce a new helper that prevents inadvertent match against base64-encoded strings which encode text strings rather than random sequences of bytes.

We could use a unit-test for this. Anyone want to jump in?