### PR TITLE
Create cache for UTF8/16 index map when invoking patterns with groups.

### DIFF
--- a/Src/RE2.Managed/RE2Regex.cs
+++ b/Src/RE2.Managed/RE2Regex.cs
@@ -47,9 +47,19 @@ namespace Microsoft.RE2.Managed
             }
         }
 
-        public bool Matches(string pattern, string text, out List<Dictionary<string, FlexMatch>> matches, long maxMemoryInBytes = 256L * 1024L * 1024L)
+        public bool Matches(string pattern, string text, out List<Dictionary<string, FlexMatch>> matches, long maxMemoryInBytes = -1)
         {
-            return Regex2.Matches(pattern, text, out matches, maxMemoryInBytes);
+            int[] indexMap = null;
+            return Regex2.Matches(pattern, text, out matches, ref indexMap, maxMemoryInBytes);
+        }
+
+        public bool Matches(string pattern,
+                            string text,
+                            out List<Dictionary<string, FlexMatch>> matches,
+                            ref int[] indexMap,
+                            long maxMemoryInBytes = 256L * 1024L * 1024L)
+        {
+            return Regex2.Matches(pattern, text, out matches, ref indexMap, maxMemoryInBytes);
         }
 
         private FlexMatch ToFlex(Match2 match, FlexString input, ref int lastUtf8Index, ref int lastUtf16Index)

--- a/Src/RE2.Managed/Regex2.cs
+++ b/Src/RE2.Managed/Regex2.cs
@@ -191,7 +191,20 @@ namespace Microsoft.RE2.Managed
             }
         }
 
