### PR TITLE
Initial matchexpression rule disable stub

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Update SARIF SDK submodule from [31f49b2 to 235394a](https://github.com/microsoft/sarif-sdk/compare/31f49b2..235394a). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/7805847d075b0991da6917cc934fb0924015402d/src/ReleaseHistory.md).
 - Update SEC101/028.PlaintextPassword regular expression to include scenarios where a variable name is used instead of string (added `*` after `["']`).
+- FEATURE: Allow rule disabling from definitions file by adding `"RuleEnabledState: "Disabled""` to rule MatchExpression.
 - BREAKING: Properly introduce fingerprint versioned hierarchical strings (according to the [SARIF spec](https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317441)) by updating `/current` component to `/v0`. 
 - BREAKING: Remove non-functional `multiline` argument from command-line. This argument should simply be removed from all command-lines.
 - BREAKING: Remove `file-size-in-kb` argument. Its use should be replaced by `max-file-size-in-kb`, a more descriptive name we pick up from the SARIF driver framework.

--- a/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
@@ -157,8 +157,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                             string current = matchExpression.SingleLineRegexes[i];
                             matchExpression.SingleLineRegexes[i] =
                                 PushData(current,
-                                            definition.SharedStrings,
-                                            sharedStrings);
+                                         definition.SharedStrings,
+                                         sharedStrings);
                         }
                     }
 

--- a/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
@@ -148,6 +148,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
                 foreach (MatchExpression matchExpression in definition.MatchExpressions)
                 {
+                    if (matchExpression.RuleEnabledState == RuleEnabledState.Disabled) { continue; }
+
                     if (matchExpression.SingleLineRegexes?.Count > 0)
                     {
                         for (int i = 0; i < matchExpression.SingleLineRegexes.Count; i++)
@@ -155,8 +157,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                             string current = matchExpression.SingleLineRegexes[i];
                             matchExpression.SingleLineRegexes[i] =
                                 PushData(current,
-                                         definition.SharedStrings,
-                                         sharedStrings);
+                                            definition.SharedStrings,
+                                            sharedStrings);
                         }
                     }
 

--- a/Src/Sarif.PatternMatcher/MatchExpression.cs
+++ b/Src/Sarif.PatternMatcher/MatchExpression.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 
+using Microsoft.CodeAnalysis.Sarif.Driver;
+
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 {
     public class MatchExpression
@@ -24,6 +26,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
         public string HelpUri { get; set; }
 
         public string Message { get; set; }
+
+        public RuleEnabledState RuleEnabledState { get; set; }
 
         public FailureLevel Level { get; set; }
 

--- a/Src/Sarif.PatternMatcher/SearchDefinition.cs
+++ b/Src/Sarif.PatternMatcher/SearchDefinition.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 
+using Microsoft.CodeAnalysis.Sarif.Driver;
+
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 {
     public class SearchDefinition
@@ -18,6 +20,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
         public string Message { get; set; }
 
         public ResultKind Kind { get; set; }
+
+        public RuleEnabledState RuleEnabledState { get; set; }
 
         public FailureLevel Level { get; set; }
 

--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -62,8 +62,16 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 { nameof(SdkResources.NotApplicable_InvalidMetadata), new MultiformatMessageString() { Text = SdkResources.NotApplicable_InvalidMetadata, } },
             };
 
+            var enabledMatchExpressionList = new List<MatchExpression>();
             foreach (MatchExpression matchExpression in definition.MatchExpressions)
             {
+                if (matchExpression.RuleEnabledState == RuleEnabledState.Disabled)
+                {
+                    continue;
+                }
+
+                enabledMatchExpressionList.Add(matchExpression);
+
                 string matchExpressionMessage = matchExpression.Message;
                 matchExpression.ArgumentNameToIndexMap = GenerateIndicesForNamedArguments(ref matchExpressionMessage);
 
@@ -87,7 +95,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 };
             }
 
-            _matchExpressions = definition.MatchExpressions;
+            _matchExpressions = enabledMatchExpressionList;
         }
 
         public override Uri HelpUri => _helpUri;
