### PR TITLE
Add Timing Metric Testing

### DIFF
--- a/Src/Sarif.PatternMatcher.Cli/Program.cs
+++ b/Src/Sarif.PatternMatcher.Cli/Program.cs
@@ -54,6 +54,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
                 ExportSearchDefinitionsOptions,
                 ImportAndAnalyzeOptions,
                 StressOptions,
+                TimingOptions,
                 ValidateOptions>(args)
               .MapResult(
                 (AnalyzeOptions options) => RunAnalyzeCommand(options),
@@ -62,6 +63,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
                 (ExportSearchDefinitionsOptions options) => new ExportSearchDefinitionsCommand().Run(options),
                 (ImportAndAnalyzeOptions options) => new ImportAndAnalyzeCommand().Run(options),
                 (StressOptions options) => new StressCommand().Run(options),
+                (TimingOptions options) => new TimingCommand().Run(options),
                 (ValidateOptions options) => new ValidateCommand().Run(options),
                 _ => isValidHelpCommand || isVersionCommand
                         ? CommandBase.SUCCESS

--- a/Src/Sarif.PatternMatcher.Cli/TimingCommand.cs
+++ b/Src/Sarif.PatternMatcher.Cli/TimingCommand.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+
+using Microsoft.CodeAnalysis.Sarif.Driver;
+using Microsoft.CodeAnalysis.Sarif.Multitool;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
+{
+    internal class TimingCommand : CommandBase
+    {
+        private static int filesScanned = 0;
+        private readonly List<Tuple<string, long, long>> fileDataTupleList = new List<Tuple<string, long, long>>();
+        private readonly IFileSystem fileSystem = Sarif.FileSystem.Instance;
+
+        public int Run(TimingOptions options)
+        {
+            Console.WriteLine("Starting Timing Tests!");
+
+            List<string> filesToSearch = GetWhatFilesToSearch(options);
+
+            ISet<Skimmer<AnalyzeContext>> skimmers = AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(fileSystem, options.SearchDefinitionsPaths);
+
+            foreach (string filePath in filesToSearch)
+            {
+                Console.WriteLine($"Scanning file: {filesScanned} of {filesToSearch.Count}");
+                TimeScanFileWithSkimmers(filePath, skimmers);
+                filesScanned++;
+            }
+
+            ExportSizeAndExecutionTime();
+            return SUCCESS;
+        }
+
+        public void ExportSizeAndExecutionTime()
+        {
+            // output Tuple list to csv in 3 columns
+            var sb = new StringBuilder($"Filename, File Size in KB, Runtime in ms{Environment.NewLine}");
+
+            foreach (Tuple<string, long, long> runData in fileDataTupleList)
+            {
+                sb.AppendLine($"{runData.Item1}, {runData.Item2}, {runData.Item3}");
+            }
+
+            File.WriteAllText("C:\\Users\\hulonjenkins\\OneDrive - Microsoft\\Documents\\HulonDesk\\FileSizeToRuntimeData.csv", sb.ToString());
+        }
+
+        private List<string> GetWhatFilesToSearch(TimingOptions options)
+        {
+            // Get a list of files to search
+            IEnumerable<string> folderToSearch = options.TargetFileSpecifiers;
+            var filesToSearch = new List<string>();
+            foreach (string folder in folderToSearch)
+            {
+                filesToSearch.AddRange(Directory.GetFiles(folder, "*", SearchOption.AllDirectories).ToList<string>());
+            }
+
+            return filesToSearch;
+        }
+
+        private void TimeScanFileWithSkimmers(string filePath, ISet<Skimmer<AnalyzeContext>> skimmers)
+        {
+            string resourceContent = fileSystem.FileReadAllText(filePath);
+            long fileSizeInBytes = fileSystem.FileInfoLength(filePath);
+
+            var timer = new Stopwatch();
+            timer.Start();
+
+            // Critical Section Being Timed
+            {
+                var logger = new AdoLogger();
+
+                // Set up Context
+                var context = new AnalyzeContext
+                {
+                    TargetUri = new Uri(filePath, UriKind.RelativeOrAbsolute),
+                    FileContents = resourceContent,
+                    Logger = logger,
+                    FileRegionsCache = new FileRegionsCache(),
+                };
+
+                var disabledSkimmers = new HashSet<string>();
+                IEnumerable<Skimmer<AnalyzeContext>> applicableSkimmers = AnalyzeCommand.DetermineApplicabilityForTargetHelper(context, skimmers, disabledSkimmers);
+
+                logger.AnalysisStarted();
+
+                // Run analyze
+                using (context)
+                {
+                    AnalyzeCommand.AnalyzeTargetHelper(context, applicableSkimmers, disabledSkimmers: new HashSet<string>());
+                }
+                logger.AnalysisStopped(RuntimeConditions.None);
+            }
+
+            timer.Stop();
+            fileDataTupleList.Add(Tuple.Create(filePath.Replace(',', ';'), fileSystem.FileInfoLength(filePath) / 1024, timer.ElapsedMilliseconds));
+        }
+    }
+}

--- a/Src/Sarif.PatternMatcher.Cli/TimingOption.cs
+++ b/Src/Sarif.PatternMatcher.Cli/TimingOption.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+using CommandLine;
+
+using Microsoft.CodeAnalysis.Sarif.Driver;
+
+namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
+{
+    [Verb("timing", HelpText = "Run timing tests")]
+    internal class TimingOptions : CommonOptionsBase
+    {
+        [Value(0,
+               HelpText = "One or more specifiers to a file, directory, or filter pattern that resolves to one or more binaries to analyze.")]
+        public IEnumerable<string> TargetFileSpecifiers { get; set; }
+
+        [Option(
+            'd',
+            "search-definitions",
+            Separator = ';',
+            Required = true,
+            HelpText = "A path to a file containing one or more search definitions to drive analysis.")]
+        public IEnumerable<string> SearchDefinitionsPaths { get; set; }
+
+        public long MaxMemoryInKilobytes { get; internal set; }
+    }
+}


### PR DESCRIPTION
## Changes

Added Timing Metrics
For debugging purposes, used the following as my command line arguments in Launch Profiles
_timing
"C:\Users\hulonjenkins\OneDrive - Microsoft\Documents\HulonDesk\EddyFiles"
"C:\Repos\SpmiScanning"
-d 
"C:\Repos\Spmi\src\Plugins\Security.PushProtection\SEC101.SecurePlaintextSecretsPushProtection.json;C:\Repos\Spmi\src\Plugins\Security.PushProtection\SEC101.SecurePlaintextSecretsPushProtectionInternal.json"_