### PR TITLE
Fixing broken links in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ The following packages are published from this repository:
 | [Strings.Interop](https://www.nuget.org/packages/Strings.Interop/)| [![Nuget](https://img.shields.io/nuget/vpre/Strings.Interop)](https://www.nuget.org/packages/Strings.Interop/)|
 
 ## Getting started
-- [Creating plugins](./docs/getting-started/CreatingPlugins.md)
-- [Using the client tool](./docs/getting-started/UsingClientTool.md)
-- [Using the library](./docs/getting-started/UsingLibrary.md)
+- [Creating plugins](./docs/CreatingPlugins.md)
+- [Using the client tool](./docs/UsingClientTool.md)
+- [Using the library](./docs/UsingLibrary.md)
 
 ## How To Contribute
 


### PR DESCRIPTION
## Changes

Several links in the `README` page were broken. This PR fixes the links.


