### PR TITLE
Disable DFA oom error as scary. 

### DIFF
--- a/Src/RE2.Native/RE2Native.cpp
+++ b/Src/RE2.Native/RE2Native.cpp
@@ -72,6 +72,8 @@ extern "C" __declspec(dllexport) int BuildRegex(String8 regex, int regexOptions,
 		options->set_max_mem(maxMemoryInBytes);
 	}
 
+	options->set_log_errors(false);
+
 	// Parse and construct an RE2 instance for the regular expression
 	re2::RE2* expression = new re2::RE2(expressionSp, *options);
 


### PR DESCRIPTION
Will follow up with RE2 to propose lowering this to warning.
 @eddynaka 