### PR TITLE
Update xunit and FluentAssertions dependencies

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## Unreleased
-- Update SARIF SDK submodule from [31f49b2 to 235394](https://github.com/microsoft/sarif-sdk/compare/31f49b2..235394). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/7805847d075b0991da6917cc934fb0924015402d/src/ReleaseHistory.md).
+- Update SARIF SDK submodule from [31f49b2 to 235394a](https://github.com/microsoft/sarif-sdk/compare/31f49b2..235394a). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/7805847d075b0991da6917cc934fb0924015402d/src/ReleaseHistory.md).
 - Update SEC101/028.PlaintextPassword regular expression to include scenarios where a variable name is used instead of string (added `*` after `["']`).
 - BREAKING: Properly introduce fingerprint versioned hierarchical strings (according to the [SARIF spec](https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317441)) by updating `/current` component to `/v0`. 
 - BREAKING: Remove non-functional `multiline` argument from command-line. This argument should simply be removed from all command-lines.
@@ -14,8 +14,9 @@
 - Rename `SEC101/017.NpmAuthorToken` to `SEC101/017.NpmAuthorToken` [#683](https://github.com/microsoft/sarif-pattern-matcher/pull/683)
 - Rename `SEC101/006.GitHubPat` to `SEC101/006.GitHubLegacyPat` [#678](https://github.com/microsoft/sarif-pattern-matcher/pull/678)
 - Disable `SEC101/029.AlibabaCloudCredentials` which throws ScanErrors with message: 
-	"ValidationError:Could not load file or assembly 'AlibabaCloud.OpenApiClient, Version=0.1.4.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies. A strongly-named assembly is required. (Exception from HRESULT: 0x80131044)" 
-	These exceptions are caused by incompatibilities between Alibaba code and .Net core 3.1 and 6.0. Will restore rule when dependencies are updated. [#700](https://github.com/microsoft/sarif-pattern-matcher/pull/700)
+	>ValidationError:Could not load file or assembly 'AlibabaCloud.OpenApiClient, Version=0.1.4.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies. A strongly-named assembly is required. (Exception from HRESULT: 0x80131044)
+	
+  These exceptions are caused by incompatibilities between Alibaba code and .Net core 3.1 and 6.0. Will restore rule when dependencies are updated. [#700](https://github.com/microsoft/sarif-pattern-matcher/pull/700)
 
 ## *2.0.0-dev*
 

--- a/Src/Test.UnitTests.RE2.Managed/Test.UnitTests.RE2.Managed.csproj
+++ b/Src/Test.UnitTests.RE2.Managed/Test.UnitTests.RE2.Managed.csproj
@@ -12,6 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions" Version="6.9.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="xunit" Version="2.4.2" />
   </ItemGroup>
 </Project>

--- a/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/Test.UnitTests.Sarif.PatternMatcher.Cli.csproj
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/Test.UnitTests.Sarif.PatternMatcher.Cli.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions" Version="6.9.0" />
     <PackageReference Include="Moq" Version="4.15.2" />
   </ItemGroup>
 

--- a/Src/Test.UnitTests.Sarif.PatternMatcher.Function/Test.UnitTests.Sarif.PatternMatcher.Function.csproj
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher.Function/Test.UnitTests.Sarif.PatternMatcher.Function.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(MSBuildThisFileDirectory)..\..\Targets\build.test.props" />
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions" Version="6.9.0" />
     <PackageReference Include="Moq" Version="4.15.2" />
   </ItemGroup>
 
@@ -15,6 +15,10 @@
   <ItemGroup>
     <Content Include="..\Plugins\Tests.Security\TestData\SecurePlaintextSecrets\Inputs\SEC101_102.AdoPat.txt" Link="TestData\SEC101_102.AdoPat.txt" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="..\Plugins\Tests.Security\TestData\SecurePlaintextSecrets\Inputs\SEC101_005.SlackApiKey.py" Link="TestData\SEC101_005.SlackApiKey.py" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="xunit" Version="2.4.2" />
   </ItemGroup>
   
   <Target Name="CopySecFilesAfterBuild" AfterTargets="AfterBuild">

--- a/Src/Test.UnitTests.Sarif.PatternMatcher.Sdk/Test.UnitTests.Sarif.PatternMatcher.Sdk.csproj
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher.Sdk/Test.UnitTests.Sarif.PatternMatcher.Sdk.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions" Version="6.9.0" />
     <PackageReference Include="Moq" Version="4.15.2" />
   </ItemGroup>
   

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/ExtensionMethodsTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/ExtensionMethodsTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             dict.AddProperties(properties);
             dict.Should().BeEmpty();
 
-            // Empty properties sould not affect dictionary
+            // Empty properties should not affect dictionary
             properties = new Dictionary<string, string>();
             dict.Should().BeEmpty();
 
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             dict.Count.Should().Be(2);
             foreach (KeyValuePair<string, string> kv in properties)
             {
-                dict[kv.Key].Value.Should().Be(kv.Value);
+                dict[kv.Key].Value.ToString().Should().Be(kv.Value);
             }
 
             // Duplicated items should not replace original value.
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             properties.Add("key3", "value3");
             dict.AddProperties(properties);
             dict.Count.Should().Be(3);
-            dict["key3"].Value.Should().Be("original");
+            dict["key3"].Value.ToString().Should().Be("original");
         }
     }
 }

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/Test.UnitTests.Sarif.PatternMatcher.csproj
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/Test.UnitTests.Sarif.PatternMatcher.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions" Version="6.9.0" />
     <PackageReference Include="Moq" Version="4.15.2" />
   </ItemGroup>
   

--- a/Src/Test.UnitTests.Strings.Interop/Test.UnitTests.Strings.Interop.csproj
+++ b/Src/Test.UnitTests.Strings.Interop/Test.UnitTests.Strings.Interop.csproj
@@ -11,4 +11,8 @@
     <ProjectReference Include="..\Strings.Interop\Strings.Interop.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="xunit" Version="2.4.2" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION

## Changes

Update xunit package reference to version 2.4.2.
Update FluentAssertions package reference to version 6.9.0.
Updated test using FluentAssertions to explicitly cast to string, since FluentAssertions no longer implicitly cast. Learned from https://github.com/microsoft/sarif-sdk/pull/2608 