### PR TITLE
PatternInvariantTest with 2 Json Files

### DIFF
--- a/Src/Test.UnitTests.Sarif.PatternMatcher/PatternInvariantTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/PatternInvariantTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
         {
             string definitionsFileContents = File.ReadAllText(definitionsFilePath);
             SearchDefinitions sdObject = JsonConvert.DeserializeObject<SearchDefinitions>(definitionsFileContents);
-            
+
             // Load shared strings from file in JSON
             string sharedStringsFileName = sdObject.SharedStringsFileName;
             var definitionsFilePathInfo = new DirectoryInfo(definitionsFilePath);
@@ -114,10 +114,10 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             string validatorsFolderName = "SecurePlaintextSecretsValidators";
             string securityDivision = "SEC101";
             var jsonFiles = Directory.GetFiles(definitionsFileDirectory, "*.json").Where(file => file.Contains(securityDivision)).ToList();
-            
+
             var ruleNameToIdMap = new Dictionary<string, string>();
             var invalidFilenames = new List<string>();
-            
+
             foreach (string jsonFile in jsonFiles)
             {
                 //Read the json file content to get the rule names


### PR DESCRIPTION
## Changes

Updated PatternInvariantTests to pull shared strings file from the field located in the json file. This ensures that the shared strings file that will be used is the one being checked. Before the shared strings file was passed in separately and could pass tests, while not actually being the file that the json would reference.
Also updated to loop through json files since there are now 2.