### PR TITLE
Updating spam to Sarif.PatternMatcher.Cli.

### DIFF
--- a/Src/ReleaseHistory.md
+++ b/Src/ReleaseHistory.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - BREAKING: Fix bug resulting in static validators returning `FailureLevel.Note` despite configured `FailureLevel`. [#645](https://github.com/microsoft/sarif-pattern-matcher/pull/645)
 - Update `sarif-sdk` submodule to commit [af69a1892954eb920c2a7e7b28e23effe35903c3](https://github.com/microsoft/sarif-sdk/commit/aaf69a1892954eb920c2a7e7b28e23effe35903c3), simply to keep current.
+- Update `spam` executable and dotnet library name to Sarif.PatternMatcher.Cli.
 
 ## *2.0.0-dev*
 - Update `sarif-sdk` submodule to commit [24c773bf194100d11c896ce67581832428304a35](https://github.com/microsoft/sarif-sdk/commit/24c773bf194100d11c896ce67581832428304a35), which applies `FileRegionsCache` fixes (from an unreleased version of the SDK).

--- a/Src/Sarif.PatternMatcher.Cli/Sarif.PatternMatcher.Cli.csproj
+++ b/Src/Sarif.PatternMatcher.Cli/Sarif.PatternMatcher.Cli.csproj
@@ -5,8 +5,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <ToolCommandName>spam</ToolCommandName>
-    <AssemblyName>spam</AssemblyName>
+    <ToolCommandName>Sarif.PatternMatcher.Cli</ToolCommandName>
+    <AssemblyName>Sarif.PatternMatcher.Cli</AssemblyName>
     <RootNamespace>$(RootNamespaceBase).Sarif.PatternMatcher.Cli</RootNamespace>
     <PackAsTool>true</PackAsTool>
   </PropertyGroup>


### PR DESCRIPTION
## Changes

Updating the executable and dotnet library name of the cli from spam to Sarif.PatternMatcher.Cli.