-        public static unsafe bool Matches(string pattern, string text, out List<Dictionary<string, FlexMatch>> matches, long maxMemoryInBytes)
+        public static unsafe bool Matches(string pattern,
+                                          string text,
+                                          out List<Dictionary<string, FlexMatch>> matches,
+                                          long maxMemoryInBytes)
+        {
+            int[] indexMap = null;
+            return Matches(pattern, text, out matches, ref indexMap, maxMemoryInBytes);
+        }
+
+        public static unsafe bool Matches(string pattern,
+                                          string text,
+                                          out List<Dictionary<string, FlexMatch>> matches,
+                                          ref int[] indexMap,
+                                          long maxMemoryInBytes)
         {
             ParsedRegexCache cache = null;
             try
@@ -209,7 +222,7 @@ namespace Microsoft.RE2.Managed
 
                 byte[] buffer = null;
                 var expression8 = String8.Convert(text, ref buffer);
-                int[] indexMap = GetMapOfUtf8ToUtf16ByteIndices(buffer);
+                indexMap ??= GetMapOfUtf8ToUtf16ByteIndices(buffer);
 
                 fixed (byte* textUtf8BytesPtr = expression8.Array)
                 {

--- a/Src/Sarif.PatternMatcher.Cli/StressCommand.cs
+++ b/Src/Sarif.PatternMatcher.Cli/StressCommand.cs
@@ -4,13 +4,18 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
 
 using Microsoft.CodeAnalysis.Sarif.Driver;
 using Microsoft.CodeAnalysis.Sarif.Multitool;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.RE2.Managed;
+using Microsoft.Strings.Interop;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
 {
@@ -64,6 +69,76 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
 
         public int Run(StressOptions options)
         {
+            switch (options.Scenario)
+            {
+                case StressScenario.Statelessness:
+                {
+                    RunStatelessStressScenario(options);
+                    break;
+                }
+
+                case StressScenario.RE2Timing:
+                {
+                    RunRE2TimingScenario(options);
+                    break;
+                }
+            }
+
+            return SUCCESS;
+        }
+
+        private void RunRE2TimingScenario(StressOptions options)
+        {
+            string filePath = options.InputFilePath;
+
+            FlexString resourceContent = File.ReadAllText(filePath);
+
+            var regexList = new List<string> { "a", "abc", "hulonhulonhulon", "(?:^|[^0-9A-Za-z_])(ghp_[\\w]{36})(?:[^0-9A-Za-z_]|$)", "(?P<secret>a)", "(?P<secret>abc)", "(?P<secret>hulonhulonhulon)", "(?:^|[^0-9A-Za-z_])(?P<secret>ghp_[\\w]{36})(?:[^0-9A-Za-z_]|$)" };
+
+            var sb = new StringBuilder();
+
+            int iterations = options.Iterations;
+
+            int[] indexMap = null;
+            foreach (string regex in regexList)
+            {
+                // Current Match
+                var currentRegexSW = Stopwatch.StartNew();
+
+                // Call from line 969 of SearchSkimmers.cs
+                int matchesCount = 0;
+                for (int i = 0; i < iterations; i++)
+                {
+                    ((RE2Regex)RE2Regex.Instance).Matches(regex, resourceContent, out List<Dictionary<string, FlexMatch>> matches, ref indexMap, -1);
+                    matchesCount = matches.Count;
+                }
+
+                currentRegexSW.Stop();
+
+                // Legacy Match
+                var legacyRegexSW = Stopwatch.StartNew();
+
+                // call from line 642 of PatternMatcher.cs
+
+                int legacyMatchesCount = 0;
+                for (int i = 0; i < iterations; i++)
+                {
+                    legacyMatchesCount = 0;
+                    foreach (FlexMatch match in RE2Regex.Instance.Matches(resourceContent, regex, RegexDefaults.DefaultOptionsCaseSensitive))
+                    {
+                        legacyMatchesCount++;
+                    }
+                }
+
+                legacyRegexSW.Stop();
+                sb.AppendLine($"For regex: \"{regex}\", Legacy: {legacyRegexSW.ElapsedMilliseconds}ms, matches: {legacyMatchesCount} \tCurrent: {currentRegexSW.ElapsedMilliseconds}ms, matches: {matchesCount}");
+            }
+
+            Console.WriteLine(sb.ToString());
+        }
+
+        private void RunStatelessStressScenario(StressOptions options)
+        {
             IFileSystem fileSystem = Sarif.FileSystem.Instance;
             s_configurationFiles = new string[] { options.InputFilePath };
             ISet<Skimmer<AnalyzeContext>> skimmers = AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(fileSystem, s_configurationFiles);
@@ -102,8 +177,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
                     skimmers = null;
                 }
             }
-
-            return SUCCESS;
         }
 
         private readonly string TestContents = "dXNpbmcgU3lzdGVtOwp1c2luZyBTeXN0ZW0uQ29sbGVjdGlvbnMuR2VuZXJpYzsKCm5hbWVzcGFjZSBNaWNyb3NvZnQuQ29kZUFuYWx5c2lzLlNhcmlmLlBhdHRlcm5NYXRjaGVyLlRlc3QKewogICAgLy8vIDxzdW1tYXJ5PgogICAgLy8vIFRoaXMgY2xhc3MgY29udGFpbnMgcHJlYWxsb2NhdGVkIGtleXMgZm9yIHRlc3RpbmcuIEV2ZXJ5IGtleSBtdXN0IGJlIHByZWZpeGVkCiAgICAvLy8gd2l0aCB0aGUgbmFtZSBvZiB0aGUgc2VjcmV0IGtpbmQgKHdoaWNoIGl0c2VsZiBpcyB0aGUgcHJlZml4IGZvciBldmVyeSB2YWxpZGF0b3IpLgogICAgLy8vIDwvc3VtbWFyeT4KICAgIGludGVybmFsIGNsYXNzIFByZWFsbG9jYXRlZElkZW50aWZhYmxlVGVzdFNlY3JldHMKICAgIHsKICAgICAgICBwdWJsaWMgY29uc3Qgc3RyaW5nIEFkb1BhdCA9ICJteGk0Y28ya2RsbHlpYWUzaXdtNTc0NXBhcjI0MnFzZGJhd25rYWxxb3pibHJkcDJpenBxIjsKCiAgICAgICAgLy8gVGhlIEF6dXJlIENhY2hlIGdlbmVyYXRlZCB0b2tlbnMgaGF2ZSBhbiBvZGQgYmVoYXZpb3JzLCB3aGljaCBpcyB0byBlbGltaW5hdGUgc3BlY2lhbCBjaGFyYWN0ZXJzCiAgICAgICAgLy8gZnJvbSB0b2tlbnMgYnkgcmVwbGFjaW5nIHRoZW0gd2l0aCAnUCcgKGZvciB0aGUgcGx1cyBzaWduKSBhbmQgJ1MnIGZvciB0aGUgZm9yd2FyZCBzbGFzaC4gVGhpcwogICAgICAgIC8vIGFwcHJvYWNoIHdhcyB0YWtlbiB0byBoZWxwIG1pbmltaXplIGNoYW5nZXMgdG8gdGhlIHJlc291cmNlIHByb3ZpZGVyIGNvZGUuIEEgYmV0dGVyIGFwcHJvYWNoIHdvdWxkCiAgICAgICAgLy8gaGF2ZSBiZWVuIHRvIHNpbXBseSBnZW5lcmF0ZSBrZXlzIHVudGlsIHRoZSBBUEkgcHJvZHVjZWQgYSB0b2tlbiB3aXRoIG5vIGZvcmJpZGRlbiBjaGFycyBpbiB0aGUKICAgICAgICAvLyBjaGVja3N1bS4gVGhpcyBhcHByb2FjaCB3YXMgdGFrZW4gaW4gbGF0ZXIgcmVzb3VyY2UgcHJvdmlkZXJzIChBQ1Igd2FzIGEgdmVyeSBlYXJseSBpbXBsZW1lbnRhdGlvbikuCiAgICAgICAgcHVibGljIGNvbnN0IHN0cmluZyBBenVyZUNhY2hlRm9yUmVkaXNJZGVudGlmaWFibGVLZXkgPSAiY1RoSVlMQ0Q2SDdMcldyTkhRanhoYVNCdTQyS2VTekdsQXpDYU5RSlhkQT0iOwogICAgICAgIHB1YmxpYyBjb25zdCBzdHJpbmcgQXp1cmVDYWNoZUZvclJlZGlzSW50ZXJuYWxJZGVudGlmaWFibGVLZXkgPSAiZmJRcVN1MjE2TXZ3TmFxdVNxcEk4TVYwaHFsVVBnR0NoT1kxOWRjOXhEUk1BekNhaXhDWWJRIjsKICAgICAgICBwdWJsaWMgY29uc3Qgc3RyaW5nIEF6dXJlQ2FjaGVGb3JSZWRpc0lkZW50aWZpYWJsZUtleUNoZWNrc3VtSGFzU2xhc2ggPSAickt5QmNqdG14dzBVT0wyV2c3elVHYVViN1RlcWxpSzhhQXpDYU00RjRiTT0iOwogICAgICAgIHB1YmxpYyBjb25zdCBzdHJpbmcgQXp1cmVDYWNoZUZvclJlZGlzSWRlbnRpZmlhYmxlS2V5Q2hlY2tzdW1IYXNQbHVzU2lnbiA9ICJaNzdnSEJrYXpWUkZ1ZHR1S3VzUFd1TE1ONzdKdTJPVUtBekNhTFBRTnN3PSI7CgogICAgICAgIHB1YmxpYyBjb25zdCBzdHJpbmcgQWFkQ2xpZW50QXBwSWRlbnRpZmlhYmxlQ3JlZGVudGlhbHNMZWdhY3kgID0gIjVZOTdRfmsxZ2ZzRlVhSS5salplTHpNR2Q0OEVibDc3VkVjNXYiOwogICAgICAgIHB1YmxpYyBjb25zdCBzdHJpbmcgQWFkQ2xpZW50QXBwSWRlbnRpZmlhYmxlQ3JlZGVudGlhbHNDdXJyZW50ID0gIkEwNDhRfmc2LU4tMDZfMS0xfmY2LjktN004MV84ZHUwLm9+X09jVS4iOwoKICAgICAgICBwdWJsaWMgY29uc3Qgc3RyaW5nIEF6dXJlQ29zbW9zREJJZGVudGlmaWFibGVLZXlQcmltYXJ5TWFzdGVyS2V5ID0gInp1N3Y2VlljcFJPa08xaXBHQUVpcm9Oc2M0R0xCMDdIZkxYZzRzQTlSOFI4Q0pPZzRrWjJNcjgzUGQyRzRYemZwTWo3d1J2aGh6YnNBQ0RicDlCMmp3PT0iOwogICAgICAgIHB1YmxpYyBjb25zdCBzdHJpbmcgQXp1cmVDb3Ntb3NEQklkZW50aWZpYWJsZUtleVNlY29uZGFyeU1hc3RlcktleSA9ICJnR2lpcW1pOE43QW00U3lPdUN0NDNQVVdkSnN3YnBiVXZEQjRod3lDZzBaTVZ4VUJaYlFRbE12YUFWakxvdlRWWUk1STVEc0s4WTViQUNEYk44YklMdz09IjsKICAgICAgICBwdWJsaWMgY29uc3Qgc3RyaW5nIEF6dXJlQ29zbW9zREJJZGVudGlmaWFibGVLZXlQcmltYXJ5UmVhZG9ubHlNYXN0ZXJLZXkgPSAiOU9pU2FVcG9aUGJiYTAzVThmQjh1ZThBalk1SkdCT05TVjU0cmhGN3hGd3ZLSkoxUHp1N0JUY2ZzeWpreW4yRW5LWHZNZzk5V1E1VEFDRGI5MjAycWc9PSI7CiAgICAgICAgcHVibGljIGNvbnN0IHN0cmluZyBBenVyZUNvc21vc0RCSWRlbnRpZmlhYmxlS2V5U2Vjb25kYXJ5UmVhZG9ubHlNYXN0ZXJLZXkgPSAiRDMzZDdKdTdhTXpValVQTEhPaTlRMkxXNnIxWTVISXJ0YjZkeWw4Q0R2SWlaOFdBUXZ3c28yWXZ1R0t0bzJFRm9lcEFRWXZTWUFYUEFDRGJkRlpveWc9PSI7CiAgICAgICAgcHVibGljIGNvbnN0IHN0cmluZyBBenVyZUNvc21vc0RCSW50ZXJuYWxJZGVudGlmaWFibGVLZXlQcmltYXJ5U3lzdGVtS2V5QWxsID0gIkhZd3BKbDM2aVRKdGZyZlJwOWNwb1B4aUtJMVJzWEhPOUxzc3ZmalRvYU9EM2IrbW4rNjZkTHUwdjBnUmRqQ1pkcXNYWVJ4dW5GYmdBQ0RiRHBTWjVBPT0iOwogICAgICAgIHB1YmxpYyBjb25zdCBzdHJpbmcgQXp1cmVDb3Ntb3NEQkludGVybmFsSWRlbnRpZmlhYmxlS2V5U2Vjb25kYXJ5U3lzdGVtS2V5QWxsID0gIkxLOUVSbnVsTVpVbkdjNGpHQVhHRU9YQkZ3MGdOdlExMy9wWEo1TmZqYVVtVnd2M0ZsZXVuSDVWTkZnd3dTMEFTQ1ZpWStBN2xUbUdBQ0RiRjJXTTJRPT0iOwogICAgICAgIHB1YmxpYyBjb25zdCBzdHJpbmcgQXp1cmVDb3Ntb3NEQkludGVybmFsSWRlbnRpZmlhYmxlS2V5UHJpbWFyeVN5c3RlbUtleVJlYWRXcml0ZSA9ICJWd3hxejlRemtQUFdiV3VTeStVYTlQN0RETTVvakNzZU5ONmk5UGZCMFpGTnN5VWtZeGN3SWNBUEhEZi95ZUpmdnA5aE4rZDQ4Ylg5QUNEYnFvQ3I0dz09IjsKICAgICAgICBwdWJsaWMgY29uc3Qgc3RyaW5nIEF6dXJlQ29zbW9zREJJbnRlcm5hbElkZW50aWZpYWJsZUtleVNlY29uZGFyeVN5c3RlbUtleVJlYWRXcml0ZSA9ICJLd2FMWUpja0FNQ0lUU2Jnb3YzdjFBUTRRdnZaUm80aTU1c3ZSL3ljNWdhdCtQbENrWmNrSVlzNG9XM3RCdWcwZHVaM1N1ejRSa3hYQUNEYlQ3ZlZZdz09IjsKICAgICAgICBwdWJsaWMgY29uc3Qgc3RyaW5nIEF6dXJlQ29zbW9zREJJbnRlcm5hbElkZW50aWZpYWJsZUtleVByaW1hcnlTeXN0ZW1LZXlSZWFkT25seSA9ICJ3UE9aMFR1Ri9BOW1XbDI4ZlNnVURReHdhZkcvM3JXRTFIUnkvM1JRZHVxaFR4QisrZzZjNTh6VStYci95OHpMUENWb2IzSEVDWWtRQUNEYjR5bytIQT09IjsKICAgICAgICBwdWJsaWMgY29uc3Qgc3RyaW5nIEF6dXJlQ29zbW9zREJJbnRlcm5hbElkZW50aWZpYWJsZUtleVNlY29uZGFyeVN5c3RlbUtleVJlYWRPbmx5ID0gImNZM0hOZnRsajFkREkwcGxNaU02VW43a3NQYmo5VmVMWERxcTZETTNYTDgrNDVmUTM1U010cmRodEtsVytNVHJpc3lTRTZJU0pWa3BBQ0RiUVM5cFhRPT0iOwogICAgICAgIHB1YmxpYyBjb25zdCBzdHJpbmcgQXp1cmVDb3Ntb3NEQkludGVybmFsSWRlbnRpZmlhYmxlS2V5UmVzb3VyY2VLZXlTZWVkID0gInlvaVIrcUVaVm5RRjU1S09mZkRVMXZIUFZaU3dmamhjL0FDRGJDbHZhTVk9IjsKICAgICAgICBwdWJsaWMgY29uc3Qgc3RyaW5nIEF6dXJlQ29zbW9zREJJbnRlcm5hbElkZW50aWZpYWJsZUtleURhdGFFbmNyeXB0aW9uS2V5ID0gIkkwWkZCcktJaHNYTG5XenppWUJrZjUrNThmN05NeHhGekFDRGJEV3FJZmM9IjsKCiAgICAgICAgcHVibGljIGNvbnN0IHN0cmluZyBBenVyZUZ1bmN0aW9uSWRlbnRpZmlhYmxlS2V5TWFzdGVyS2V5ID0gImxLNWpYMmQ1TnNoR3JpUXg4MkVNcklFcko4dDVQdVFSZ2pwdkdYVmNPLWxGQXpGdVNyU2o2Zz09IjsKICAgICAgICBwdWJsaWMgY29uc3Qgc3RyaW5nIEF6dXJlRnVuY3Rpb25JZGVudGlmaWFibGVLZXlTeXN0ZW1LZXkgPSAiakRTdXhsSWZZYVJkY0U1ZjlRVno1LWZFdmpwY1R2bmg2TUYwSDM1dlpuRk5BekZ1TUx5ZEVBPT0iOwogICAgICAgIHB1YmxpYyBjb25zdCBzdHJpbmcgQXp1cmVGdW5jdGlvbklkZW50aWZpYWJsZUtleUZ1bmN0aW9uS2V5ID0gIlllMmtOYnVweHFJdmdEaG5NTDFfT2ZmYndsdXNZaDRFWkg4WjFuSE85Z2pJQXpGdW01bmprdz09IjsKCiAgICAgICAgcHVibGljIGNvbnN0IHN0cmluZyBBenVyZU1MSWRlbnRpZmlhYmxlSW50ZXJuYWxTZXJ2aWNlUHJpbmNpcGFsQ3JlZGVudGlhbHNDdXJyZW50ID0gImsxR1AxR0Y0S2hLQ3VWWWhFQWhpeHVHN2hqQ1Q3eFFsRTFudlJhRVAxZDVkYzMvQU03QWpaL05GIjsKICAgICAgICBwdWJsaWMgY29uc3Qgc3RyaW5nIEF6dXJlTUxXZWJTZXJ2aWNlQ2xhc3NpY0lkZW50aWZpYWJsZUtleSA9ICI5RUR2VS9ya3NJRnBGeGNSVTFya1diT254Y2Vzck9xL3hTcFhRSWc4QTZ1VVFXbERRRHlrSU5GVGlRcDVsZzZ2dHlKOVNBd0ZnYmR6K0FNQ2RxN3BDQT09IjsKCiAgICAgICAgcHVibGljIGNvbnN0IHN0cmluZyBBenVyZVN0b3JhZ2VBY2NvdW50SWRlbnRpZmlhYmxlQ3JlZGVudGlhbHMgPSAiVTFpbVhXMGFjQTVRUnRua0t1VzE0UVBTQy9GMUpGUzltT2pkOE55L011YWI0MkNWa0k4RzAvamE3dU0xM0dsZmlTOHBwNGMva3pZcCtBU3R2QmpTMXc9PSI7CiAgICAgICAgcHVibGljIGNvbnN0IHN0cmluZyBBenVyZVN0b3JhZ2VBY2NvdW50SW50ZXJuYWxJZGVudGlmaWFibGVDcmVkZW50aWFsc0VuY3J5cHRlZDMyQnl0ZXMgPSAiS1RyWHhBWjhnakhGemxPRUJ5RUZEem9YdGtMYXR4anpyK0FTdERiSU9XZz0iOwogICAgICAgIHB1YmxpYyBjb25zdCBzdHJpbmcgQXp1cmVTdG9yYWdlQWNjb3VudEludGVybmFsSWRlbnRpZmlhYmxlQ3JlZGVudGlhbHNLZXJiZXJvcyA9ICJPdVQ5eGRJZGtwZTZrR1ZqSm9zS0NmUlRaSlF1cGR5MnNaTEwvRjVoUFNhQ1VVV3RpNmxrMVRJbjFQNFpjbS81aVgwczFqWUNNUFBuK0FTdEVPdTl3dz09IjsKICAgICAgICBwdWJsaWMgY29uc3Qgc3RyaW5nIEF6dXJlU3RvcmFnZUFjY291bnRJbnRlcm5hbElkZW50aWZpYWJsZUNyZWRlbnRpYWxzRW5jcnlwdGVkNjRCeXRlcyA9ICJBMVkzUW1Kb0hFMURNU0wyTDJMZWpici94ZEhPWEdBZVJpMm1UdkN3OHExUUJsbm16MUJYOEFlaFVndGlqZ1ljUEx1N3NZUFVmMlV0K0FTdGN6dHozQT09IjsKCiAgICAgICAgcHVibGljIGNvbnN0IHN0cmluZyBBenVyZVNlYXJjaElkZW50aWZpYWJsZUFkbWluS2V5ID0gIlZMY0dEM2JPNFBTUGFLczRzS2lTdlpDYWRQbjFoMHhWcng0Qm1UQmx1WUF6U2VEZ0IzeDEiOwogICAgICAgIHB1YmxpYyBjb25zdCBzdHJpbmcgQXp1cmVTZWFyY2hJZGVudGlmaWFibGVRdWVyeUtleSA9ICJFaGZqNUVrSHJMQXh4anNpbzZuT3ZMak13cThvYndqUTU0aXJDZmI4MGxBelNlREIxSXhKIjsKICAgICAgICBwdWJsaWMgY29uc3Qgc3RyaW5nIEF6dXJlU2VhcmNoSW50ZXJuYWxJZGVudGlmaWFibGVBZG1pbktleSA9ICJzaHgzR2VmMEVSVzl3YmtqQUNPMzNJY0s5dkJkcVdhUnZoUDYzcE5WVVJBelNlRHZiRDZOIjsKCiAgICAgICAgcHVibGljIGNvbnN0IHN0cmluZyBHaXRIdWJQYXQgPSAiZ2hwX2lKeHl1NEprU2FWVVMxRVZCbWFvazBZQWw1NnVMcjNpcFk3QiI7CgogICAgICAgIHB1YmxpYyBjb25zdCBzdHJpbmcgTnBtQXV0aG9ySWRlbnRpZmlhYmxlVG9rZW4gPSAibnBtX2VWdklESVRNMnFJMTc3RjRab0FJWG9jb3lJblNYNzJzZkRNRiI7CgogICAgICAgIHB1YmxpYyBjb25zdCBzdHJpbmcgT2ZmaWNlSW5jb21pbmdXZWJob29rVXJsID0gImh0dHBzOi8vbWljcm9zb2Z0LndlYmhvb2sub2ZmaWNlLmNvbS93ZWJob29rYjIvNzlhMWVmY2UtZDU4NS00ZGZmLWE2ZGUtY2QwNjg1ZGVkYjVkQDcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0Ny9JbmNvbWluZ1dlYmhvb2svMWJmZTE4NmM4MTVhNGUwMjgxZjJiNzRlNTU0NDJjYzgvMzAxNjViMDYtOGNjMi00OWRhLTkzOGQtZTAwNjU4Y2NjODZhIjsKICAgIH0KfQ==";

--- a/Src/Sarif.PatternMatcher.Cli/StressCommand.cs
+++ b/Src/Sarif.PatternMatcher.Cli/StressCommand.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
                 for (int i = 0; i < iterations; i++)
                 {
                     legacyMatchesCount = 0;
-                    foreach (FlexMatch match in RE2Regex.Instance.Matches(resourceContent, regex, RegexDefaults.DefaultOptionsCaseSensitive))
+                   foreach (FlexMatch match in RE2Regex.Instance.Matches(resourceContent, regex, RegexDefaults.DefaultOptionsCaseSensitive))
                     {
                         legacyMatchesCount++;
                     }

--- a/Src/Sarif.PatternMatcher.Cli/StressOptions.cs
+++ b/Src/Sarif.PatternMatcher.Cli/StressOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+
 using CommandLine;
 
 using Microsoft.CodeAnalysis.Sarif.Driver;
@@ -10,5 +12,23 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
     [Verb("stress", HelpText = "Run various stress scenarios.")]
     internal class StressOptions : SingleFileOptionsBase
     {
+        [Value(
+            0,
+            HelpText = "A naive performance or stress scenario name (currently Statelessness or RE2Timing).",
+            Required = true)]
+        public StressScenario Scenario { get; set; }
+
+        [Option(
+            "iterations",
+            HelpText = "The # of iterations to run of the specified scenario.",
+            Default = 1
+            )]
+        public int Iterations { get; set; }
+    }
+
+    public enum StressScenario
+    {
+        Statelessness = 0,
+        RE2Timing,
     }
 }

--- a/Src/Sarif.PatternMatcher/AnalyzeContext.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeContext.cs
@@ -79,6 +79,13 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
         /// </summary>
         public OptionallyEmittedData DataToInsert { get; set; }
 
+        /// <summary>
+        /// An array of integers that comprise a map of UTF8 to UTF16 byte
+        /// indices. This data is required to rationalize match segments
+        /// when analyzing .NET strings in RE2 (which processes UTF8).
+        /// </summary>
+        public int[] Utf8ToUtf16ByteIndices;
+
         public void Dispose()
         {
             FileRegionsCache?.ClearCache();

--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -835,7 +835,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             // end of lines as well as the beginning or end of the search text.
             string lineRegex = $"(?m)^.*{firstRegex}.*";
 
-            if (Matches(lineRegex,
+            if (!Matches(lineRegex,
                         searchText,
                         out List<Dictionary<string, FlexMatch>> singleLineMatches,
                         context))

--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -789,15 +789,10 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
                 Debug.Assert(!contentsRegex.StartsWith("$"), $"Unexpanded regex variable: {contentsRegex}");
 
-                long maxMemoryInKB =
-                    context.MaxMemoryInKilobytes == -1
-                        ? context.MaxMemoryInKilobytes
-                        : 1024 * context.MaxMemoryInKilobytes;
-
                 if (!Matches(contentsRegex,
-                                                 searchText,
-                                                 out List<Dictionary<string, FlexMatch>> matches,
-                                                 context))
+                             searchText,
+                             out List<Dictionary<string, FlexMatch>> matches,
+                             context))
                 {
                     if (matchExpression.IntrafileRegexMetadata[i] == RegexMetadata.Optional)
                     {
@@ -840,15 +835,10 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             // end of lines as well as the beginning or end of the search text.
             string lineRegex = $"(?m)^.*{firstRegex}.*";
 
-            long maxMemoryInKB =
-                context.MaxMemoryInKilobytes == -1
-                    ? context.MaxMemoryInKilobytes
-                    : 1024 * context.MaxMemoryInKilobytes;
-
             if (Matches(lineRegex,
-                                             searchText,
-                                             out List<Dictionary<string, FlexMatch>> singleLineMatches,
-                                             context))
+                        searchText,
+                        out List<Dictionary<string, FlexMatch>> singleLineMatches,
+                        context))
             {
                 return;
             }
@@ -869,11 +859,10 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 {
                     string regex = matchExpression.SingleLineRegexes[i];
 
-                    if (!((RE2Regex)_engine).Matches(regex,
-                                                     lineText,
-                                                     out List<Dictionary<string, FlexMatch>> intralineMatches,
-                                                     ref context.Utf8ToUtf16ByteIndices,
-                                                     maxMemoryInKB))
+                    if (!Matches(regex,
+                                 lineText,
+                                 out List<Dictionary<string, FlexMatch>> intralineMatches,
+                                 context))
                     {
                         continue;
                     }
@@ -990,8 +979,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             // INTERESTING BREAKPPOINT: debug static analysis match failures.
             // Set a conditional breakpoint on 'matchExpression.Name' to filter by specific rules.
             // Set a conditional breakpoint on 'searchText' to filter on specific target text patterns.
-
-
             if (!Matches(matchExpression.ContentsRegex,
                          searchText,
                          out List<Dictionary<string, FlexMatch>> matches,
@@ -1100,9 +1087,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                              out List<Dictionary<string, FlexMatch>> matches,
                              AnalyzeContext context)
         {
-            matches = null;
-            RE2Regex re2regex = _engine as RE2Regex;
-
+            var re2regex = _engine as RE2Regex;
 
             long maxMemoryInKB =
                 context.MaxMemoryInKilobytes == -1
@@ -1111,11 +1096,11 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
             if (re2regex != null)
             {
-                return ((RE2Regex)_engine).Matches(contentsRegex,
-                                                   searchText,
-                                                   out matches,
-                                                   ref context.Utf8ToUtf16ByteIndices,
-                                                   maxMemoryInKB);
+                return re2regex.Matches(contentsRegex,
+                                        searchText,
+                                        out matches,
+                                        ref context.Utf8ToUtf16ByteIndices,
+                                        maxMemoryInKB);
             }
 
             return _engine.Matches(contentsRegex,

--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -794,11 +794,11 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                         ? context.MaxMemoryInKilobytes
                         : 1024 * context.MaxMemoryInKilobytes;
 
-                if (!((RE2Regex)_engine).Matches(matchExpression.ContentsRegex,
-                                     searchText,
-                                     out List<Dictionary<string, FlexMatch>> matches,
-                                     ref context.Utf8ToUtf16ByteIndices,
-                                     maxMemoryInKB))
+                if (!((RE2Regex)_engine).Matches(contentsRegex,
+                                                 searchText,
+                                                 out List<Dictionary<string, FlexMatch>> matches,
+                                                 ref context.Utf8ToUtf16ByteIndices,
+                                                 maxMemoryInKB))
                 {
                     if (matchExpression.IntrafileRegexMetadata[i] == RegexMetadata.Optional)
                     {
@@ -984,6 +984,11 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                                                    ? Decode(binary64DecodedMatch.Value)
                                                    : context.FileContents;
 
+            long maxMemoryInKB =
+                context.MaxMemoryInKilobytes == -1
+                    ? context.MaxMemoryInKilobytes
+                    : 1024 * context.MaxMemoryInKilobytes;
+
             // INTERESTING BREAKPPOINT: debug static analysis match failures.
             // Set a conditional breakpoint on 'matchExpression.Name' to filter by specific rules.
             // Set a conditional breakpoint on 'searchText' to filter on specific target text patterns.
@@ -991,7 +996,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                                  searchText,
                                  out List<Dictionary<string, FlexMatch>> matches,
                                  ref context.Utf8ToUtf16ByteIndices,
-                                 context.MaxMemoryInKilobytes == -1 ? context.MaxMemoryInKilobytes : 1024 * context.MaxMemoryInKilobytes))
+                                 maxMemoryInKB))
             {
                 return;
             }

--- a/Src/Test.UnitTests.RE2.Managed/Regex2Tests.cs
+++ b/Src/Test.UnitTests.RE2.Managed/Regex2Tests.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -21,6 +23,39 @@ namespace Microsoft.RE2.Managed
         {
             // Ensure Test harness is running x64
             Regex2.NativeLibraryFolderPath = @"runtimes\win-x64\native";
+        }
+
+        [Fact]
+        public void Re2TimingTest()
+        {
+            string filePath = "d:\\repros\\SarifSdk.v2.sarif";
+
+            FlexString resourceContent = File.ReadAllText(filePath);
+
+            var regexList = new List<string> { "a", "abc", "hulonhulonhulon", "(?:^|[^0-9A-Za-z_])(ghp_[\\w]{36})(?:[^0-9A-Za-z_]|$)", "(?P<secret>a)", "(?P<secret>abc)", "(?P<secret>hulonhulonhulon)", "(?:^|[^0-9A-Za-z_])(?P<secret>ghp_[\\w]{36})(?:[^0-9A-Za-z_]|$)" };
+
+            var sb = new StringBuilder();
+
+            int[] indexMap = null;
+            foreach (string regex in regexList)
+            {
+                // Current Match
+                var currentRegexSW = Stopwatch.StartNew();
+                // call from line 969 of SearchSkimmers.cs
+                bool currentMatches = ((RE2Regex)RE2Regex.Instance).Matches(regex, resourceContent, out List<Dictionary<string, FlexMatch>> matches, ref indexMap, -1);
+                currentRegexSW.Stop();
+
+                // Legacy Match
+                var legacyRegexSW = Stopwatch.StartNew();
+
+                // call from line 642 of PatternMatcher.cs
+                IEnumerable<FlexMatch> legacyMatches = RE2Regex.Instance.Matches(resourceContent, regex, RegexDefaults.DefaultOptionsCaseSensitive);
+                legacyRegexSW.Stop();
+                sb.AppendLine($"For regex: \"{regex}\", Legacy: {legacyRegexSW.ElapsedMilliseconds}ms, matches: {legacyMatches.Count()} \tCurrent: {currentRegexSW.ElapsedMilliseconds}ms, matches: {matches.Count}");
+            }
+
+            // Force assertation failure to see test results.
+            Assert.True(false, sb.ToString());
         }
 
         [Fact]

--- a/Src/Test.UnitTests.RE2.Managed/Regex2Tests.cs
+++ b/Src/Test.UnitTests.RE2.Managed/Regex2Tests.cs
@@ -26,39 +26,6 @@ namespace Microsoft.RE2.Managed
         }
 
         [Fact]
-        public void Re2TimingTest()
-        {
-            string filePath = "d:\\repros\\SarifSdk.v2.sarif";
-
-            FlexString resourceContent = File.ReadAllText(filePath);
-
-            var regexList = new List<string> { "a", "abc", "hulonhulonhulon", "(?:^|[^0-9A-Za-z_])(ghp_[\\w]{36})(?:[^0-9A-Za-z_]|$)", "(?P<secret>a)", "(?P<secret>abc)", "(?P<secret>hulonhulonhulon)", "(?:^|[^0-9A-Za-z_])(?P<secret>ghp_[\\w]{36})(?:[^0-9A-Za-z_]|$)" };
-
-            var sb = new StringBuilder();
-
-            int[] indexMap = null;
-            foreach (string regex in regexList)
-            {
-                // Current Match
-                var currentRegexSW = Stopwatch.StartNew();
-                // call from line 969 of SearchSkimmers.cs
-                bool currentMatches = ((RE2Regex)RE2Regex.Instance).Matches(regex, resourceContent, out List<Dictionary<string, FlexMatch>> matches, ref indexMap, -1);
-                currentRegexSW.Stop();
-
-                // Legacy Match
-                var legacyRegexSW = Stopwatch.StartNew();
-
-                // call from line 642 of PatternMatcher.cs
-                IEnumerable<FlexMatch> legacyMatches = RE2Regex.Instance.Matches(resourceContent, regex, RegexDefaults.DefaultOptionsCaseSensitive);
-                legacyRegexSW.Stop();
-                sb.AppendLine($"For regex: \"{regex}\", Legacy: {legacyRegexSW.ElapsedMilliseconds}ms, matches: {legacyMatches.Count()} \tCurrent: {currentRegexSW.ElapsedMilliseconds}ms, matches: {matches.Count}");
-            }
-
-            // Force assertation failure to see test results.
-            Assert.True(false, sb.ToString());
-        }
-
-        [Fact]
         public void Regex2_Basics()
         {
             byte[] buffer = null, buffer2 = null;

--- a/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/AnalyzeCommandTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/AnalyzeCommandTests.cs
@@ -431,6 +431,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
                 };
 
                 int result = Program.Main(args);
+                Program.InstantiatedAnalyzeCommand.RuntimeErrors.Should().Be(0);
                 result.Should().Be(0);
 
                 sarifLog = JsonConvert.DeserializeObject<SarifLog>(File.ReadAllText(sarifLogFileName));
@@ -536,6 +537,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
                 }
 
                 int result = Program.Main(args);
+                Program.InstantiatedAnalyzeCommand.RuntimeErrors.Should().Be(0);
                 result.Should().Be(CommandBase.SUCCESS);
 
                 sarifLog = JsonConvert.DeserializeObject<SarifLog>(File.ReadAllText(sarifLogFileName));


### PR DESCRIPTION
RE2 supports named groups using a particular regex syntax, e.g., (?P<myGroup>). Retrieving groups requires special invocation from our RE2 managed API, however. This layer first parses the input file in order to handle UTF8/UTF16 interoperability between .NET and RE2. This parsing occurred on every call for every pattern, greatly compromising performance.

This interim change allows for the scan tool to build that per-file UTF8/UTF16 index single time. We should next test and see how this performs relative to a second approach (which would entail eliding the groups altogether, calling the RE2 helpers with no special group processing and then (but only in the event of a match attempting to resolve the groups).

This latter optimization actually could be accomplished strictly within RE2 (rather than, say, falling back onto .NET)