### PR TITLE
Dynamic not implemented

### DIFF
--- a/Src/Plugins/Tests.Security/Helpers/HttpMockHelper.cs
+++ b/Src/Plugins/Tests.Security/Helpers/HttpMockHelper.cs
@@ -130,6 +130,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Helpers
 
         // Expected Outputs
         public string ExpectedMessage { get; set; }
+        public Fingerprint ExpectedFingerprint { get; set; }
         public ValidationState ExpectedValidationState { get; set; }
     }
 }

--- a/Src/Sarif.PatternMatcher/ValidatorsCache.cs
+++ b/Src/Sarif.PatternMatcher/ValidatorsCache.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 
+using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.PushProtection.SecurePlaintextSecretsValidators;
 using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk;
 using Microsoft.RE2.Managed;
 
@@ -195,7 +196,11 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
             IEnumerable<ValidationResult> validationResults = staticValidator.IsValidStatic(groups, context.ObservedFingerprintCache);
 
-            if (staticValidator is DynamicValidatorBase dynamicValidator)
+            // An 'ExtensibleStaticValidatorBase' is a rule that extends DynamicValidatorBase
+            // strictly so that other rules can use it as a base type and add dynamic
+            // validation.
+            if (staticValidator is DynamicValidatorBase dynamicValidator
+                && !(staticValidator is ExtensibleStaticValidatorBase))
             {
                 pluginCanPerformDynamicAnalysis = true;
 


### PR DESCRIPTION
Create an unusual object hierarchy that allows for a static validating rule to extend dynamic analysis without actually implementing a dynamic analysis. This allows a separate plug-in to provide that capability.