### PR TITLE
RE2.Managed & Strings.Interop Package -> Project References.

### DIFF
--- a/Src/Sarif.PatternMatcher.Sdk/Sarif.PatternMatcher.Sdk.csproj
+++ b/Src/Sarif.PatternMatcher.Sdk/Sarif.PatternMatcher.Sdk.csproj
@@ -14,8 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\RE2.Managed\RE2.Managed.csproj" />
     <ProjectReference Include="..\sarif-sdk\src\Sarif\Sarif.csproj" />
-    
-    <PackageReference Include="RE2.Managed" Version="1.10.0" />
   </ItemGroup>
 </Project>

--- a/Src/Sarif.PatternMatcher/Sarif.PatternMatcher.csproj
+++ b/Src/Sarif.PatternMatcher/Sarif.PatternMatcher.csproj
@@ -11,15 +11,14 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-
-    <PackageReference Include="RE2.Managed" Version="1.10.0" />
-    <PackageReference Include="Strings.Interop" Version="1.10.0" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\RE2.Managed\RE2.Managed.csproj" />
     <ProjectReference Include="..\sarif-sdk\src\Sarif.Driver\Sarif.Driver.csproj" />
     <ProjectReference Include="..\sarif-sdk\src\Sarif\Sarif.csproj" />
     <ProjectReference Include="..\Sarif.PatternMatcher.Sdk\Sarif.PatternMatcher.Sdk.csproj" />
+    <ProjectReference Include="..\Strings.Interop\Strings.Interop.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Changes
Swapped RE2.Managed from Package Reference to Project Reference.
Swapped Strings.Interop from Package Reference to Project Reference.

We had the projects but were using NuGet packages instead. Removed the NuGet packages and added reference to projects.