@@ -120,11 +128,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
             foreach (MatchExpression matchExpression in _matchExpressions)
             {
-                if (matchExpression.RuleEnabledState == RuleEnabledState.Disabled)
-                {
-                    continue;
-                }
-
                 if (!string.IsNullOrEmpty(matchExpression.FileNameDenyRegex) && _engine.IsMatch(filePath, matchExpression.FileNameDenyRegex))
                 {
                     continue;
@@ -201,11 +204,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
             foreach (MatchExpression matchExpression in _matchExpressions)
             {
-                if (matchExpression.RuleEnabledState == RuleEnabledState.Disabled)
-                {
-                    continue;
-                }
-
                 if (!string.IsNullOrEmpty(matchExpression.FileNameAllowRegex))
                 {
                     if (!_engine.IsMatch(filePath,
@@ -535,9 +533,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             }
 
             // We'll limit rank precision to two decimal places. Because this value
-            // is actually converted from a nomalized range of 0.0 to 1.0, to the
+            // is actually converted from a normalized range of 0.0 to 1.0, to the
             // SARIF 0.0 to 100.0 equivalent, this is effectively four decimal places
-            // of precision as far as the normalized Shannon entrop is concerned.
+            // of precision as far as the normalized Shannon entropy is concerned.
             rank = Math.Round(rank, 2, MidpointRounding.AwayFromZero);
 
             var result = new Result()
@@ -895,7 +893,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                         continue;
                     }
 
-                    // TODO: we only support a single intraline match per expression. How shoud
+                    // TODO: we only support a single intraline match per expression. How should
                     // we report or error out in cases where this expectation isn't met?
                     Dictionary<string, FlexMatch> intralineMatch = intralineMatches[0];
 

--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -62,16 +62,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 { nameof(SdkResources.NotApplicable_InvalidMetadata), new MultiformatMessageString() { Text = SdkResources.NotApplicable_InvalidMetadata, } },
             };
 
-            var enabledMatchExpressionList = new List<MatchExpression>();
             foreach (MatchExpression matchExpression in definition.MatchExpressions)
             {
-                if (matchExpression.RuleEnabledState == RuleEnabledState.Disabled)
-                {
-                    continue;
-                }
-
-                enabledMatchExpressionList.Add(matchExpression);
-
                 string matchExpressionMessage = matchExpression.Message;
                 matchExpression.ArgumentNameToIndexMap = GenerateIndicesForNamedArguments(ref matchExpressionMessage);
 
@@ -95,7 +87,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 };
             }
 
-            _matchExpressions = enabledMatchExpressionList;
+            _matchExpressions = definition.MatchExpressions;
         }
 
         public override Uri HelpUri => _helpUri;

--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -120,6 +120,11 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
             foreach (MatchExpression matchExpression in _matchExpressions)
             {
+                if (matchExpression.RuleEnabledState == RuleEnabledState.Disabled)
+                {
+                    continue;
+                }
+
                 if (!string.IsNullOrEmpty(matchExpression.FileNameDenyRegex) && _engine.IsMatch(filePath, matchExpression.FileNameDenyRegex))
                 {
                     continue;
@@ -196,6 +201,11 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
             foreach (MatchExpression matchExpression in _matchExpressions)
             {
+                if (matchExpression.RuleEnabledState == RuleEnabledState.Disabled)
+                {
+                    continue;
+                }
+
                 if (!string.IsNullOrEmpty(matchExpression.FileNameAllowRegex))
                 {
                     if (!_engine.IsMatch(filePath,


### PR DESCRIPTION
## Changes

Add functionality to disable a rule in json file. By adding RuleEnabledState = "Disabled", the rule will not run any analysis. Future efforst will have this same field determine failure level since those fields are included in the RuleEnabledState enum.

For significant contributions please make sure you have completed the following items:

* [ ] `ReleaseHistory.md` updated for non-trivial changes
* [ ] Added unit tests
