### PR TITLE
Update RE2 compilation to VS2022 target tools, 14.3

### DIFF
--- a/Src/RE2.Native/RE2.Native.x64.vcxproj
+++ b/Src/RE2.Native/RE2.Native.x64.vcxproj
@@ -25,7 +25,7 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <TargetName>RE2.Native.x64</TargetName>
     <TargetExt>.dll</TargetExt>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <OutDir>$(SolutionDir)..\Bld\bin\$(Configuration)\x64\</OutDir>
     <IntDir>$(SolutionDir)..\Bld\bin\int\x64\$(Configuration)\</IntDir>

--- a/Src/RE2.Native/RE2.Native.x86.vcxproj
+++ b/Src/RE2.Native/RE2.Native.x86.vcxproj
@@ -25,7 +25,7 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <TargetName>RE2.Native.x86</TargetName>
     <TargetExt>.dll</TargetExt>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <OutDir>$(SolutionDir)..\Bld\bin\$(Configuration)\x86\</OutDir>
     <IntDir>$(SolutionDir)..\Bld\bin\int\x86\$(Configuration)\</IntDir>

--- a/Src/RE2.Native/re2.x64.vcxproj
+++ b/Src/RE2.Native/re2.x64.vcxproj
@@ -21,7 +21,7 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <TargetName>re2.x64</TargetName>
     <TargetExt>.lib</TargetExt>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <OutDir>$(SolutionDir)..\Bld\bin\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)..\Bld\bin\int\x64\$(Configuration)\</IntDir>

--- a/Src/RE2.Native/re2.x86.vcxproj
+++ b/Src/RE2.Native/re2.x86.vcxproj
@@ -21,7 +21,7 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <TargetName>re2.x86</TargetName>
     <TargetExt>.lib</TargetExt>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <OutDir>$(SolutionDir)..\Bld\bin\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)..\Bld\bin\int\x86\$(Configuration)\</IntDir>


### PR DESCRIPTION
FYI, upgrading RE2 compilation with the result that we will now require VS2022 to compile.

You will need to install the 14.3 Spectre-enabled c runtime libraries for x64/x86 if you haven't.