### PR TITLE
Update status codes to convert 'forbidden' to unauthorized.

### DIFF
--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_044.NpmCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_044.NpmCredentialsValidator.cs
@@ -125,6 +125,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                         return ReturnAuthorizedAccess(ref message, host, account: id);
                     }
 
+                    case HttpStatusCode.Forbidden:
                     case HttpStatusCode.Unauthorized:
                     {
                         return ReturnUnauthorizedAccess(ref message, host, account: id);


### PR DESCRIPTION
@HulonJenkins @marmegh 

A simple change to handle the transient condition of returning 'forbidden' from the NPM credentials check.

Observed empirically. Someone should mock this circumstance out soonish. :)