### PR TITLE
Output changes: persist rules metadata to `Run.Tool.Extensions`

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,13 +1,12 @@
 # Release History
 
 ## Unreleased
-- Update SARIF SDK submodule from [31f49b2 to 235394a](https://github.com/microsoft/sarif-sdk/compare/31f49b2..235394a). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/7805847d075b0991da6917cc934fb0924015402d/src/ReleaseHistory.md).
-- Update SEC101/028.PlaintextPassword regular expression to include scenarios where a variable name is used instead of string (added `*` after `["']`).
+- Update SARIF SDK submodule from [31f49b2 to 59643b0](https://github.com/microsoft/sarif-sdk/compare/31f49b2..59643b0). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/59643b0/src/ReleaseHistory.md).
 - BREAKING: Properly introduce fingerprint versioned hierarchical strings (according to the [SARIF spec](https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317441)) by updating `/current` component to `/v0`. 
 - BREAKING: Remove non-functional `multiline` argument from command-line. This argument should simply be removed from all command-lines.
 - BREAKING: Remove `file-size-in-kb` argument. Its use should be replaced by `max-file-size-in-kb`, a more descriptive name we pick up from the SARIF driver framework.
 - BREAKING: Fix bug resulting in static validators returning `FailureLevel.Note` despite configured `FailureLevel`. [#645](https://github.com/microsoft/sarif-pattern-matcher/pull/645)
-- Update `sarif-sdk` submodule to commit [7ddf923a4652a333f3356e9db4c5742b78a22c96](https://github.com/microsoft/sarif-sdk/commit/7ddf923a4652a333f3356e9db4c5742b78a22c96), which includes threading fixes in driver framework and fixes to ensure snipet population.
+- Update SEC101/028.PlaintextPassword regular expression to include scenarios where a variable name is used instead of string (added `*` after `["']`).
 - Update `spam` executable and dotnet library name to Sarif.PatternMatcher.Cli. 
 - Update `Microsoft.Security.Utilities` to [v1.4.0](https://github.com/microsoft/security-utilities/releases/tag/v1.4.0). [#662](https://github.com/microsoft/sarif-pattern-matcher/pull/662)
 - Rename `SEC101/050.IdentifiableNpmLegacyAuthorToken` to `SEC101/050.NpmIdentifiableAuthorToken` [#683](https://github.com/microsoft/sarif-pattern-matcher/pull/683)

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,6 +1,6 @@
 # Release History
 
-## Unreleased
+## v3.0.0-dev1 Released 01/27/2023
 - Update SARIF SDK submodule from [31f49b2 to 59643b0](https://github.com/microsoft/sarif-sdk/compare/31f49b2..59643b0). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/59643b0/src/ReleaseHistory.md).
 - Update SEC101/028.PlaintextPassword regular expression to include scenarios where a variable name is used instead of string (added `*` after `["']`).
 - FEATURE: Allow rule disabling from definitions file by adding `"RuleEnabledState: "Disabled""` to rule MatchExpression.
@@ -20,7 +20,6 @@
   These exceptions are caused by incompatibilities between Alibaba code and .Net core 3.1 and 6.0. Will restore rule when dependencies are updated. [#700](https://github.com/microsoft/sarif-pattern-matcher/pull/700)
 
 ## *2.0.0-dev*
-
 - Update `sarif-sdk` submodule to commit [24c773bf194100d11c896ce67581832428304a35](https://github.com/microsoft/sarif-sdk/commit/24c773bf194100d11c896ce67581832428304a35), which applies `FileRegionsCache` fixes (from an unreleased version of the SDK).
 - Update search definitions probing logic to look for file alongside the client tool.
 - BUG: Resolve `OutofMemoryException` and `NullReferenceException' failures resulting from a failure to honor file size scan limits set by `--file-size-in-kb` argument and updated Sarif.Sdk submodule to commit [ce8c5cb12d29aa407d0bf98f5fa2c764ec7fb65b](https://github.com/microsoft/sarif-sdk/commit/ce8c5cb12d29aa407d0bf98f5fa2c764ec7fb65b). [#621](https://github.com/microsoft/sarif-pattern-matcher/pull/621)
@@ -31,19 +30,16 @@
 - BUG: Loosen `Newtonsoft.Json` minimum version requirement to 12.0.3 for `Sarif.PatternMatcher` project. [#644](https://github.com/microsoft/sarif-pattern-matcher/pull/644)
 
 ## *v1.10.0*
-
 - FEATURE: Enable response file parsing provided by driver framework. Arguments (e.g., '@Commands.rsp') prefixed with a '@' character will be evaluated as a file path to a text file that contains commands to be injected on the command-line. 
 - BREAKING: Change fingerprint naming conventions and add new unique secret fingerprint (and opaque unique fingerprint hash).
 - RE2.Native will now compile in all environments with the latest Windows SDK 10.0.* installed. [#607](https://github.com/microsoft/sarif-pattern-matcher/pull/607). Our current release pipelines build NuGet packages with Windows SDK version 10.0.22000.
 
 ## *v1.9.0*
-
 - Bump MongoDB.Driver from 2.13.1 to 2.15.0 and Microsoft.AspNetCore.Http from 2.1.0 to 2.2.0. [#608](https://github.com/microsoft/sarif-pattern-matcher/pull/608)
 - Bump Sarif.Sdk from 2.4.13 to [2.4.15](https://github.com/microsoft/sarif-sdk/blob/v2.4.15/src/ReleaseHistory.md) by updating submodule to commit [9f0eed7549736b28d59a2e93f443ba47e3bd978e](https://github.com/microsoft/sarif-sdk/commit/9f0eed7549736b28d59a2e93f443ba47e3bd978e). [#612](https://github.com/microsoft/sarif-pattern-matcher/pull/612)
 - NR: Adding Url rule in the plugin `ReviewPotentiallySensitiveData`. [#611](https://github.com/microsoft/sarif-pattern-matcher/pull/611)
 
 ## *v1.8.0*
-
 - BUG: Resolve `InvalidOperationException` and `IndexOutOfRange` exceptions in `StaticValidatorBase.IsValidStatic` due to unsafe use of HashSet<string> class.
   [#595](https://github.com/microsoft/sarif-pattern-matcher/pull/585)
 - NR: Adding SlackWorkflow rule with dynamic validation.
@@ -55,10 +51,8 @@
   [#586](https://github.com/microsoft/sarif-pattern-matcher/pull/586)
 - NR: Adding IdentifiableNpmLegacyAuthorToken rule with dynamic validation.
   [#588](https://github.com/microsoft/sarif-pattern-matcher/pull/588)
-
-  
+    
 ## *v1.5.0-g9f639c22c7*
-
 - FPC: Improving RabbitMQ regex (removing new lines and spaces) from secret.
   [#548](https://github.com/microsoft/sarif-pattern-matcher/pull/548)
 - FND: Improving `SEC101/018.TwilioCredentials` dynamic validation for test
@@ -84,7 +78,6 @@
   [#562](https://github.com/microsoft/sarif-pattern-matcher/pull/562)
 
 ## *v1.5.0-alpha-0117-g136d47026e*
-
 - Plugin Improvement: Required properties will throw `KeyNotFoundException` if
   they do not exist.
   [#539](https://github.com/microsoft/sarif-pattern-matcher/pull/539)
@@ -100,7 +93,6 @@
   [#545](https://github.com/microsoft/sarif-pattern-matcher/pull/545)
   
 ## *v1.5.0-alpha-0109-gf687e5e98a*
-
 - NR: Adding CratesApiKey rule with dynamic validation.
   [#531](https://github.com/microsoft/sarif-pattern-matcher/pull/531)
 - Replacing `\b` to the correct border regular expression reducing false
@@ -110,7 +102,6 @@
   [#534](https://github.com/microsoft/sarif-pattern-matcher/pull/534)
 
 ## *v1.5.0-alpha-0100-g6ee5829558*
-
 - [6ee5829](https://github.com/microsoft/sarif-pattern-matcher/commit/6ee5829) Adding tests for NPM rule (#525)
 - [640f7f6](https://github.com/microsoft/sarif-pattern-matcher/commit/640f7f6) Making HttpClient static again when not using in tests (#526)
 - [4ca1e08](https://github.com/microsoft/sarif-pattern-matcher/commit/4ca1e08) Create Mock Http tests for Slack Tokens (#524)
@@ -127,7 +118,6 @@
 - [23dc3fe](https://github.com/microsoft/sarif-pattern-matcher/commit/23dc3fe) Improving exception handling for Crypto rule (#513)
 
 ## *v1.5.0-alpha-0086-gfe5f68dd32*
-
 - [fe5f68d](https://github.com/microsoft/sarif-pattern-matcher/commit/fe5f68d) Updating release notes and submodules (#511)
 - [4cab00f](https://github.com/microsoft/sarif-pattern-matcher/commit/4cab00f) Test StripeKey should be warning (#510)
 - [6874534](https://github.com/microsoft/sarif-pattern-matcher/commit/6874534) Fixing wrong resultlevelkind in cache (#509)

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## Unreleased
-- Update SARIF SDK submodule from [31f49b2 to 235394](https://github.com/microsoft/sarif-sdk/compare/31f49b2..235394). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/7805847d075b0991da6917cc934fb0924015402d/src/ReleaseHistory.md).
+- Update SARIF SDK submodule from [31f49b2 to 235394a](https://github.com/microsoft/sarif-sdk/compare/31f49b2..235394a). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/7805847d075b0991da6917cc934fb0924015402d/src/ReleaseHistory.md).
 - Update SEC101/028.PlaintextPassword regular expression to include scenarios where a variable name is used instead of string (added `*` after `["']`).
 - BREAKING: Properly introduce fingerprint versioned hierarchical strings (according to the [SARIF spec](https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317441)) by updating `/current` component to `/v0`. 
 - BREAKING: Remove non-functional `multiline` argument from command-line. This argument should simply be removed from all command-lines.
@@ -14,8 +14,9 @@
 - Rename `SEC101/017.NpmAuthorToken` to `SEC101/017.NpmAuthorToken` [#683](https://github.com/microsoft/sarif-pattern-matcher/pull/683)
 - Rename `SEC101/006.GitHubPat` to `SEC101/006.GitHubLegacyPat` [#678](https://github.com/microsoft/sarif-pattern-matcher/pull/678)
 - Disable `SEC101/029.AlibabaCloudCredentials` which throws ScanErrors with message: 
-	"ValidationError:Could not load file or assembly 'AlibabaCloud.OpenApiClient, Version=0.1.4.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies. A strongly-named assembly is required. (Exception from HRESULT: 0x80131044)" 
-	These exceptions are caused by incompatibilities between Alibaba code and .Net core 3.1 and 6.0. Will restore rule when dependencies are updated. [#700](https://github.com/microsoft/sarif-pattern-matcher/pull/700)
+	>ValidationError:Could not load file or assembly 'AlibabaCloud.OpenApiClient, Version=0.1.4.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies. A strongly-named assembly is required. (Exception from HRESULT: 0x80131044)
+	
+  These exceptions are caused by incompatibilities between Alibaba code and .Net core 3.1 and 6.0. Will restore rule when dependencies are updated. [#700](https://github.com/microsoft/sarif-pattern-matcher/pull/700)
 
 ## *2.0.0-dev*
 

--- a/Src/Plugins/AzureDevOpsConfiguration/AZC101.BuildDefinitionSecurity.json
+++ b/Src/Plugins/AzureDevOpsConfiguration/AZC101.BuildDefinitionSecurity.json
@@ -1,6 +1,8 @@
 {
-  "SharedStringsFileName": "AzureDevOpsConfiguration.SharedStrings.txt",
   "ValidatorsAssemblyName": "AzureDevOpsConfiguration.dll",
+  "SharedStringsFileName": "AzureDevOpsConfiguration.SharedStrings.txt",
+  "ExtensionName": "SecureAzureDevOps",
+  "Guid": "183f9c88-1424-4f6c-a8a5-cd59c0bdc312",
   "Definitions": [
     {
       "Id": "AZC101",

--- a/Src/Plugins/AzureDevOpsConfiguration/AZC102.ServiceConnectionSecurity.json
+++ b/Src/Plugins/AzureDevOpsConfiguration/AZC102.ServiceConnectionSecurity.json
@@ -1,6 +1,8 @@
 {
-  "SharedStringsFileName": "AzureDevOpsConfiguration.SharedStrings.txt",
   "ValidatorsAssemblyName": "AzureDevOpsConfiguration.dll",
+  "SharedStringsFileName": "AzureDevOpsConfiguration.SharedStrings.txt",
+  "ExtensionName": "SecureAzureDevOps",
+  "Guid": "47df6279-81d8-4975-b003-b24985217187",
   "Definitions": [
     {
       "Id": "AZC102",

--- a/Src/Plugins/SalModernization/SEC105.UpdateSalToCurrentVersion.json
+++ b/Src/Plugins/SalModernization/SEC105.UpdateSalToCurrentVersion.json
@@ -1,6 +1,8 @@
 {
-  "SharedStringsFileName": "SalModernization.SharedStrings.txt",
   "ValidatorsAssemblyName": "SalModernization.dll",
+  "SharedStringsFileName": "SalModernization.SharedStrings.txt",
+  "ExtensionName": "UseCurrentSalAnnotations",
+  "Guid": "9c5b3438-9e4c-4261-a785-1cec3e6e9efc",
   "Definitions": [
     {
       "Id": "SEC105/001",

--- a/Src/Plugins/Security/SEC101.SecurePlaintextSecrets.json
+++ b/Src/Plugins/Security/SEC101.SecurePlaintextSecrets.json
@@ -1,10 +1,11 @@
 {
   "ValidatorsAssemblyName": "Security.dll",
   "SharedStringsFileName": "Security.SharedStrings.txt",
+  "ExtensionName": "DoNotExposePlaintextSecrets",
+  "Guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
   "Definitions": [
     {
       "Id": "SEC101",
-      "Name": "DoNotExposePlaintextSecrets",
       "Level": "Warning",
       "FileNameDenyRegex": "$BinaryFiles",
       "Description": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content.",
@@ -12,307 +13,307 @@
       "MatchExpressions": [
         {
           "Id": "SEC101/002",
-          "Name": "DoNotExposePlaintextSecrets/GoogleOAuthCredentials",
+          "Name": "GoogleOAuthCredentials",
           "ContentsRegex": "$SEC101/002.GoogleOAuthCredentials",
           "MessageArguments": { "secretKind": "Google OAuth id and secret" },
           "HelpUri": "https://developers.google.com/identity/protocols/oauth2"
         },
         {
           "Id": "SEC101/003",
-          "Name": "DoNotExposePlaintextSecrets/GoogleApiKey",
+          "Name": "GoogleApiKey",
           "ContentsRegex": "$SEC101/003.GoogleApiKey",
           "MessageArguments": { "secretKind": "Google API key" },
           "HelpUri": "https://support.google.com/googleapi/answer/6158862?hl=en"
         },
         {
           "Id": "SEC101/004",
-          "Name": "DoNotExposePlaintextSecrets/FacebookAppCredentials",
+          "Name": "FacebookAppCredentials",
           "IntrafileRegexes": [ "$SEC101/004.FacebookAppCredentialsId", "$SEC101/004.FacebookAppCredentialsSecret" ],
           "MessageArguments": { "secretKind": "Facebook App id and secret" },
           "HelpUri": "https://developers.facebook.com/docs/facebook-login/security/#appsecret"
         },
         {
           "Id": "SEC101/005",
-          "Name": "DoNotExposePlaintextSecrets/SlackApiKey",
-          "DeprecatedName": "DoNotExposePlaintextSecrets/SlackToken",
+          "Name": "SlackApiKey",
+          "DeprecatedName": "SlackToken",
           "ContentsRegex": "$SEC101/005.SlackApiKey",
           "MessageArguments": { "secretKind": "Slack api key" },
           "HelpUri": "https://slack.com/help/articles/215770388-Create-and-regenerate-API-tokens"
         },
         {
           "Id": "SEC101/006",
-          "Name": "DoNotExposePlaintextSecrets/GitHubLegacyPat",
-          "DeprecatedName": "DoNotExposePlaintextSecrets/GitHubPat",
+          "Name": "GitHubLegacyPat",
+          "DeprecatedName": "GitHubPat",
           "ContentsRegex": "$SEC101/006.GitHubPatLegacy",
           "MessageArguments": { "secretKind": "legacy format GitHub personal access token" },
           "HelpUri": "https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/token-expiration-and-revocation"
         },
         {
           "Id": "SEC101/006",
-          "Name": "DoNotExposePlaintextSecrets/GitHubLegacyPat",
-          "DeprecatedName": "DoNotExposePlaintextSecrets/GitHubPat",
+          "Name": "GitHubLegacyPat",
+          "DeprecatedName": "GitHubPat",
           "ContentsRegex": "$SEC101/006.GitHubPatCurrent",
           "MessageArguments": { "secretKind": "GitHub personal access token" },
           "HelpUri": "https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/token-expiration-and-revocation"
         },
         {
           "Id": "SEC101/007",
-          "Name": "DoNotExposePlaintextSecrets/GitHubAppCredentials",
+          "Name": "GitHubAppCredentials",
           "IntrafileRegexes": [ "$SEC101/007.GitHubAppCredentialsId", "$SEC101/007.GitHubAppCredentialsSecret" ],
           "MessageArguments": { "secretKind": "GitHub app id and secret" },
           "HelpUri": "https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/token-expiration-and-revocation"
         },
         {
           "Id": "SEC101/008",
-          "Name": "DoNotExposePlaintextSecrets/AwsCredentials",
+          "Name": "AwsCredentials",
           "IntrafileRegexes": [ "$SEC101/008.AwsCredentialsId", "$SEC101/008.AwsCredentialsSecret" ],
           "MessageArguments": { "secretKind": "Aws access key and secret" },
           "HelpUri": "https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html"
         },
         {
           "Id": "SEC101/009",
-          "Name": "DoNotExposePlaintextSecrets/LinkedInCredentials",
+          "Name": "LinkedInCredentials",
           "IntrafileRegexes": [ "$SEC101/009.LinkedInCredentialsId", "$SEC101/009.LinkedInCredentialsSecret" ],
           "MessageArguments": { "secretKind": "LinkedIn access key and secret" },
           "HelpUri": "https://developer.linkedin.com/support/faq"
         },
         {
           "Id": "SEC101/010",
-          "Name": "DoNotExposePlaintextSecrets/SquarePat",
+          "Name": "SquarePat",
           "ContentsRegex": "$SEC101/010.SquarePat",
           "MessageArguments": { "secretKind": "Square personal access token" },
           "HelpUri": "https://developer.squareup.com/docs/build-basics/access-tokens"
         },
         {
           "Id": "SEC101/011",
-          "Name": "DoNotExposePlaintextSecrets/SquareCredentials",
+          "Name": "SquareCredentials",
           "IntrafileRegexes": [ "$SEC101/011.SquareCredentialsId", "$SEC101/011.SquareCredentialsSecret" ],
           "MessageArguments": { "secretKind": "Square access key and secret" },
           "HelpUri": "https://developer.squareup.com/docs/build-basics/access-tokens"
         },
         {
           "Id": "SEC101/012",
-          "Name": "DoNotExposePlaintextSecrets/SlackWebhook",
+          "Name": "SlackWebhook",
           "ContentsRegex": "$SEC101/012.SlackWebhook",
           "MessageArguments": { "secretKind": "Slack web hook" },
           "HelpUri": "https://slack.com/help/articles/215770388-Create-and-regenerate-API-tokens"
         },
         {
           "Id": "SEC101/013",
-          "Name": "DoNotExposePlaintextSecrets/CryptographicPrivateKey",
+          "Name": "CryptographicPrivateKey",
           "ContentsRegex": "$SEC101/013/Pem.CryptographicPrivateKey",
           "MessageArguments": { "secretKind": "PEM encoded private key" },
           "Properties": { "kind": "Default" }
         },
         {
           "Id": "SEC101/013",
-          "Name": "DoNotExposePlaintextSecrets/CryptographicPrivateKey",
+          "Name": "CryptographicPrivateKey",
           "ContentsRegex": "$SEC101/013/Putty.CryptographicPrivateKey",
           "MessageArguments": { "secretKind": "PuTTY private key" },
           "Properties": { "kind": "Putty" }
         },
         {
           "Id": "SEC101/013",
-          "Name": "DoNotExposePlaintextSecrets/CryptographicPrivateKey",
+          "Name": "CryptographicPrivateKey",
           "ContentsRegex": "$SEC101/013/PemCer.CryptographicPrivateKey",
           "MessageArguments": { "secretKind": "PEM encoded key" },
           "Properties": { "kind": "PemCer" }
         },
         {
           "Id": "SEC101/013",
-          "Name": "DoNotExposePlaintextSecrets/CryptographicPrivateKey",
+          "Name": "CryptographicPrivateKey",
           "ContentsRegex": "$SEC101/013/RsaKeyPair.CryptographicPrivateKey",
           "MessageArguments": { "secretKind": "XML RSA key pair" },
           "Properties": { "kind": "RSAKeyPair" }
         },
         {
           "Id": "SEC101/013",
-          "Name": "DoNotExposePlaintextSecrets/CryptographicPrivateKey",
+          "Name": "CryptographicPrivateKey",
           "ContentsRegex": "$SEC101/013/PrivateKeyBlob.CryptographicPrivateKey",
           "MessageArguments": { "secretKind": "Microsoft private key blob" },
           "Properties": { "kind": "PrivateKeyBlob" }
         },
         {
           "Id": "SEC101/014",
-          "Name": "DoNotExposePlaintextSecrets/FacebookAccessToken",
+          "Name": "FacebookAccessToken",
           "ContentsRegex": "$SEC101/014.FacebookAccessToken",
           "MessageArguments": { "secretKind": "Facebook access token" },
           "HelpUri": "https://developers.facebook.com/docs/facebook-login/access-tokens"
         },
         {
           "Id": "SEC101/015",
-          "Name": "DoNotExposePlaintextSecrets/AkamaiCredentials",
+          "Name": "AkamaiCredentials",
           "ContentsRegex": "$SEC101/015.AkamaiCredentials",
           "MessageArguments": { "secretKind": "Akamai credential" },
           "HelpUri": "https://developer.akamai.com/api/web_performance/key_and_quota/v1.html"
         },
         {
           "Id": "SEC101/016",
-          "Name": "DoNotExposePlaintextSecrets/StripeApiKey",
+          "Name": "StripeApiKey",
           "ContentsRegex": "$SEC101/016.StripeApiKey",
           "MessageArguments": { "secretKind": "Stripe API key" },
           "HelpUri": "https://stripe.com/docs/keys"
         },
         {
           "Id": "SEC101/017",
-          "Name": "DoNotExposePlaintextSecrets/NpmLegacyAuthorToken",
-          "DeprecatedName": "DoNotExposePlaintextSecrets/NpmAuthorToken",
+          "Name": "NpmLegacyAuthorToken",
+          "DeprecatedName": "NpmAuthorToken",
           "ContentsRegex": "$SEC101/017.NpmLegacyAuthorToken",
           "MessageArguments": { "secretKind": "NPM legacy author token" },
           "HelpUri": "https://docs.npmjs.com/creating-and-viewing-access-tokens"
         },
         {
           "Id": "SEC101/018",
-          "Name": "DoNotExposePlaintextSecrets/TwilioCredentials",
+          "Name": "TwilioCredentials",
           "IntrafileRegexes": [ "$SEC101/018.TwilioCredentialsId", "$SEC101/018.TwilioCredentialsSecret" ],
           "MessageArguments": { "secretKind": "Twilio credentials" },
           "HelpUri": "https://support.twilio.com/hc/en-us/articles/223136027-Auth-Tokens-and-How-to-Change-Them"
         },
         {
           "Id": "SEC101/019",
-          "Name": "DoNotExposePlaintextSecrets/PicaticApiKey",
+          "Name": "PicaticApiKey",
           "ContentsRegex": "$SEC101/019.PicaticApiKey",
           "MessageArguments": { "secretKind": "Picatic API key" },
           "HelpUri": "https://www.eventbrite.com/platform/api#/introduction/authentication"
         },
         {
           "Id": "SEC101/020",
-          "Name": "DoNotExposePlaintextSecrets/DropboxAccessToken",
+          "Name": "DropboxAccessToken",
           "ContentsRegex": "$SEC101/020.DropboxAccessTokenNoExpiration",
           "MessageArguments": { "secretKind": "Dropbox access token" },
           "HelpUri": "https://developers.dropbox.com/oauth-guide#implementing-oauth"
         },
         {
           "Id": "SEC101/020",
-          "Name": "DoNotExposePlaintextSecrets/DropboxAccessToken",
+          "Name": "DropboxAccessToken",
           "ContentsRegex": "$SEC101/020.DropboxAccessTokenShortExpiration",
           "MessageArguments": { "secretKind": "Dropbox access token" },
           "HelpUri": "https://developers.dropbox.com/oauth-guide#implementing-oauth"
         },
         {
           "Id": "SEC101/021",
-          "Name": "DoNotExposePlaintextSecrets/DropboxAppCredentials",
+          "Name": "DropboxAppCredentials",
           "IntrafileRegexes": [ "$SEC101/021.DropboxAppCredentialsId", "$SEC101/021.DropboxAppCredentialsSecret" ],
           "MessageArguments": { "secretKind": "Dropbox app credentials" },
           "HelpUri": "https://developers.dropbox.com/oauth-guide#implementing-oauth"
         },
         {
           "Id": "SEC101/022",
-          "Name": "DoNotExposePlaintextSecrets/PayPalBraintreeAccessToken",
+          "Name": "PayPalBraintreeAccessToken",
           "ContentsRegex": "$SEC101/022.PayPalBraintreeAccessToken",
           "MessageArguments": { "secretKind": "PayPal/Braintree Access Token" },
           "HelpUri": "https://developer.paypal.com/braintree/docs/guides/extend/oauth/access-tokens/"
         },
         {
           "Id": "SEC101/023",
-          "Name": "DoNotExposePlaintextSecrets/AmazonMwsAuthToken",
+          "Name": "AmazonMwsAuthToken",
           "ContentsRegex": "$SEC101/023.AmazonMwsAuthToken",
           "MessageArguments": { "secretKind": "Amazon MWS Auth Token" },
           "HelpUri": "https://docs.developer.amazonservices.com/en_US/faq.html#faq__GeneralFAQ"
         },
         {
           "Id": "SEC101/024",
-          "Name": "DoNotExposePlaintextSecrets/TwilioApiKey",
+          "Name": "TwilioApiKey",
           "ContentsRegex": "$SEC101/024.TwilioApiKey",
           "MessageArguments": { "secretKind": "Twilio API Key" },
           "HelpUri": "https://www.twilio.com/docs/usage/api/keys"
         },
         {
           "Id": "SEC101/025",
-          "Name": "DoNotExposePlaintextSecrets/SendGridApiKey",
+          "Name": "SendGridApiKey",
           "ContentsRegex": "$SEC101/025.SendGridApiKey",
           "MessageArguments": { "secretKind": "SendGrid API Key" },
           "HelpUri": "https://docs.sendgrid.com/api-reference/api-keys/delete-api-keys"
         },
         {
           "Id": "SEC101/026",
-          "Name": "DoNotExposePlaintextSecrets/MailgunApiCredentials",
-          "DeprecatedName": "DoNotExposePlaintextSecrets/MailgunApiKey",
+          "Name": "MailgunApiCredentials",
+          "DeprecatedName": "MailgunApiKey",
           "IntrafileRegexes": [ "$SEC101/026.MailgunApiCredentialsId", "$SEC101/026.MailgunApiCredentialsSecret" ],
           "MessageArguments": { "secretKind": "Mailgun API credential" },
           "HelpUri": "https://documentation.mailgun.com/en/latest/api-intro.html#authentication"
         },
         {
           "Id": "SEC101/027",
-          "Name": "DoNotExposePlaintextSecrets/MailChimpApiKey",
+          "Name": "MailChimpApiKey",
           "ContentsRegex": "$SEC101/027.MailChimpApiKey",
           "MessageArguments": { "secretKind": "MailChimp API Key" },
           "HelpUri": "https://mailchimp.com/help/about-api-keys/"
         },
         {
           "Id": "SEC101/028",
-          "Name": "DoNotExposePlaintextSecrets/PlaintextPassword",
+          "Name": "PlaintextPassword",
           "ContentsRegex": "$SEC101/028.PlaintextPassword",
           "MessageArguments": { "secretKind": "plaintext password" }
         },
         {
           "Id": "SEC101/030",
-          "Name": "DoNotExposePlaintextSecrets/GoogleServiceAccountKey",
+          "Name": "GoogleServiceAccountKey",
           "ContentsRegex": "$SEC101/030.GoogleServiceAccountKeyConsoleFormat",
           "MessageArguments": { "secretKind": "Google service account key" },
           "HelpUri": "https://cloud.google.com/iam/docs/creating-managing-service-account-keys"
         },
         {
           "Id": "SEC101/030",
-          "Name": "DoNotExposePlaintextSecrets/GoogleServiceAccountKey",
+          "Name": "GoogleServiceAccountKey",
           "ContentsRegex": "$SEC101/030.GoogleServiceAccountKeyConsoleRestFormat",
           "MessageArguments": { "secretKind": "Google service account key" },
           "HelpUri": "https://cloud.google.com/iam/docs/creating-managing-service-account-keys"
         },
         {
           "Id": "SEC101/031",
-          "Name": "DoNotExposePlaintextSecrets/NuGetApiKey",
+          "Name": "NuGetApiKey",
           "ContentsRegex": "$SEC101/031.NuGetApiKey",
           "MessageArguments": { "secretKind": "NuGet API Key" },
           "HelpUri": "https://aka.ms/1eslivesecrets/remediation#sec101031---nugetapikey"
         },
         {
           "Id": "SEC101/032",
-          "Name": "DoNotExposePlaintextSecrets/GpgCredentials",
+          "Name": "GpgCredentials",
           "ContentsRegex": "$SEC101/032.GpgCredentials",
           "MessageArguments": { "secretKind": "GPG credential" }
         },
         {
           "Id": "SEC101/033",
-          "Name": "DoNotExposePlaintextSecrets/MongoDbCredentials",
-          "DeprecatedName": "DoNotExposePlaintextSecrets/MongoDbConnectionString",
+          "Name": "MongoDbCredentials",
+          "DeprecatedName": "MongoDbConnectionString",
           "ContentsRegex": "$SEC101/033.MongoDbCredentials",
           "MessageArguments": { "secretKind": "MongoDb credential" }
         },
         {
           "Id": "SEC101/034",
-          "Name": "DoNotExposePlaintextSecrets/CredentialObject",
+          "Name": "CredentialObject",
           "ContentsRegex": "$SEC101/034.CredentialObjectConstructor",
           "MessageArguments": { "secretKind": "PSCredential constructor" }
         },
         {
           "Id": "SEC101/034",
-          "Name": "DoNotExposePlaintextSecrets/CredentialObject",
+          "Name": "CredentialObject",
           "ContentsRegex": "$SEC101/034.CredentialObjectInitializer",
           "MessageArguments": { "secretKind": "PSCredential object initializer" }
         },
         {
           "Id": "SEC101/035",
-          "Name": "DoNotExposePlaintextSecrets/CloudantCredentials",
+          "Name": "CloudantCredentials",
           "ContentsRegex": "$SEC101/035.CloudantCredentialsPython",
           "MessageArguments": { "secretKind": "Cloudant credential" }
         },
         {
           "Id": "SEC101/035",
-          "Name": "DoNotExposePlaintextSecrets/CloudantCredentials",
+          "Name": "CloudantCredentials",
           "ContentsRegex": "$SEC101/035.CloudantCredentialsJson",
           "MessageArguments": { "secretKind": "Cloudant credential" }
         },
         {
           "Id": "SEC101/035",
-          "Name": "DoNotExposePlaintextSecrets/CloudantCredentials",
+          "Name": "CloudantCredentials",
           "ContentsRegex": "$SEC101/035.CloudantCredentialsUrl",
           "MessageArguments": { "secretKind": "Cloudant credential" }
         },
         {
           "Id": "SEC101/036",
-          "Name": "DoNotExposePlaintextSecrets/MySqlCredentials",
-          "DeprecatedName": "DoNotExposePlaintextSecrets/MySqlConnectionString",
+          "Name": "MySqlCredentials",
+          "DeprecatedName": "MySqlConnectionString",
           "SingleLineRegexes": [
             "$SEC101/036.MySqlCredentialsAdoId",
             "$SEC101/036.MySqlCredentialsAdoHost",
@@ -325,16 +326,16 @@
         },
         {
           "Id": "SEC101/036",
-          "Name": "DoNotExposePlaintextSecrets/MySqlCredentials",
-          "DeprecatedName": "DoNotExposePlaintextSecrets/MySqlConnectionString",
+          "Name": "MySqlCredentials",
+          "DeprecatedName": "MySqlConnectionString",
           "ContentsRegex": "$SEC101/036.MySqlCredentialsPlainJdbc",
           "MessageArguments": { "secretKind": "JDBC MySQL credential" },
           "HelpUri": "https://aka.ms/1eslivesecrets/remediation#sec101036---mysqlcredentials"
         },
         {
           "Id": "SEC101/037",
-          "Name": "DoNotExposePlaintextSecrets/SqlCredentials",
-          "DeprecatedName": "DoNotExposePlaintextSecrets/SqlConnectionString",
+          "Name": "SqlCredentials",
+          "DeprecatedName": "SqlConnectionString",
           "SingleLineRegexes": [
             "$SEC101/037.SqlCredentialsAdoId",
             "$SEC101/037.SqlCredentialsAdoHost",
@@ -347,8 +348,8 @@
         },
         {
           "Id": "SEC101/037",
-          "Name": "DoNotExposePlaintextSecrets/SqlCredentials",
-          "DeprecatedName": "DoNotExposePlaintextSecrets/SqlConnectionString",
+          "Name": "SqlCredentials",
+          "DeprecatedName": "SqlConnectionString",
           "SingleLineRegexes": [
             "$SEC101/037.SqlCredentialsJdbcId",
             "$SEC101/037.SqlCredentialsJdbcHost",
@@ -361,16 +362,16 @@
         },
         {
           "Id": "SEC101/037",
-          "Name": "DoNotExposePlaintextSecrets/SqlCredentials",
-          "DeprecatedName": "DoNotExposePlaintextSecrets/SqlConnectionString",
+          "Name": "SqlCredentials",
+          "DeprecatedName": "SqlConnectionString",
           "ContentsRegex": "$SEC101/037.SqlCredentialsPhp",
           "MessageArguments": { "secretKind": "PHP SQL credential" },
           "HelpUri": "https://aka.ms/1eslivesecrets/remediation#sec101037---sqlcredentials"
         },
         {
           "Id": "SEC101/038",
-          "Name": "DoNotExposePlaintextSecrets/PostgreSqlCredentials",
-          "DeprecatedName": "DoNotExposePlaintextSecrets/PostgreSqlConnectionString",
+          "Name": "PostgreSqlCredentials",
+          "DeprecatedName": "PostgreSqlConnectionString",
           "SingleLineRegexes": [
             "$SEC101/038.PostgreSqlCredentialsAdoId",
             "$SEC101/038.PostgreSqlCredentialsAdoHost",
@@ -383,38 +384,38 @@
         },
         {
           "Id": "SEC101/039",
-          "Name": "DoNotExposePlaintextSecrets/ShopifyAccessToken",
+          "Name": "ShopifyAccessToken",
           "ContentsRegex": "$SEC101/039.ShopifyAccessToken",
           "MessageArguments": { "secretKind": "Shopify access token" }
         },
         {
           "Id": "SEC101/040",
-          "Name": "DoNotExposePlaintextSecrets/ShopifySharedSecret",
+          "Name": "ShopifySharedSecret",
           "ContentsRegex": "$SEC101/040.ShopifySharedSecret",
           "MessageArguments": { "secretKind": "Shopify shared secret" }
         },
         {
           "Id": "SEC101/041",
-          "Name": "DoNotExposePlaintextSecrets/RabbitMqCredentials",
-          "DeprecatedName": "DoNotExposePlaintextSecrets/RabbitMqConnectionString",
+          "Name": "RabbitMqCredentials",
+          "DeprecatedName": "RabbitMqConnectionString",
           "ContentsRegex": "$SEC101/041.RabbitMqCredentials",
           "MessageArguments": { "secretKind": "RabbitMq credential" }
         },
         {
           "Id": "SEC101/042",
-          "Name": "DoNotExposePlaintextSecrets/DynatraceToken",
+          "Name": "DynatraceToken",
           "ContentsRegex": "$SEC101/042.DynatraceToken",
           "MessageArguments": { "secretKind": "Dynatrace Key" }
         },
         {
           "Id": "SEC101/043",
-          "Name": "DoNotExposePlaintextSecrets/NuGetCredentials",
+          "Name": "NuGetCredentials",
           "ContentsRegex": "$SEC101/043.NuGetPackageSourceCredentialsXml",
           "MessageArguments": { "secretKind": "NuGet credentials" }
         },
         {
           "Id": "SEC101/044",
-          "Name": "DoNotExposePlaintextSecrets/NpmCredentials",
+          "Name": "NpmCredentials",
           "IntrafileRegexes": [
             "$SEC101/044.NpmCredentialsRegistry",
             "$SEC101/044.NpmCredentialsAuth"
@@ -424,7 +425,7 @@
         },
         {
           "Id": "SEC101/044",
-          "Name": "DoNotExposePlaintextSecrets/NpmCredentials",
+          "Name": "NpmCredentials",
           "IntrafileRegexes": [
             "$SEC101/044.NpmCredentialsRegistry",
             "$SEC101/044.NpmCredentialsUser",
@@ -435,47 +436,47 @@
         },
         {
           "Id": "SEC101/045",
-          "Name": "DoNotExposePlaintextSecrets/PostmanApiKey",
+          "Name": "PostmanApiKey",
           "ContentsRegex": "$SEC101/045.PostmanApiKey",
           "MessageArguments": { "secretKind": "Postman API key" },
           "HelpUri": "https://learning.postman.com/docs/developer/intro-api/"
         },
         {
           "Id": "SEC101/046",
-          "Name": "DoNotExposePlaintextSecrets/DiscordApiCredentials",
+          "Name": "DiscordApiCredentials",
           "IntrafileRegexes": [ "$SEC101/046.DiscordApiCredentialsId", "$SEC101/046.DiscordApiCredentialsSecret" ],
           "MessageArguments": { "secretKind": "Discord API credential" }
         },
         {
           "Id": "SEC101/047",
-          "Name": "DoNotExposePlaintextSecrets/CratesApiKey",
+          "Name": "CratesApiKey",
           "ContentsRegex": "$SEC101/047.CratesApiKey",
           "MessageArguments": { "secretKind": "Crates API key" }
         },
         {
           "Id": "SEC101/048",
-          "Name": "DoNotExposePlaintextSecrets/SlackWorkflowKey",
+          "Name": "SlackWorkflowKey",
           "ContentsRegex": "$SEC101/048.SlackWorkflowKey",
           "MessageArguments": { "secretKind": "Slack workflow key" }
         },
         {
           "Id": "SEC101/049",
-          "Name": "DoNotExposePlaintextSecrets/TelegramBotToken",
+          "Name": "TelegramBotToken",
           "ContentsRegex": "$SEC101/049.TelegramBotToken",
           "MessageArguments": { "secretKind": "Telegram bot token" },
           "HelpUri": "https://core.telegram.org/bots#generating-an-authentication-token"
         },
         {
           "Id": "SEC101/050",
-          "Name": "DoNotExposePlaintextSecrets/NpmIdentifiableAuthorToken",
-          "DeprecatedName": "DoNotExposePlaintextSecrets/IdentifiableNpmLegacyAuthorToken",
+          "Name": "NpmIdentifiableAuthorToken",
+          "DeprecatedName": "IdentifiableNpmLegacyAuthorToken",
           "ContentsRegex": "$SEC101/050.NpmIdentifiableAuthorToken",
           "MessageArguments": { "secretKind": "NPM identifiable author token" },
           "HelpUri": "https://docs.npmjs.com/creating-and-viewing-access-tokens"
         },
         {
           "Id": "SEC101/102",
-          "Name": "DoNotExposePlaintextSecrets/AdoPat",
+          "Name": "AdoPat",
           "MatchLengthToDecode": 52,
           "ContentsRegex": "$SEC101/102.AdoPat",
           "MessageArguments": { "secretKind": "Azure DevOps personal access token" },

--- a/Src/Plugins/Security/SEC102.ReviewPotentiallySensitiveData.json
+++ b/Src/Plugins/Security/SEC102.ReviewPotentiallySensitiveData.json
@@ -1,6 +1,8 @@
 {
   "ValidatorsAssemblyName": "Security.dll",
   "SharedStringsFileName": "Security.SharedStrings.txt",
+  "ExtensionName": "ReviewPotentiallySensitiveData",
+  "Guid": "dad7661b-34d6-4052-87b4-e234d9aae66b",
   "Definitions": [
     {
       "Id": "SEC102",

--- a/Src/Plugins/Security/SEC103.ReviewPotentiallySensitiveFiles.json
+++ b/Src/Plugins/Security/SEC103.ReviewPotentiallySensitiveFiles.json
@@ -1,5 +1,7 @@
 {
   "ValidatorsAssemblyName": "Security.dll",
+  "ExtensionName": "ReviewPotentiallySensitiveFiles",
+  "Guid": "3a7488cc-1b12-4f27-9239-af10146ebf30",
   "Definitions": [
     {
       "Name": "ReviewPotentiallySensitiveFiles",
@@ -9,7 +11,7 @@
       "Message": "'{0:scanTarget}' is {1:validationPrefix}{2:fileKind}{3:validationSuffix}{4:validatorMessage}.",
       "MatchExpressions": [
         {
-          "Id":  "SEC103/001",
+          "Id": "SEC103/001",
           "Name": "ReviewPotentiallySensitiveFiles/OnePasswordFile",
           "FileNameAllowRegex": "(?i)\\.(agilekeychain|agilekeychain_zip)$",
           "MessageArguments": { "fileKind": "1Password manager database file" }

--- a/Src/Plugins/Security/SEC104.UseSecureApi.json
+++ b/Src/Plugins/Security/SEC104.UseSecureApi.json
@@ -1,5 +1,7 @@
 {
   "SharedStringsFileName": "Security.SharedStrings.txt",
+  "ExtensionName": "UseSecureApi",
+  "Guid": "07374f10-f46b-458a-9179-cc937e1857e4",
   "Definitions": [
     {
       "Id": "SEC104/001",

--- a/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/BuildDefinitionSecurity/ExpectedOutputs/AZC101.builddefinition.DontMakeSecretsAvailableToForkedBuilds.sarif
+++ b/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/BuildDefinitionSecurity/ExpectedOutputs/AZC101.builddefinition.DontMakeSecretsAvailableToForkedBuilds.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "183f9c88-1424-4f6c-a8a5-cd59c0bdc312",
             "name": "Microsoft/AzureDevOpsConfiguration/SecureAzureDevOps",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "AZC101/240",

--- a/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/BuildDefinitionSecurity/ExpectedOutputs/AZC101.builddefinition.DontMakeSecretsAvailableToForkedBuilds.sarif
+++ b/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/BuildDefinitionSecurity/ExpectedOutputs/AZC101.builddefinition.DontMakeSecretsAvailableToForkedBuilds.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "183f9c88-1424-4f6c-a8a5-cd59c0bdc312",
             "name": "Microsoft/AzureDevOpsConfiguration/SecureAzureDevOps",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "AZC101/240",

--- a/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/BuildDefinitionSecurity/ExpectedOutputs/AZC101.builddefinition.DontMakeSecretsAvailableToForkedBuilds.sarif
+++ b/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/BuildDefinitionSecurity/ExpectedOutputs/AZC101.builddefinition.DontMakeSecretsAvailableToForkedBuilds.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "183f9c88-1424-4f6c-a8a5-cd59c0bdc312",
-            "name": "Microsoft/AzureDevOpsConfiguration/SecureAzureDevOps",
-            "version": "3.0.0.2",
+            "name": "SecureAzureDevOps",
             "rules": [
               {
                 "id": "AZC101/240",

--- a/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/BuildDefinitionSecurity/ExpectedOutputs/AZC101.builddefinition.DontMakeSecretsAvailableToForkedBuilds.sarif
+++ b/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/BuildDefinitionSecurity/ExpectedOutputs/AZC101.builddefinition.DontMakeSecretsAvailableToForkedBuilds.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "AZC101/240",
-              "name": "DontMakeSecretsAvailableToForkedBuilds",
-              "fullDescription": {
-                "text": "Do not make secrets available to builds for fork of public repository."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "183f9c88-1424-4f6c-a8a5-cd59c0bdc312",
+            "name": "Microsoft/AzureDevOpsConfiguration/SecureAzureDevOps",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "AZC101/240",
+                "name": "DontMakeSecretsAvailableToForkedBuilds",
+                "fullDescription": {
+                  "text": "Do not make secrets available to builds for fork of public repository."
                 },
-                "Default": {
-                  "text": "[Build Definition Id:{0}]({1}/{2}/{3}/_build/definitionId={0}) in organization '{2}' project '{3}' was found {4} {5} {6}."
-                }
-              },
-              "helpUri": "https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#important-security-considerations"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "[Build Definition Id:{0}]({1}/{2}/{3}/_build/definitionId={0}) in organization '{2}' project '{3}' was found {4} {5} {6}."
+                  }
+                },
+                "helpUri": "https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#important-security-considerations"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "AZC101.BuildDefinitionSecurity.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "AZC101/240",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "AZC101/240",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "error",
           "message": {
             "id": "Default",

--- a/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/BuildDefinitionSecurity/ExpectedOutputs/AZC101.builddefinition.NoIssue.sarif
+++ b/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/BuildDefinitionSecurity/ExpectedOutputs/AZC101.builddefinition.NoIssue.sarif
@@ -5,12 +5,15 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0"
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
         }
       },
       "invocations": [

--- a/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/BuildDefinitionSecurity/ExpectedOutputs/AZC101.builddefinition.NoIssue.sarif
+++ b/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/BuildDefinitionSecurity/ExpectedOutputs/AZC101.builddefinition.NoIssue.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "183f9c88-1424-4f6c-a8a5-cd59c0bdc312",
             "name": "Microsoft/AzureDevOpsConfiguration/SecureAzureDevOps",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "locations": [
               {
                 "uri": "AZC101.BuildDefinitionSecurity.json",

--- a/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/BuildDefinitionSecurity/ExpectedOutputs/AZC101.builddefinition.NoIssue.sarif
+++ b/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/BuildDefinitionSecurity/ExpectedOutputs/AZC101.builddefinition.NoIssue.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "183f9c88-1424-4f6c-a8a5-cd59c0bdc312",
-            "name": "Microsoft/AzureDevOpsConfiguration/SecureAzureDevOps",
-            "version": "3.0.0.2",
+            "name": "SecureAzureDevOps",
             "locations": [
               {
                 "uri": "AZC101.BuildDefinitionSecurity.json",

--- a/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/BuildDefinitionSecurity/ExpectedOutputs/AZC101.builddefinition.NoIssue.sarif
+++ b/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/BuildDefinitionSecurity/ExpectedOutputs/AZC101.builddefinition.NoIssue.sarif
@@ -14,7 +14,20 @@
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
-        }
+        },
+        "extensions": [
+          {
+            "guid": "183f9c88-1424-4f6c-a8a5-cd59c0bdc312",
+            "name": "Microsoft/AzureDevOpsConfiguration/SecureAzureDevOps",
+            "version": "1.11.0",
+            "locations": [
+              {
+                "uri": "AZC101.BuildDefinitionSecurity.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {

--- a/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/BuildDefinitionSecurity/ExpectedOutputs/AZC101.builddefinition.NoIssue.sarif
+++ b/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/BuildDefinitionSecurity/ExpectedOutputs/AZC101.builddefinition.NoIssue.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "183f9c88-1424-4f6c-a8a5-cd59c0bdc312",
             "name": "Microsoft/AzureDevOpsConfiguration/SecureAzureDevOps",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "locations": [
               {
                 "uri": "AZC101.BuildDefinitionSecurity.json",

--- a/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/ServiceConnectionSecurity/ExpectedOutputs/AZC102_150.serviceconnection.DoNotUseClassicConnections.sarif
+++ b/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/ServiceConnectionSecurity/ExpectedOutputs/AZC102_150.serviceconnection.DoNotUseClassicConnections.sarif
@@ -5,47 +5,63 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "AZC102/150",
-              "name": "DoNotUseClassicConnections",
-              "fullDescription": {
-                "text": "Do not use classic Azure service connections to access a subscription."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "47df6279-81d8-4975-b003-b24985217187",
+            "name": "Microsoft/AzureDevOpsConfiguration/SecureAzureDevOps",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "AZC102/150",
+                "name": "DoNotUseClassicConnections",
+                "fullDescription": {
+                  "text": "Do not use classic Azure service connections to access a subscription."
                 },
-                "Default": {
-                  "text": "[Service connection Id:{0}]({1}/{2}/{3}/_settings/adminservices?resourceId={0}) in organization '{2}' project '{3}' was found {4} {5} {6}."
-                }
-              },
-              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
-            },
-            {
-              "id": "AZC102/190",
-              "name": "DoNotGrantAllPipelinesAccess",
-              "fullDescription": {
-                "text": "Do not make service connection accessible to all pipelines."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "[Service connection Id:{0}]({1}/{2}/{3}/_settings/adminservices?resourceId={0}) in organization '{2}' project '{3}' was found {4} {5} {6}."
+                  }
                 },
-                "Default": {
-                  "text": "[Service connection Id:{0}]({1}) in organization '{2}' project '{3}' was scanned. {4}. {5} {6}."
-                }
+                "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
               },
-              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
-            }
-          ]
-        }
+              {
+                "id": "AZC102/190",
+                "name": "DoNotGrantAllPipelinesAccess",
+                "fullDescription": {
+                  "text": "Do not make service connection accessible to all pipelines."
+                },
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "[Service connection Id:{0}]({1}) in organization '{2}' project '{3}' was scanned. {4}. {5} {6}."
+                  }
+                },
+                "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "AZC102.ServiceConnectionSecurity.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -62,8 +78,13 @@
       ],
       "results": [
         {
-          "ruleId": "AZC102/150",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "AZC102/150",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "error",
           "message": {
             "id": "Default",
@@ -109,8 +130,10 @@
           "rank": 46.29
         },
         {
-          "ruleId": "AZC102/190",
-          "ruleIndex": 1,
+          "rule": {
+            "id": "AZC102/190",
+            "index": 1
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/ServiceConnectionSecurity/ExpectedOutputs/AZC102_150.serviceconnection.DoNotUseClassicConnections.sarif
+++ b/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/ServiceConnectionSecurity/ExpectedOutputs/AZC102_150.serviceconnection.DoNotUseClassicConnections.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "47df6279-81d8-4975-b003-b24985217187",
             "name": "Microsoft/AzureDevOpsConfiguration/SecureAzureDevOps",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "AZC102/150",

--- a/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/ServiceConnectionSecurity/ExpectedOutputs/AZC102_150.serviceconnection.DoNotUseClassicConnections.sarif
+++ b/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/ServiceConnectionSecurity/ExpectedOutputs/AZC102_150.serviceconnection.DoNotUseClassicConnections.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "47df6279-81d8-4975-b003-b24985217187",
-            "name": "Microsoft/AzureDevOpsConfiguration/SecureAzureDevOps",
-            "version": "3.0.0.2",
+            "name": "SecureAzureDevOps",
             "rules": [
               {
                 "id": "AZC102/150",

--- a/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/ServiceConnectionSecurity/ExpectedOutputs/AZC102_150.serviceconnection.DoNotUseClassicConnections.sarif
+++ b/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/ServiceConnectionSecurity/ExpectedOutputs/AZC102_150.serviceconnection.DoNotUseClassicConnections.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "47df6279-81d8-4975-b003-b24985217187",
             "name": "Microsoft/AzureDevOpsConfiguration/SecureAzureDevOps",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "AZC102/150",

--- a/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/ServiceConnectionSecurity/ExpectedOutputs/AZC102_150.serviceconnection.DoNotUseClassicConnections.sarif
+++ b/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/ServiceConnectionSecurity/ExpectedOutputs/AZC102_150.serviceconnection.DoNotUseClassicConnections.sarif
@@ -132,7 +132,10 @@
         {
           "rule": {
             "id": "AZC102/190",
-            "index": 1
+            "index": 1,
+            "toolComponent": {
+              "index": 0
+            }
           },
           "message": {
             "id": "Default",

--- a/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/ServiceConnectionSecurity/ExpectedOutputs/AZC102_190.serviceconnection.DoNotShareWithAllPipelines.sarif
+++ b/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/ServiceConnectionSecurity/ExpectedOutputs/AZC102_190.serviceconnection.DoNotShareWithAllPipelines.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "AZC102/190",
-              "name": "DoNotGrantAllPipelinesAccess",
-              "fullDescription": {
-                "text": "Do not make service connection accessible to all pipelines."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "47df6279-81d8-4975-b003-b24985217187",
+            "name": "Microsoft/AzureDevOpsConfiguration/SecureAzureDevOps",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "AZC102/190",
+                "name": "DoNotGrantAllPipelinesAccess",
+                "fullDescription": {
+                  "text": "Do not make service connection accessible to all pipelines."
                 },
-                "Default": {
-                  "text": "[Service connection Id:{0}]({1}) in organization '{2}' project '{3}' was scanned. {4}. {5} {6}."
-                }
-              },
-              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "[Service connection Id:{0}]({1}) in organization '{2}' project '{3}' was scanned. {4}. {5} {6}."
+                  }
+                },
+                "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "AZC102.ServiceConnectionSecurity.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "AZC102/190",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "AZC102/190",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/ServiceConnectionSecurity/ExpectedOutputs/AZC102_190.serviceconnection.DoNotShareWithAllPipelines.sarif
+++ b/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/ServiceConnectionSecurity/ExpectedOutputs/AZC102_190.serviceconnection.DoNotShareWithAllPipelines.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "47df6279-81d8-4975-b003-b24985217187",
             "name": "Microsoft/AzureDevOpsConfiguration/SecureAzureDevOps",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "AZC102/190",

--- a/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/ServiceConnectionSecurity/ExpectedOutputs/AZC102_190.serviceconnection.DoNotShareWithAllPipelines.sarif
+++ b/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/ServiceConnectionSecurity/ExpectedOutputs/AZC102_190.serviceconnection.DoNotShareWithAllPipelines.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "47df6279-81d8-4975-b003-b24985217187",
             "name": "Microsoft/AzureDevOpsConfiguration/SecureAzureDevOps",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "AZC102/190",

--- a/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/ServiceConnectionSecurity/ExpectedOutputs/AZC102_190.serviceconnection.DoNotShareWithAllPipelines.sarif
+++ b/Src/Plugins/Tests.AzureDevOpsConfiguration/TestData/ServiceConnectionSecurity/ExpectedOutputs/AZC102_190.serviceconnection.DoNotShareWithAllPipelines.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "47df6279-81d8-4975-b003-b24985217187",
-            "name": "Microsoft/AzureDevOpsConfiguration/SecureAzureDevOps",
-            "version": "3.0.0.2",
+            "name": "SecureAzureDevOps",
             "rules": [
               {
                 "id": "AZC102/190",

--- a/Src/Plugins/Tests.AzureDevOpsConfiguration/Validators/AZC102_190.DoNotShareWithAllPipelines.cs
+++ b/Src/Plugins/Tests.AzureDevOpsConfiguration/Validators/AZC102_190.DoNotShareWithAllPipelines.cs
@@ -176,7 +176,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.AzureDevOpsConfigu
                     sb.AppendLine($"The test '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
                 }
 
-                if (message != testCase.ExpectedMessage)
+                if (message?.Split(Environment.NewLine)[0] != testCase.ExpectedMessage)
                 {
                     sb.AppendLine($"The test '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
                 }

--- a/Src/Plugins/Tests.SalModernization/TestData/UpdateSalToCurrentVersion/ExpectedOutputs/SEC105_001.AnalysisAssume.sarif
+++ b/Src/Plugins/Tests.SalModernization/TestData/UpdateSalToCurrentVersion/ExpectedOutputs/SEC105_001.AnalysisAssume.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "9c5b3438-9e4c-4261-a785-1cec3e6e9efc",
-            "name": "Microsoft/SalModernization/UseCurrentSalAnnotations",
-            "version": "3.0.0.2",
+            "name": "UseCurrentSalAnnotations",
             "rules": [
               {
                 "id": "SEC105/001",

--- a/Src/Plugins/Tests.SalModernization/TestData/UpdateSalToCurrentVersion/ExpectedOutputs/SEC105_001.AnalysisAssume.sarif
+++ b/Src/Plugins/Tests.SalModernization/TestData/UpdateSalToCurrentVersion/ExpectedOutputs/SEC105_001.AnalysisAssume.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "9c5b3438-9e4c-4261-a785-1cec3e6e9efc",
             "name": "Microsoft/SalModernization/UseCurrentSalAnnotations",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC105/001",

--- a/Src/Plugins/Tests.SalModernization/TestData/UpdateSalToCurrentVersion/ExpectedOutputs/SEC105_001.AnalysisAssume.sarif
+++ b/Src/Plugins/Tests.SalModernization/TestData/UpdateSalToCurrentVersion/ExpectedOutputs/SEC105_001.AnalysisAssume.sarif
@@ -5,63 +5,79 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC105/001",
-              "name": "RemoveObsoleteOrRedundantAnnotations",
-              "fullDescription": {
-                "text": "Obsolete or redundant SAL annotation."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "9c5b3438-9e4c-4261-a785-1cec3e6e9efc",
+            "name": "Microsoft/SalModernization/UseCurrentSalAnnotations",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC105/001",
+                "name": "RemoveObsoleteOrRedundantAnnotations",
+                "fullDescription": {
+                  "text": "Obsolete or redundant SAL annotation."
                 },
-                "Default": {
-                  "text": "The SAL v1 '{0}' annotation is obsolete in SAL v2 and should be removed."
-                }
-              },
-              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
-            },
-            {
-              "id": "SEC105/002",
-              "name": "RenameLegacyAnnotationsToCurrentVersion",
-              "fullDescription": {
-                "text": "SAL 1 can be replaced with SAL 2."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "The SAL v1 '{0}' annotation is obsolete in SAL v2 and should be removed."
+                  }
                 },
-                "Default": {
-                  "text": "The SAL v1 '{0}' annotation is obsolete and should be replaced with the SAL v2 equivalent '{1}'."
-                }
+                "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
               },
-              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
-            },
-            {
-              "id": "SEC105/003",
-              "name": "UpdateAnnotationsToCurrentVersion",
-              "fullDescription": {
-                "text": "Conversion from SAL 1 to SAL 2 cannot be automatically done."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+              {
+                "id": "SEC105/002",
+                "name": "RenameLegacyAnnotationsToCurrentVersion",
+                "fullDescription": {
+                  "text": "SAL 1 can be replaced with SAL 2."
                 },
-                "Default": {
-                  "text": "The SAL v1 '{0}' annotation has changed in SAL v2 and should be converted manually to the correct pattern."
-                }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "The SAL v1 '{0}' annotation is obsolete and should be replaced with the SAL v2 equivalent '{1}'."
+                  }
+                },
+                "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
               },
-              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
-            }
-          ]
-        }
+              {
+                "id": "SEC105/003",
+                "name": "UpdateAnnotationsToCurrentVersion",
+                "fullDescription": {
+                  "text": "Conversion from SAL 1 to SAL 2 cannot be automatically done."
+                },
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "The SAL v1 '{0}' annotation has changed in SAL v2 and should be converted manually to the correct pattern."
+                  }
+                },
+                "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC105.UpdateSalToCurrentVersion.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -78,8 +94,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC105/001/allocator",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC105/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -149,8 +170,13 @@
           ]
         },
         {
-          "ruleId": "SEC105/001/allocator",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC105/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -220,8 +246,10 @@
           ]
         },
         {
-          "ruleId": "SEC105/002/analysisassume",
-          "ruleIndex": 1,
+          "rule": {
+            "id": "SEC105/002",
+            "index": 1
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -292,8 +320,10 @@
           ]
         },
         {
-          "ruleId": "SEC105/003/maybenull",
-          "ruleIndex": 2,
+          "rule": {
+            "id": "SEC105/003",
+            "index": 2
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -332,8 +362,10 @@
           "rank": 54.42
         },
         {
-          "ruleId": "SEC105/003/notnull",
-          "ruleIndex": 2,
+          "rule": {
+            "id": "SEC105/003",
+            "index": 2
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -372,8 +404,10 @@
           "rank": 54.42
         },
         {
-          "ruleId": "SEC105/003/postinvalid",
-          "ruleIndex": 2,
+          "rule": {
+            "id": "SEC105/003",
+            "index": 2
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -412,8 +446,10 @@
           "rank": 54.42
         },
         {
-          "ruleId": "SEC105/003/postinvalid",
-          "ruleIndex": 2,
+          "rule": {
+            "id": "SEC105/003",
+            "index": 2
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.SalModernization/TestData/UpdateSalToCurrentVersion/ExpectedOutputs/SEC105_001.AnalysisAssume.sarif
+++ b/Src/Plugins/Tests.SalModernization/TestData/UpdateSalToCurrentVersion/ExpectedOutputs/SEC105_001.AnalysisAssume.sarif
@@ -248,7 +248,10 @@
         {
           "rule": {
             "id": "SEC105/002",
-            "index": 1
+            "index": 1,
+            "toolComponent": {
+              "index": 0
+            }
           },
           "message": {
             "id": "Default",
@@ -322,7 +325,10 @@
         {
           "rule": {
             "id": "SEC105/003",
-            "index": 2
+            "index": 2,
+            "toolComponent": {
+              "index": 0
+            }
           },
           "message": {
             "id": "Default",
@@ -364,7 +370,10 @@
         {
           "rule": {
             "id": "SEC105/003",
-            "index": 2
+            "index": 2,
+            "toolComponent": {
+              "index": 0
+            }
           },
           "message": {
             "id": "Default",
@@ -406,7 +415,10 @@
         {
           "rule": {
             "id": "SEC105/003",
-            "index": 2
+            "index": 2,
+            "toolComponent": {
+              "index": 0
+            }
           },
           "message": {
             "id": "Default",
@@ -448,7 +460,10 @@
         {
           "rule": {
             "id": "SEC105/003",
-            "index": 2
+            "index": 2,
+            "toolComponent": {
+              "index": 0
+            }
           },
           "message": {
             "id": "Default",

--- a/Src/Plugins/Tests.SalModernization/TestData/UpdateSalToCurrentVersion/ExpectedOutputs/SEC105_001.AnalysisAssume.sarif
+++ b/Src/Plugins/Tests.SalModernization/TestData/UpdateSalToCurrentVersion/ExpectedOutputs/SEC105_001.AnalysisAssume.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "9c5b3438-9e4c-4261-a785-1cec3e6e9efc",
             "name": "Microsoft/SalModernization/UseCurrentSalAnnotations",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC105/001",

--- a/Src/Plugins/Tests.Security/EndToEndTests.cs
+++ b/Src/Plugins/Tests.Security/EndToEndTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             // as bugs in test utilization of shared resources) that could result.
             //
             var inputFiles = parameter as List<string>;
-            Dictionary<string, string>  results = Debugger.IsAttached
+            Dictionary<string, string> results = Debugger.IsAttached
                 ? SingleThreadedConstructTestOutputs(inputResourceNames, inputFiles)
                 : MultiThreadedConstructTestOutputs(inputResourceNames, inputFiles);
 

--- a/Src/Plugins/Tests.Security/EndToEndTests.cs
+++ b/Src/Plugins/Tests.Security/EndToEndTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             // extension name changes from .json to .dll).
 
             ISet<Skimmer<AnalyzeContext>> skimmers =
-                AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(fileSystem, 
+                AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(fileSystem,
                                                                   new string[] { regexDefinitionsPath },
                                                                   tool);
             return skimmers;

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_001.HttpAuthorizationRequestHeaderValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_001.HttpAuthorizationRequestHeaderValidatorTests.cs
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     sb.AppendLine($"The test '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
                 }
 
-                if (message != testCase.ExpectedMessage)
+                if (testCase.ExpectedMessage != message?.Split(Environment.NewLine)[0])
                 {
                     sb.AppendLine($"The test '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
                 }

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_004.FacebookAppCredentialsValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_004.FacebookAppCredentialsValidatorTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
@@ -156,7 +157,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
                 }
 
-                if (!message.Equals(testCase.ExpectedMessage))
+                if (testCase.ExpectedMessage != message?.Split(Environment.NewLine)[0])
                 {
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
                 }

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_005.SlackApiKeyValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_005.SlackApiKeyValidatorTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
@@ -172,7 +173,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
                 }
 
-                if (!message.Equals(testCase.ExpectedMessage))
+                if (testCase.ExpectedMessage != message?.Split(Environment.NewLine)[0])
                 {
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
                 }

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_007.GitHubAppCredentialsValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_007.GitHubAppCredentialsValidatorTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
@@ -98,7 +99,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
                 }
 
-                if (!message.Equals(testCase.ExpectedMessage))
+                if (testCase.ExpectedMessage != message?.Split(Environment.NewLine)[0])
                 {
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
                 }

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_010.SquarePatValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_010.SquarePatValidatorTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
@@ -91,7 +92,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
                 }
 
-                if (!message.Equals(testCase.ExpectedMessage))
+                if (testCase.ExpectedMessage != message?.Split(Environment.NewLine)[0])
                 {
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
                 }

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_011.SquareCredentialsValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_011.SquareCredentialsValidatorTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
@@ -132,7 +133,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
                 }
 
-                if (!message.Equals(testCase.ExpectedMessage))
+                if (testCase.ExpectedMessage != message?.Split(Environment.NewLine)[0])
                 {
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
                 }

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_012.SlackWebhookValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_012.SlackWebhookValidatorTests.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
                 }
 
-                if (!message.Equals(testCase.ExpectedMessage))
+                if (testCase.ExpectedMessage != message?.Split(Environment.NewLine)[0])
                 {
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
                 }

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_015.AkamaiCredentialsValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_015.AkamaiCredentialsValidatorTests.cs
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
                 }
 
-                if (!message.Equals(testCase.ExpectedMessage))
+                if (testCase.ExpectedMessage != message?.Split(Environment.NewLine)[0])
                 {
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
                 }

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_016.StripeApiKeyValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_016.StripeApiKeyValidatorTests.cs
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
                 }
 
-                if (!message.Equals(testCase.ExpectedMessage))
+                if (testCase.ExpectedMessage != message?.Split(Environment.NewLine)[0])
                 {
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
                 }

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_017.NpmLegacyAuthorTokenValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_017.NpmLegacyAuthorTokenValidatorTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
@@ -50,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     sb.AppendLine($"The test '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
                 }
 
-                if (message != testCase.ExpectedMessage)
+                if (testCase.ExpectedMessage != message?.Split(Environment.NewLine)[0])
                 {
                     sb.AppendLine($"The test '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
                 }

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_018.TwilioCredentialsValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_018.TwilioCredentialsValidatorTests.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
                 }
 
-                if (message != testCase.ExpectedMessage)
+                if (testCase.ExpectedMessage != message?.Split(Environment.NewLine)[0])
                 {
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
                 }

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_020.DropboxAccessTokenValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_020.DropboxAccessTokenValidatorTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
@@ -121,7 +122,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
                 }
 
-                if (!message.Equals(testCase.ExpectedMessage))
+                if (testCase.ExpectedMessage != message?.Split(Environment.NewLine)[0])
                 {
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
                 }

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_021.DropboxAppCredentialsValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_021.DropboxAppCredentialsValidatorTests.cs
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     sb.AppendLine($"The test '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
                 }
 
-                if (message != testCase.ExpectedMessage)
+                if (testCase.ExpectedMessage != message?.Split(Environment.NewLine)[0])
                 {
                     sb.AppendLine($"The test '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
                 }

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_025.SendGridApiKeyValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_025.SendGridApiKeyValidatorTests.cs
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
                 }
 
-                if (!message.Equals(testCase.ExpectedMessage))
+                if (testCase.ExpectedMessage != message?.Split(Environment.NewLine)[0])
                 {
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
                 }

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_026.MailgunApiKeyValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_026.MailgunApiKeyValidatorTests.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
                 }
 
-                if (!message.Equals(testCase.ExpectedMessage))
+                if (testCase.ExpectedMessage != message?.Split(Environment.NewLine)[0])
                 {
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
                 }

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_027.MailChimpApiKeyValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_027.MailChimpApiKeyValidatorTests.cs
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
                 }
 
-                if (!message.Equals(testCase.ExpectedMessage))
+                if (testCase.ExpectedMessage != message?.Split(Environment.NewLine)[0])
                 {
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
                 }

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_043.NuGetCredentialsValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_043.NuGetCredentialsValidatorTests.cs
@@ -227,7 +227,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     sb.AppendLine($"The test '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
                 }
 
-                if (message != testCase.ExpectedMessage)
+                if (testCase.ExpectedMessage != message?.Split(Environment.NewLine)[0])
                 {
                     sb.AppendLine($"The test '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
                 }

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_044.NpmCredentialsValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_044.NpmCredentialsValidatorTests.cs
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     sb.AppendLine($"The test '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
                 }
 
-                if (message != testCase.ExpectedMessage)
+                if (testCase.ExpectedMessage != message?.Split(Environment.NewLine)[0])
                 {
                     sb.AppendLine($"The test '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
                 }

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_045.PostmanApiKeyValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_045.PostmanApiKeyValidatorTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
                 }
 
-                if (!message.Equals(testCase.ExpectedMessage))
+                if (testCase.ExpectedMessage != message?.Split(Environment.NewLine)[0])
                 {
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
                 }

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_046.DiscordApiCredentialsValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_046.DiscordApiCredentialsValidatorTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
@@ -93,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
                 }
 
-                if (!message.Equals(testCase.ExpectedMessage))
+                if (testCase.ExpectedMessage != message?.Split(Environment.NewLine)[0])
                 {
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
                 }

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_047.CratesApiKeyValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_047.CratesApiKeyValidatorTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
@@ -77,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
                 }
 
-                if (message != testCase.ExpectedMessage)
+                if (testCase.ExpectedMessage != message?.Split(Environment.NewLine)[0])
                 {
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
                 }

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_048.SlackWorkflowKeyValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_048.SlackWorkflowKeyValidatorTests.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
                 }
 
-                if (message != testCase.ExpectedMessage)
+                if (!(testCase.ExpectedMessage == message?.Split(Environment.NewLine)[0]))
                 {
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
                 }

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_049.TelegramBotTokenValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_049.TelegramBotTokenValidatorTests.cs
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
                 }
 
-                if (message != testCase.ExpectedMessage)
+                if (!(testCase.ExpectedMessage == message?.Split(Environment.NewLine)[0]))
                 {
                     sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
                 }

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_050.NpmIdentifiableAuthorTokenValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_050.NpmIdentifiableAuthorTokenValidatorTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
@@ -50,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     sb.AppendLine($"The test '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
                 }
 
-                if (message != testCase.ExpectedMessage)
+                if (testCase.ExpectedMessage != message?.Split(Environment.NewLine)[0])
                 {
                     sb.AppendLine($"The test '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
                 }

--- a/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveData/ExpectedOutputs/SEC102_001.EmailAddress.sarif
+++ b/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveData/ExpectedOutputs/SEC102_001.EmailAddress.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "dad7661b-34d6-4052-87b4-e234d9aae66b",
             "name": "Microsoft/Security/ReviewPotentiallySensitiveData",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC102/001",

--- a/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveData/ExpectedOutputs/SEC102_001.EmailAddress.sarif
+++ b/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveData/ExpectedOutputs/SEC102_001.EmailAddress.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "dad7661b-34d6-4052-87b4-e234d9aae66b",
-            "name": "Microsoft/Security/ReviewPotentiallySensitiveData",
-            "version": "3.0.0.2",
+            "name": "ReviewPotentiallySensitiveData",
             "rules": [
               {
                 "id": "SEC102/001",

--- a/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveData/ExpectedOutputs/SEC102_001.EmailAddress.sarif
+++ b/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveData/ExpectedOutputs/SEC102_001.EmailAddress.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC102/001",
-              "name": "ReviewPotentiallySensitiveData/EmailAddress",
-              "fullDescription": {
-                "text": "Review exposed potentially sensitive data, such as service principal names, social security numbers, etc."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "dad7661b-34d6-4052-87b4-e234d9aae66b",
+            "name": "Microsoft/Security/ReviewPotentiallySensitiveData",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC102/001",
+                "name": "ReviewPotentiallySensitiveData/EmailAddress",
+                "fullDescription": {
+                  "text": "Review exposed potentially sensitive data, such as service principal names, social security numbers, etc."
                 },
-                "Default": {
-                  "text": "'{0}@{1}' is an apparent {2}."
-                }
-              },
-              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}@{1}' is an apparent {2}."
+                  }
+                },
+                "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC102.ReviewPotentiallySensitiveData.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -88,8 +109,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -130,8 +156,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -172,8 +203,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -214,8 +250,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -256,8 +297,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -298,8 +344,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -340,8 +391,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -382,8 +438,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -424,8 +485,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -466,8 +532,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -508,8 +579,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -550,8 +626,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -592,8 +673,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -634,8 +720,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -676,8 +767,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -718,8 +814,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -760,8 +861,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -802,8 +908,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -844,8 +955,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -886,8 +1002,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -928,8 +1049,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -970,8 +1096,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -1012,8 +1143,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -1054,8 +1190,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -1096,8 +1237,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -1138,8 +1284,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -1180,8 +1331,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -1222,8 +1378,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -1264,8 +1425,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -1306,8 +1472,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -1348,8 +1519,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -1390,8 +1566,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -1432,8 +1613,13 @@
           }
         },
         {
-          "ruleId": "SEC102/001",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",

--- a/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveData/ExpectedOutputs/SEC102_001.EmailAddress.sarif
+++ b/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveData/ExpectedOutputs/SEC102_001.EmailAddress.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "dad7661b-34d6-4052-87b4-e234d9aae66b",
             "name": "Microsoft/Security/ReviewPotentiallySensitiveData",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC102/001",

--- a/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveData/ExpectedOutputs/SEC102_002.SocialSecurityNumber.sarif
+++ b/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveData/ExpectedOutputs/SEC102_002.SocialSecurityNumber.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "dad7661b-34d6-4052-87b4-e234d9aae66b",
             "name": "Microsoft/Security/ReviewPotentiallySensitiveData",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC102/002",

--- a/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveData/ExpectedOutputs/SEC102_002.SocialSecurityNumber.sarif
+++ b/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveData/ExpectedOutputs/SEC102_002.SocialSecurityNumber.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC102/002",
-              "name": "ReviewPotentiallySensitiveData/SocialSecurityNumber",
-              "fullDescription": {
-                "text": "Review exposed potentially sensitive data, such as service principal names, social security numbers, etc."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "dad7661b-34d6-4052-87b4-e234d9aae66b",
+            "name": "Microsoft/Security/ReviewPotentiallySensitiveData",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC102/002",
+                "name": "ReviewPotentiallySensitiveData/SocialSecurityNumber",
+                "fullDescription": {
+                  "text": "Review exposed potentially sensitive data, such as service principal names, social security numbers, etc."
                 },
-                "Default": {
-                  "text": "'{0}' is an apparent {1}."
-                }
-              },
-              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is an apparent {1}."
+                  }
+                },
+                "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC102.ReviewPotentiallySensitiveData.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC102/002",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/002",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -88,8 +109,13 @@
           "rank": 46.82
         },
         {
-          "ruleId": "SEC102/002",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/002",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -130,8 +156,13 @@
           "rank": 40.65
         },
         {
-          "ruleId": "SEC102/002",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/002",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -172,8 +203,13 @@
           "rank": 44.23
         },
         {
-          "ruleId": "SEC102/002",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/002",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",

--- a/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveData/ExpectedOutputs/SEC102_002.SocialSecurityNumber.sarif
+++ b/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveData/ExpectedOutputs/SEC102_002.SocialSecurityNumber.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "dad7661b-34d6-4052-87b4-e234d9aae66b",
             "name": "Microsoft/Security/ReviewPotentiallySensitiveData",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC102/002",

--- a/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveData/ExpectedOutputs/SEC102_002.SocialSecurityNumber.sarif
+++ b/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveData/ExpectedOutputs/SEC102_002.SocialSecurityNumber.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "dad7661b-34d6-4052-87b4-e234d9aae66b",
-            "name": "Microsoft/Security/ReviewPotentiallySensitiveData",
-            "version": "3.0.0.2",
+            "name": "ReviewPotentiallySensitiveData",
             "rules": [
               {
                 "id": "SEC102/002",

--- a/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveData/ExpectedOutputs/SEC102_003.Url.sarif
+++ b/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveData/ExpectedOutputs/SEC102_003.Url.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "dad7661b-34d6-4052-87b4-e234d9aae66b",
             "name": "Microsoft/Security/ReviewPotentiallySensitiveData",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC102/003",

--- a/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveData/ExpectedOutputs/SEC102_003.Url.sarif
+++ b/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveData/ExpectedOutputs/SEC102_003.Url.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC102/003",
-              "name": "ReviewPotentiallySensitiveData/Url",
-              "fullDescription": {
-                "text": "Review exposed potentially sensitive data, such as service principal names, social security numbers, etc."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "dad7661b-34d6-4052-87b4-e234d9aae66b",
+            "name": "Microsoft/Security/ReviewPotentiallySensitiveData",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC102/003",
+                "name": "ReviewPotentiallySensitiveData/Url",
+                "fullDescription": {
+                  "text": "Review exposed potentially sensitive data, such as service principal names, social security numbers, etc."
                 },
-                "Default": {
-                  "text": "'{0}' is an apparent URL."
-                }
-              },
-              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is an apparent URL."
+                  }
+                },
+                "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC102.ReviewPotentiallySensitiveData.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC102/003",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/003",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -86,8 +107,13 @@
           }
         },
         {
-          "ruleId": "SEC102/003",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/003",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",
@@ -126,8 +152,13 @@
           }
         },
         {
-          "ruleId": "SEC102/003",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC102/003",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "note",
           "message": {
             "id": "Default",

--- a/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveData/ExpectedOutputs/SEC102_003.Url.sarif
+++ b/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveData/ExpectedOutputs/SEC102_003.Url.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "dad7661b-34d6-4052-87b4-e234d9aae66b",
             "name": "Microsoft/Security/ReviewPotentiallySensitiveData",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC102/003",

--- a/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveData/ExpectedOutputs/SEC102_003.Url.sarif
+++ b/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveData/ExpectedOutputs/SEC102_003.Url.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "dad7661b-34d6-4052-87b4-e234d9aae66b",
-            "name": "Microsoft/Security/ReviewPotentiallySensitiveData",
-            "version": "3.0.0.2",
+            "name": "ReviewPotentiallySensitiveData",
             "rules": [
               {
                 "id": "SEC102/003",

--- a/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_002.ASCIIArmoredFile_fake.sarif
+++ b/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_002.ASCIIArmoredFile_fake.sarif
@@ -34,8 +34,7 @@
         "extensions": [
           {
             "guid": "3a7488cc-1b12-4f27-9239-af10146ebf30",
-            "name": "Microsoft/Security/ReviewPotentiallySensitiveFiles",
-            "version": "3.0.0.2",
+            "name": "ReviewPotentiallySensitiveFiles",
             "locations": [
               {
                 "uri": "SEC103.ReviewPotentiallySensitiveFiles.json",

--- a/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_002.ASCIIArmoredFile_fake.sarif
+++ b/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_002.ASCIIArmoredFile_fake.sarif
@@ -32,7 +32,20 @@
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
-        }
+        },
+        "extensions": [
+          {
+            "guid": "3a7488cc-1b12-4f27-9239-af10146ebf30",
+            "name": "Microsoft/Security/ReviewPotentiallySensitiveFiles",
+            "version": "1.11.0",
+            "locations": [
+              {
+                "uri": "SEC103.ReviewPotentiallySensitiveFiles.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {

--- a/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_002.ASCIIArmoredFile_fake.sarif
+++ b/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_002.ASCIIArmoredFile_fake.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "rules": [
             {
               "id": "SEC103/002",
@@ -37,7 +35,7 @@
           {
             "guid": "3a7488cc-1b12-4f27-9239-af10146ebf30",
             "name": "Microsoft/Security/ReviewPotentiallySensitiveFiles",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "locations": [
               {
                 "uri": "SEC103.ReviewPotentiallySensitiveFiles.json",

--- a/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_002.ASCIIArmoredFile_fake.sarif
+++ b/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_002.ASCIIArmoredFile_fake.sarif
@@ -5,12 +5,12 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
           "rules": [
             {
               "id": "SEC103/002",
@@ -28,7 +28,10 @@
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
             }
-          ]
+          ],
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
         }
       },
       "invocations": [

--- a/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_002.ASCIIArmoredFile_fake.sarif
+++ b/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_002.ASCIIArmoredFile_fake.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "rules": [
             {
               "id": "SEC103/002",
@@ -37,7 +37,7 @@
           {
             "guid": "3a7488cc-1b12-4f27-9239-af10146ebf30",
             "name": "Microsoft/Security/ReviewPotentiallySensitiveFiles",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "locations": [
               {
                 "uri": "SEC103.ReviewPotentiallySensitiveFiles.json",

--- a/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_004.CertificateFile_der_encoded.sarif
+++ b/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_004.CertificateFile_der_encoded.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "rules": [
             {
               "id": "SEC103/004",
@@ -37,7 +35,7 @@
           {
             "guid": "3a7488cc-1b12-4f27-9239-af10146ebf30",
             "name": "Microsoft/Security/ReviewPotentiallySensitiveFiles",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "locations": [
               {
                 "uri": "SEC103.ReviewPotentiallySensitiveFiles.json",

--- a/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_004.CertificateFile_der_encoded.sarif
+++ b/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_004.CertificateFile_der_encoded.sarif
@@ -34,8 +34,7 @@
         "extensions": [
           {
             "guid": "3a7488cc-1b12-4f27-9239-af10146ebf30",
-            "name": "Microsoft/Security/ReviewPotentiallySensitiveFiles",
-            "version": "3.0.0.2",
+            "name": "ReviewPotentiallySensitiveFiles",
             "locations": [
               {
                 "uri": "SEC103.ReviewPotentiallySensitiveFiles.json",

--- a/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_004.CertificateFile_der_encoded.sarif
+++ b/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_004.CertificateFile_der_encoded.sarif
@@ -32,7 +32,20 @@
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
-        }
+        },
+        "extensions": [
+          {
+            "guid": "3a7488cc-1b12-4f27-9239-af10146ebf30",
+            "name": "Microsoft/Security/ReviewPotentiallySensitiveFiles",
+            "version": "1.11.0",
+            "locations": [
+              {
+                "uri": "SEC103.ReviewPotentiallySensitiveFiles.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {

--- a/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_004.CertificateFile_der_encoded.sarif
+++ b/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_004.CertificateFile_der_encoded.sarif
@@ -5,12 +5,12 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
           "rules": [
             {
               "id": "SEC103/004",
@@ -28,7 +28,10 @@
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
             }
-          ]
+          ],
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
         }
       },
       "invocations": [

--- a/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_004.CertificateFile_der_encoded.sarif
+++ b/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_004.CertificateFile_der_encoded.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "rules": [
             {
               "id": "SEC103/004",
@@ -37,7 +37,7 @@
           {
             "guid": "3a7488cc-1b12-4f27-9239-af10146ebf30",
             "name": "Microsoft/Security/ReviewPotentiallySensitiveFiles",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "locations": [
               {
                 "uri": "SEC103.ReviewPotentiallySensitiveFiles.json",

--- a/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_024.MicrosoftSerializedCertificateStoreFile_default.sarif
+++ b/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_024.MicrosoftSerializedCertificateStoreFile_default.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "rules": [
             {
               "id": "SEC103/024",
@@ -37,7 +37,7 @@
           {
             "guid": "3a7488cc-1b12-4f27-9239-af10146ebf30",
             "name": "Microsoft/Security/ReviewPotentiallySensitiveFiles",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "locations": [
               {
                 "uri": "SEC103.ReviewPotentiallySensitiveFiles.json",

--- a/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_024.MicrosoftSerializedCertificateStoreFile_default.sarif
+++ b/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_024.MicrosoftSerializedCertificateStoreFile_default.sarif
@@ -34,8 +34,7 @@
         "extensions": [
           {
             "guid": "3a7488cc-1b12-4f27-9239-af10146ebf30",
-            "name": "Microsoft/Security/ReviewPotentiallySensitiveFiles",
-            "version": "3.0.0.2",
+            "name": "ReviewPotentiallySensitiveFiles",
             "locations": [
               {
                 "uri": "SEC103.ReviewPotentiallySensitiveFiles.json",

--- a/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_024.MicrosoftSerializedCertificateStoreFile_default.sarif
+++ b/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_024.MicrosoftSerializedCertificateStoreFile_default.sarif
@@ -32,7 +32,20 @@
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
-        }
+        },
+        "extensions": [
+          {
+            "guid": "3a7488cc-1b12-4f27-9239-af10146ebf30",
+            "name": "Microsoft/Security/ReviewPotentiallySensitiveFiles",
+            "version": "1.11.0",
+            "locations": [
+              {
+                "uri": "SEC103.ReviewPotentiallySensitiveFiles.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {

--- a/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_024.MicrosoftSerializedCertificateStoreFile_default.sarif
+++ b/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_024.MicrosoftSerializedCertificateStoreFile_default.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "rules": [
             {
               "id": "SEC103/024",
@@ -37,7 +35,7 @@
           {
             "guid": "3a7488cc-1b12-4f27-9239-af10146ebf30",
             "name": "Microsoft/Security/ReviewPotentiallySensitiveFiles",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "locations": [
               {
                 "uri": "SEC103.ReviewPotentiallySensitiveFiles.json",

--- a/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_024.MicrosoftSerializedCertificateStoreFile_default.sarif
+++ b/Src/Plugins/Tests.Security/TestData/ReviewPotentiallySensitiveFiles/ExpectedOutputs/SEC103_024.MicrosoftSerializedCertificateStoreFile_default.sarif
@@ -5,12 +5,12 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
           "rules": [
             {
               "id": "SEC103/024",
@@ -28,7 +28,10 @@
               },
               "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
             }
-          ]
+          ],
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
         }
       },
       "invocations": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_001.HttpAuthorizationRequestHeader.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_001.HttpAuthorizationRequestHeader.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "locations": [
               {
                 "uri": "SEC101.SecurePlaintextSecrets.json",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_001.HttpAuthorizationRequestHeader.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_001.HttpAuthorizationRequestHeader.sarif
@@ -5,13 +5,29 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0"
-        }
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_001.HttpAuthorizationRequestHeader.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_001.HttpAuthorizationRequestHeader.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "locations": [
               {
                 "uri": "SEC101.SecurePlaintextSecrets.json",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_001.HttpAuthorizationRequestHeader.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_001.HttpAuthorizationRequestHeader.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "locations": [
               {
                 "uri": "SEC101.SecurePlaintextSecrets.json",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_002.GoogleOAuthCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_002.GoogleOAuthCredentials.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/002",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_002.GoogleOAuthCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_002.GoogleOAuthCredentials.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/002",
-              "name": "DoNotExposePlaintextSecrets/GoogleOAuthCredentials",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/002",
+                "name": "GoogleOAuthCredentials",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://developers.google.com/identity/protocols/oauth2"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://developers.google.com/identity/protocols/oauth2"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/002",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/002",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -91,8 +112,13 @@
           "rank": 60.74
         },
         {
-          "ruleId": "SEC101/002",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/002",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -136,8 +162,13 @@
           "rank": 60.74
         },
         {
-          "ruleId": "SEC101/002",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/002",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_002.GoogleOAuthCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_002.GoogleOAuthCredentials.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/002",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_002.GoogleOAuthCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_002.GoogleOAuthCredentials.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/002",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_003.GoogleApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_003.GoogleApiKey.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/003",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_003.GoogleApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_003.GoogleApiKey.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/003",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_003.GoogleApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_003.GoogleApiKey.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/003",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_003.GoogleApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_003.GoogleApiKey.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/003",
-              "name": "DoNotExposePlaintextSecrets/GoogleApiKey",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/003",
+                "name": "GoogleApiKey",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://support.google.com/googleapi/answer/6158862?hl=en"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://support.google.com/googleapi/answer/6158862?hl=en"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/003",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/003",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_004.FacebookAppCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_004.FacebookAppCredentials.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/004",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_004.FacebookAppCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_004.FacebookAppCredentials.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/004",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_004.FacebookAppCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_004.FacebookAppCredentials.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/004",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_004.FacebookAppCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_004.FacebookAppCredentials.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/004",
-              "name": "DoNotExposePlaintextSecrets/FacebookAppCredentials",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/004",
+                "name": "FacebookAppCredentials",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://developers.facebook.com/docs/facebook-login/security/#appsecret"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://developers.facebook.com/docs/facebook-login/security/#appsecret"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/004",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/004",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -91,8 +112,13 @@
           "rank": 54.56
         },
         {
-          "ruleId": "SEC101/004",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/004",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -136,8 +162,13 @@
           "rank": 54.56
         },
         {
-          "ruleId": "SEC101/004",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/004",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -181,8 +212,13 @@
           "rank": 54.56
         },
         {
-          "ruleId": "SEC101/004",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/004",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -226,8 +262,13 @@
           "rank": 54.56
         },
         {
-          "ruleId": "SEC101/004",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/004",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_005.SlackApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_005.SlackApiKey.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/005",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_005.SlackApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_005.SlackApiKey.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/005",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_005.SlackApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_005.SlackApiKey.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/005",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_005.SlackApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_005.SlackApiKey.sarif
@@ -5,34 +5,50 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/005",
-              "name": "DoNotExposePlaintextSecrets/SlackApiKey",
-              "deprecatedNames": [
-                "DoNotExposePlaintextSecrets/SlackToken"
-              ],
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/005",
+                "name": "SlackApiKey",
+                "deprecatedNames": [
+                  "SlackToken"
+                ],
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://slack.com/help/articles/215770388-Create-and-regenerate-API-tokens"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://slack.com/help/articles/215770388-Create-and-regenerate-API-tokens"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -49,8 +65,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/005",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/005",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_006.GitHubLegacyPat.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_006.GitHubLegacyPat.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/006",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_006.GitHubLegacyPat.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_006.GitHubLegacyPat.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/006",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_006.GitHubLegacyPat.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_006.GitHubLegacyPat.sarif
@@ -5,34 +5,50 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/006",
-              "name": "DoNotExposePlaintextSecrets/GitHubLegacyPat",
-              "deprecatedNames": [
-                "DoNotExposePlaintextSecrets/GitHubPat"
-              ],
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/006",
+                "name": "GitHubLegacyPat",
+                "deprecatedNames": [
+                  "GitHubPat"
+                ],
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/token-expiration-and-revocation"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/token-expiration-and-revocation"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -49,8 +65,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/006",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/006",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -94,8 +115,13 @@
           "rank": 49.73
         },
         {
-          "ruleId": "SEC101/006",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/006",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -139,8 +165,13 @@
           "rank": 50.75
         },
         {
-          "ruleId": "SEC101/006",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/006",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -184,8 +215,13 @@
           "rank": 51.69
         },
         {
-          "ruleId": "SEC101/006",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/006",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -229,8 +265,13 @@
           "rank": 47.5
         },
         {
-          "ruleId": "SEC101/006",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/006",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_006.GitHubLegacyPat.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_006.GitHubLegacyPat.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/006",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_007.GitHubAppCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_007.GitHubAppCredentials.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/007",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_007.GitHubAppCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_007.GitHubAppCredentials.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/007",
-              "name": "DoNotExposePlaintextSecrets/GitHubAppCredentials",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/007",
+                "name": "GitHubAppCredentials",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/token-expiration-and-revocation"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/token-expiration-and-revocation"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/007",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/007",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -91,8 +112,13 @@
           "rank": 39.88
         },
         {
-          "ruleId": "SEC101/007",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/007",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -136,8 +162,13 @@
           "rank": 34.39
         },
         {
-          "ruleId": "SEC101/007",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/007",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -181,8 +212,13 @@
           "rank": 34.41
         },
         {
-          "ruleId": "SEC101/007",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/007",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -226,8 +262,13 @@
           "rank": 39.88
         },
         {
-          "ruleId": "SEC101/007",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/007",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -271,8 +312,13 @@
           "rank": 34.39
         },
         {
-          "ruleId": "SEC101/007",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/007",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_007.GitHubAppCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_007.GitHubAppCredentials.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/007",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_007.GitHubAppCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_007.GitHubAppCredentials.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/007",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_008.AwsCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_008.AwsCredentials.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/008",
-              "name": "DoNotExposePlaintextSecrets/AwsCredentials",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/008",
+                "name": "AwsCredentials",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/008",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/008",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -91,8 +112,13 @@
           "rank": 66.61
         },
         {
-          "ruleId": "SEC101/008",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/008",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -136,8 +162,13 @@
           "rank": 65.9
         },
         {
-          "ruleId": "SEC101/008",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/008",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -181,8 +212,13 @@
           "rank": 66.61
         },
         {
-          "ruleId": "SEC101/008",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/008",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_008.AwsCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_008.AwsCredentials.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/008",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_008.AwsCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_008.AwsCredentials.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/008",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_008.AwsCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_008.AwsCredentials.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/008",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_009.LinkedInCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_009.LinkedInCredentials.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/009",
-              "name": "DoNotExposePlaintextSecrets/LinkedInCredentials",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/009",
+                "name": "LinkedInCredentials",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://developer.linkedin.com/support/faq"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://developer.linkedin.com/support/faq"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/009",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/009",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -91,8 +112,13 @@
           "rank": 14.29
         },
         {
-          "ruleId": "SEC101/009",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/009",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -136,8 +162,13 @@
           "rank": 14.29
         },
         {
-          "ruleId": "SEC101/009",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/009",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_009.LinkedInCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_009.LinkedInCredentials.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/009",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_009.LinkedInCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_009.LinkedInCredentials.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/009",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_009.LinkedInCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_009.LinkedInCredentials.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/009",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_010.SquarePat.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_010.SquarePat.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/010",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_010.SquarePat.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_010.SquarePat.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/010",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_010.SquarePat.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_010.SquarePat.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/010",
-              "name": "DoNotExposePlaintextSecrets/SquarePat",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/010",
+                "name": "SquarePat",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://developer.squareup.com/docs/build-basics/access-tokens"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://developer.squareup.com/docs/build-basics/access-tokens"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/010",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/010",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -91,8 +112,13 @@
           "rank": 74.86
         },
         {
-          "ruleId": "SEC101/010",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/010",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -136,8 +162,13 @@
           "rank": 74.86
         },
         {
-          "ruleId": "SEC101/010",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/010",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_010.SquarePat.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_010.SquarePat.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/010",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_011.SquareCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_011.SquareCredentials.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/011",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_011.SquareCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_011.SquareCredentials.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/011",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_011.SquareCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_011.SquareCredentials.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/011",
-              "name": "DoNotExposePlaintextSecrets/SquareCredentials",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/011",
+                "name": "SquareCredentials",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://developer.squareup.com/docs/build-basics/access-tokens"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://developer.squareup.com/docs/build-basics/access-tokens"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/011",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/011",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -91,8 +112,13 @@
           "rank": 71.41
         },
         {
-          "ruleId": "SEC101/011",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/011",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -136,8 +162,13 @@
           "rank": 72.2
         },
         {
-          "ruleId": "SEC101/011",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/011",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_011.SquareCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_011.SquareCredentials.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/011",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_012.SlackWebhook.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_012.SlackWebhook.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/012",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_012.SlackWebhook.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_012.SlackWebhook.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/012",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_012.SlackWebhook.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_012.SlackWebhook.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/012",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_012.SlackWebhook.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_012.SlackWebhook.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/012",
-              "name": "DoNotExposePlaintextSecrets/SlackWebhook",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/012",
+                "name": "SlackWebhook",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://slack.com/help/articles/215770388-Create-and-regenerate-API-tokens"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://slack.com/help/articles/215770388-Create-and-regenerate-API-tokens"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/012",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/012",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_013.CryptographicPrivateKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_013.CryptographicPrivateKey.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/013",
-              "name": "DoNotExposePlaintextSecrets/CryptographicPrivateKey",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/013",
+                "name": "CryptographicPrivateKey",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/013",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/013",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "level": "error",
           "message": {
             "id": "Default",
@@ -92,8 +113,13 @@
           "rank": 85.9
         },
         {
-          "ruleId": "SEC101/013",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/013",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_013.CryptographicPrivateKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_013.CryptographicPrivateKey.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/013",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_013.CryptographicPrivateKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_013.CryptographicPrivateKey.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/013",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_013.CryptographicPrivateKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_013.CryptographicPrivateKey.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/013",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_014.FacebookAccessToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_014.FacebookAccessToken.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/014",
-              "name": "DoNotExposePlaintextSecrets/FacebookAccessToken",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/014",
+                "name": "FacebookAccessToken",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://developers.facebook.com/docs/facebook-login/access-tokens"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://developers.facebook.com/docs/facebook-login/access-tokens"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/014",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/014",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -91,8 +112,13 @@
           "rank": 52.85
         },
         {
-          "ruleId": "SEC101/014",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/014",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_014.FacebookAccessToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_014.FacebookAccessToken.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/014",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_014.FacebookAccessToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_014.FacebookAccessToken.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/014",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_014.FacebookAccessToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_014.FacebookAccessToken.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/014",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_015.AkamaiCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_015.AkamaiCredentials.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/015",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_015.AkamaiCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_015.AkamaiCredentials.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/015",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_015.AkamaiCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_015.AkamaiCredentials.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/015",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_015.AkamaiCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_015.AkamaiCredentials.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/015",
-              "name": "DoNotExposePlaintextSecrets/AkamaiCredentials",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/015",
+                "name": "AkamaiCredentials",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://developer.akamai.com/api/web_performance/key_and_quota/v1.html"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://developer.akamai.com/api/web_performance/key_and_quota/v1.html"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/015",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/015",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -91,8 +112,13 @@
           "rank": 2.24
         },
         {
-          "ruleId": "SEC101/015",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/015",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -136,8 +162,13 @@
           "rank": 2.24
         },
         {
-          "ruleId": "SEC101/015",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/015",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_016.StripeApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_016.StripeApiKey.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/016",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_016.StripeApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_016.StripeApiKey.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/016",
-              "name": "DoNotExposePlaintextSecrets/StripeApiKey",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/016",
+                "name": "StripeApiKey",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://stripe.com/docs/keys"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://stripe.com/docs/keys"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/016",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/016",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -91,8 +112,13 @@
           "rank": 38.3
         },
         {
-          "ruleId": "SEC101/016",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/016",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_016.StripeApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_016.StripeApiKey.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/016",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_016.StripeApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_016.StripeApiKey.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/016",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_017.NpmLegacyAuthorToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_017.NpmLegacyAuthorToken.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/017",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_017.NpmLegacyAuthorToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_017.NpmLegacyAuthorToken.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/017",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_017.NpmLegacyAuthorToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_017.NpmLegacyAuthorToken.sarif
@@ -5,34 +5,50 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/017",
-              "name": "DoNotExposePlaintextSecrets/NpmLegacyAuthorToken",
-              "deprecatedNames": [
-                "DoNotExposePlaintextSecrets/NpmAuthorToken"
-              ],
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/017",
+                "name": "NpmLegacyAuthorToken",
+                "deprecatedNames": [
+                  "NpmAuthorToken"
+                ],
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://docs.npmjs.com/creating-and-viewing-access-tokens"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://docs.npmjs.com/creating-and-viewing-access-tokens"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -49,8 +65,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/017",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/017",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -94,8 +115,13 @@
           "rank": 52.63
         },
         {
-          "ruleId": "SEC101/017",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/017",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_017.NpmLegacyAuthorToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_017.NpmLegacyAuthorToken.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/017",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_018.TwilioCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_018.TwilioCredentials.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/018",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_018.TwilioCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_018.TwilioCredentials.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/018",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_018.TwilioCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_018.TwilioCredentials.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/018",
-              "name": "DoNotExposePlaintextSecrets/TwilioCredentials",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/018",
+                "name": "TwilioCredentials",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://support.twilio.com/hc/en-us/articles/223136027-Auth-Tokens-and-How-to-Change-Them"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://support.twilio.com/hc/en-us/articles/223136027-Auth-Tokens-and-How-to-Change-Them"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/018",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/018",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -91,8 +112,13 @@
           "rank": 54.56
         },
         {
-          "ruleId": "SEC101/018",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/018",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_018.TwilioCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_018.TwilioCredentials.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/018",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_019.PicaticApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_019.PicaticApiKey.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/016",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_019.PicaticApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_019.PicaticApiKey.sarif
@@ -5,47 +5,63 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/016",
-              "name": "DoNotExposePlaintextSecrets/StripeApiKey",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/016",
+                "name": "StripeApiKey",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://stripe.com/docs/keys"
-            },
-            {
-              "id": "SEC101/019",
-              "name": "DoNotExposePlaintextSecrets/PicaticApiKey",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
+                "helpUri": "https://stripe.com/docs/keys"
               },
-              "helpUri": "https://www.eventbrite.com/platform/api#/introduction/authentication"
-            }
-          ]
-        }
+              {
+                "id": "SEC101/019",
+                "name": "PicaticApiKey",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
+                },
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://www.eventbrite.com/platform/api#/introduction/authentication"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -62,8 +78,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/016",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/016",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -107,8 +128,13 @@
           "rank": 54.59
         },
         {
-          "ruleId": "SEC101/016",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/016",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -152,8 +178,13 @@
           "rank": 56.01
         },
         {
-          "ruleId": "SEC101/019",
-          "ruleIndex": 1,
+          "rule": {
+            "id": "SEC101/019",
+            "index": 1,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -197,8 +228,13 @@
           "rank": 54.59
         },
         {
-          "ruleId": "SEC101/019",
-          "ruleIndex": 1,
+          "rule": {
+            "id": "SEC101/019",
+            "index": 1,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_019.PicaticApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_019.PicaticApiKey.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/016",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_019.PicaticApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_019.PicaticApiKey.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/016",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_020.DropboxAccessToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_020.DropboxAccessToken.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/020",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_020.DropboxAccessToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_020.DropboxAccessToken.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/020",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_020.DropboxAccessToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_020.DropboxAccessToken.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/020",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_020.DropboxAccessToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_020.DropboxAccessToken.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/020",
-              "name": "DoNotExposePlaintextSecrets/DropboxAccessToken",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/020",
+                "name": "DropboxAccessToken",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://developers.dropbox.com/oauth-guide#implementing-oauth"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://developers.dropbox.com/oauth-guide#implementing-oauth"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/020",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/020",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -91,8 +112,13 @@
           "rank": 72.61
         },
         {
-          "ruleId": "SEC101/020",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/020",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_021.DropboxAppCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_021.DropboxAppCredentials.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/021",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_021.DropboxAppCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_021.DropboxAppCredentials.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/021",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_021.DropboxAppCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_021.DropboxAppCredentials.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/021",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_021.DropboxAppCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_021.DropboxAppCredentials.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/021",
-              "name": "DoNotExposePlaintextSecrets/DropboxAppCredentials",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/021",
+                "name": "DropboxAppCredentials",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://developers.dropbox.com/oauth-guide#implementing-oauth"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://developers.dropbox.com/oauth-guide#implementing-oauth"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/021",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/021",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_022.PayPalBraintreeAccessToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_022.PayPalBraintreeAccessToken.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/022",
-              "name": "DoNotExposePlaintextSecrets/PayPalBraintreeAccessToken",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/022",
+                "name": "PayPalBraintreeAccessToken",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://developer.paypal.com/braintree/docs/guides/extend/oauth/access-tokens/"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://developer.paypal.com/braintree/docs/guides/extend/oauth/access-tokens/"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/022",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/022",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -91,8 +112,13 @@
           "rank": 44.87
         },
         {
-          "ruleId": "SEC101/022",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/022",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_022.PayPalBraintreeAccessToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_022.PayPalBraintreeAccessToken.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/022",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_022.PayPalBraintreeAccessToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_022.PayPalBraintreeAccessToken.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/022",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_022.PayPalBraintreeAccessToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_022.PayPalBraintreeAccessToken.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/022",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_024.TwilioApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_024.TwilioApiKey.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/024",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_024.TwilioApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_024.TwilioApiKey.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/024",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_024.TwilioApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_024.TwilioApiKey.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/024",
-              "name": "DoNotExposePlaintextSecrets/TwilioApiKey",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/024",
+                "name": "TwilioApiKey",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://www.twilio.com/docs/usage/api/keys"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://www.twilio.com/docs/usage/api/keys"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/024",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/024",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -91,8 +112,13 @@
           "rank": 43.75
         },
         {
-          "ruleId": "SEC101/024",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/024",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_024.TwilioApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_024.TwilioApiKey.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/024",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_025.SendGridApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_025.SendGridApiKey.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/025",
-              "name": "DoNotExposePlaintextSecrets/SendGridApiKey",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/025",
+                "name": "SendGridApiKey",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://docs.sendgrid.com/api-reference/api-keys/delete-api-keys"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://docs.sendgrid.com/api-reference/api-keys/delete-api-keys"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/025",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/025",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_025.SendGridApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_025.SendGridApiKey.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/025",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_025.SendGridApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_025.SendGridApiKey.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/025",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_025.SendGridApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_025.SendGridApiKey.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/025",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_026.MailgunApiCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_026.MailgunApiCredentials.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/026",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_026.MailgunApiCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_026.MailgunApiCredentials.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/026",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_026.MailgunApiCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_026.MailgunApiCredentials.sarif
@@ -5,34 +5,50 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/026",
-              "name": "DoNotExposePlaintextSecrets/MailgunApiCredentials",
-              "deprecatedNames": [
-                "DoNotExposePlaintextSecrets/MailgunApiKey"
-              ],
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/026",
+                "name": "MailgunApiCredentials",
+                "deprecatedNames": [
+                  "MailgunApiKey"
+                ],
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://documentation.mailgun.com/en/latest/api-intro.html#authentication"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://documentation.mailgun.com/en/latest/api-intro.html#authentication"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -49,8 +65,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/026",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/026",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -94,8 +115,13 @@
           "rank": 37.01
         },
         {
-          "ruleId": "SEC101/026",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/026",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -139,8 +165,13 @@
           "rank": 37.01
         },
         {
-          "ruleId": "SEC101/026",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/026",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_026.MailgunApiCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_026.MailgunApiCredentials.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/026",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_027.MailChimpApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_027.MailChimpApiKey.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/027",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_027.MailChimpApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_027.MailChimpApiKey.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/027",
-              "name": "DoNotExposePlaintextSecrets/MailChimpApiKey",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/027",
+                "name": "MailChimpApiKey",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://mailchimp.com/help/about-api-keys/"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://mailchimp.com/help/about-api-keys/"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/027",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/027",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -91,8 +112,13 @@
           "rank": 46.45
         },
         {
-          "ruleId": "SEC101/027",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/027",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_027.MailChimpApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_027.MailChimpApiKey.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/027",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_027.MailChimpApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_027.MailChimpApiKey.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/027",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_028.PlaintextPassword.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_028.PlaintextPassword.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/028",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_028.PlaintextPassword.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_028.PlaintextPassword.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/028",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_028.PlaintextPassword.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_028.PlaintextPassword.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/028",
-              "name": "DoNotExposePlaintextSecrets/PlaintextPassword",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/028",
+                "name": "PlaintextPassword",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/028",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/028",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -91,8 +112,13 @@
           "rank": 42.48
         },
         {
-          "ruleId": "SEC101/028",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/028",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -136,8 +162,13 @@
           "rank": 33.62
         },
         {
-          "ruleId": "SEC101/028",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/028",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -181,8 +212,13 @@
           "rank": 33.17
         },
         {
-          "ruleId": "SEC101/028",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/028",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -226,8 +262,13 @@
           "rank": 36.43
         },
         {
-          "ruleId": "SEC101/028",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/028",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -271,8 +312,13 @@
           "rank": 36.43
         },
         {
-          "ruleId": "SEC101/028",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/028",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -316,8 +362,13 @@
           "rank": 33.62
         },
         {
-          "ruleId": "SEC101/028",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/028",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -361,8 +412,13 @@
           "rank": 0.0
         },
         {
-          "ruleId": "SEC101/028",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/028",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -406,8 +462,13 @@
           "rank": 33.17
         },
         {
-          "ruleId": "SEC101/028",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/028",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -451,8 +512,13 @@
           "rank": 44.07
         },
         {
-          "ruleId": "SEC101/028",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/028",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_028.PlaintextPassword.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_028.PlaintextPassword.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/028",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_029.AlibabaCloudCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_029.AlibabaCloudCredentials.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "locations": [
               {
                 "uri": "SEC101.SecurePlaintextSecrets.json",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_029.AlibabaCloudCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_029.AlibabaCloudCredentials.sarif
@@ -5,13 +5,29 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0"
-        }
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_029.AlibabaCloudCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_029.AlibabaCloudCredentials.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "locations": [
               {
                 "uri": "SEC101.SecurePlaintextSecrets.json",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_029.AlibabaCloudCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_029.AlibabaCloudCredentials.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "locations": [
               {
                 "uri": "SEC101.SecurePlaintextSecrets.json",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_030.GoogleServiceAccountKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_030.GoogleServiceAccountKey.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/030",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_030.GoogleServiceAccountKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_030.GoogleServiceAccountKey.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/030",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_030.GoogleServiceAccountKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_030.GoogleServiceAccountKey.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/030",
-              "name": "DoNotExposePlaintextSecrets/GoogleServiceAccountKey",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/030",
+                "name": "GoogleServiceAccountKey",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://cloud.google.com/iam/docs/creating-managing-service-account-keys"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://cloud.google.com/iam/docs/creating-managing-service-account-keys"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/030",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/030",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -91,8 +112,13 @@
           "rank": 0.0
         },
         {
-          "ruleId": "SEC101/030",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/030",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -136,8 +162,13 @@
           "rank": 32.85
         },
         {
-          "ruleId": "SEC101/030",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/030",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_030.GoogleServiceAccountKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_030.GoogleServiceAccountKey.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/030",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_031.NuGetApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_031.NuGetApiKey.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/031",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_031.NuGetApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_031.NuGetApiKey.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/031",
-              "name": "DoNotExposePlaintextSecrets/NuGetApiKey",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/031",
+                "name": "NuGetApiKey",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://aka.ms/1eslivesecrets/remediation#sec101031---nugetapikey"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://aka.ms/1eslivesecrets/remediation#sec101031---nugetapikey"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/031",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/031",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_031.NuGetApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_031.NuGetApiKey.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/031",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_031.NuGetApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_031.NuGetApiKey.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/031",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_032.GpgCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_032.GpgCredentials.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/032",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_032.GpgCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_032.GpgCredentials.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/032",
-              "name": "DoNotExposePlaintextSecrets/GpgCredentials",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/032",
+                "name": "GpgCredentials",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/032",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/032",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -91,8 +112,13 @@
           "rank": 44.07
         },
         {
-          "ruleId": "SEC101/032",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/032",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -136,8 +162,13 @@
           "rank": 44.07
         },
         {
-          "ruleId": "SEC101/032",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/032",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -181,8 +212,13 @@
           "rank": 44.07
         },
         {
-          "ruleId": "SEC101/032",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/032",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_032.GpgCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_032.GpgCredentials.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/032",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_032.GpgCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_032.GpgCredentials.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/032",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_033.MongoDbCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_033.MongoDbCredentials.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/033",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_033.MongoDbCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_033.MongoDbCredentials.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/033",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_033.MongoDbCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_033.MongoDbCredentials.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/033",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_033.MongoDbCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_033.MongoDbCredentials.sarif
@@ -5,34 +5,50 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/033",
-              "name": "DoNotExposePlaintextSecrets/MongoDbCredentials",
-              "deprecatedNames": [
-                "DoNotExposePlaintextSecrets/MongoDbConnectionString"
-              ],
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/033",
+                "name": "MongoDbCredentials",
+                "deprecatedNames": [
+                  "MongoDbConnectionString"
+                ],
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -49,8 +65,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/033",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/033",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -94,8 +115,13 @@
           "rank": 44.6
         },
         {
-          "ruleId": "SEC101/033",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/033",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -139,8 +165,13 @@
           "rank": 44.6
         },
         {
-          "ruleId": "SEC101/033",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/033",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -184,8 +215,13 @@
           "rank": 44.6
         },
         {
-          "ruleId": "SEC101/033",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/033",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -229,8 +265,13 @@
           "rank": 44.6
         },
         {
-          "ruleId": "SEC101/033",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/033",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -274,8 +315,13 @@
           "rank": 39.29
         },
         {
-          "ruleId": "SEC101/033",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/033",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_034.CredentialObject.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_034.CredentialObject.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/034",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_034.CredentialObject.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_034.CredentialObject.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/034",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_034.CredentialObject.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_034.CredentialObject.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/034",
-              "name": "DoNotExposePlaintextSecrets/CredentialObject",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/034",
+                "name": "CredentialObject",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/034",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/034",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -91,8 +112,13 @@
           "rank": 44.07
         },
         {
-          "ruleId": "SEC101/034",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/034",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -136,8 +162,13 @@
           "rank": 44.07
         },
         {
-          "ruleId": "SEC101/034",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/034",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -181,8 +212,13 @@
           "rank": 44.07
         },
         {
-          "ruleId": "SEC101/034",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/034",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -226,8 +262,13 @@
           "rank": 44.07
         },
         {
-          "ruleId": "SEC101/034",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/034",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_034.CredentialObject.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_034.CredentialObject.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/034",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_035.CloudantCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_035.CloudantCredentials.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/035",
-              "name": "DoNotExposePlaintextSecrets/CloudantCredentials",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/035",
+                "name": "CloudantCredentials",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/035",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/035",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -91,8 +112,13 @@
           "rank": 56.09
         },
         {
-          "ruleId": "SEC101/035",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/035",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -136,8 +162,13 @@
           "rank": 54.13
         },
         {
-          "ruleId": "SEC101/035",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/035",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_035.CloudantCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_035.CloudantCredentials.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/035",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_035.CloudantCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_035.CloudantCredentials.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/035",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_035.CloudantCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_035.CloudantCredentials.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/035",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_038.PostgreSqlCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_038.PostgreSqlCredentials.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/038",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_038.PostgreSqlCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_038.PostgreSqlCredentials.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/038",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_038.PostgreSqlCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_038.PostgreSqlCredentials.sarif
@@ -5,34 +5,50 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/038",
-              "name": "DoNotExposePlaintextSecrets/PostgreSqlCredentials",
-              "deprecatedNames": [
-                "DoNotExposePlaintextSecrets/PostgreSqlConnectionString"
-              ],
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/038",
+                "name": "PostgreSqlCredentials",
+                "deprecatedNames": [
+                  "PostgreSqlConnectionString"
+                ],
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://aka.ms/1eslivesecrets/remediation#sec101038----postgresqlcredentials"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://aka.ms/1eslivesecrets/remediation#sec101038----postgresqlcredentials"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -49,8 +65,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/038",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/038",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -94,8 +115,13 @@
           "rank": 42.11
         },
         {
-          "ruleId": "SEC101/038",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/038",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -139,8 +165,13 @@
           "rank": 29.41
         },
         {
-          "ruleId": "SEC101/038",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/038",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -184,8 +215,13 @@
           "rank": 29.41
         },
         {
-          "ruleId": "SEC101/038",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/038",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -229,8 +265,13 @@
           "rank": 29.41
         },
         {
-          "ruleId": "SEC101/038",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/038",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -274,8 +315,13 @@
           "rank": 29.41
         },
         {
-          "ruleId": "SEC101/038",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/038",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -319,8 +365,13 @@
           "rank": 29.41
         },
         {
-          "ruleId": "SEC101/038",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/038",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -364,8 +415,13 @@
           "rank": 29.41
         },
         {
-          "ruleId": "SEC101/038",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/038",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -409,8 +465,13 @@
           "rank": 29.41
         },
         {
-          "ruleId": "SEC101/038",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/038",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -454,8 +515,13 @@
           "rank": 29.41
         },
         {
-          "ruleId": "SEC101/038",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/038",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_038.PostgreSqlCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_038.PostgreSqlCredentials.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/038",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_039.ShopifyAccessToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_039.ShopifyAccessToken.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/039",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_039.ShopifyAccessToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_039.ShopifyAccessToken.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/039",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_039.ShopifyAccessToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_039.ShopifyAccessToken.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/039",
-              "name": "DoNotExposePlaintextSecrets/ShopifyAccessToken",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/039",
+                "name": "ShopifyAccessToken",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/039",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/039",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -91,8 +112,13 @@
           "rank": 49.08
         },
         {
-          "ruleId": "SEC101/039",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/039",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -136,8 +162,13 @@
           "rank": 49.96
         },
         {
-          "ruleId": "SEC101/039",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/039",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_039.ShopifyAccessToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_039.ShopifyAccessToken.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/039",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_040.ShopifySharedSecret.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_040.ShopifySharedSecret.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/040",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_040.ShopifySharedSecret.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_040.ShopifySharedSecret.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/040",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_040.ShopifySharedSecret.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_040.ShopifySharedSecret.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/040",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_040.ShopifySharedSecret.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_040.ShopifySharedSecret.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/040",
-              "name": "DoNotExposePlaintextSecrets/ShopifySharedSecret",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/040",
+                "name": "ShopifySharedSecret",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/040",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/040",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -91,8 +112,13 @@
           "rank": 47.3
         },
         {
-          "ruleId": "SEC101/040",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/040",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_041.RabbitMqCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_041.RabbitMqCredentials.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/041",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_041.RabbitMqCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_041.RabbitMqCredentials.sarif
@@ -5,34 +5,50 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/041",
-              "name": "DoNotExposePlaintextSecrets/RabbitMqCredentials",
-              "deprecatedNames": [
-                "DoNotExposePlaintextSecrets/RabbitMqConnectionString"
-              ],
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/041",
+                "name": "RabbitMqCredentials",
+                "deprecatedNames": [
+                  "RabbitMqConnectionString"
+                ],
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -49,8 +65,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/041",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/041",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -94,8 +115,13 @@
           "rank": 39.29
         },
         {
-          "ruleId": "SEC101/041",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/041",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -139,8 +165,13 @@
           "rank": 39.29
         },
         {
-          "ruleId": "SEC101/041",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/041",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -184,8 +215,13 @@
           "rank": 39.29
         },
         {
-          "ruleId": "SEC101/041",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/041",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_041.RabbitMqCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_041.RabbitMqCredentials.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/041",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_041.RabbitMqCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_041.RabbitMqCredentials.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/041",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_042.DynatraceToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_042.DynatraceToken.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/042",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_042.DynatraceToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_042.DynatraceToken.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/042",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_042.DynatraceToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_042.DynatraceToken.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/042",
-              "name": "DoNotExposePlaintextSecrets/DynatraceToken",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/042",
+                "name": "DynatraceToken",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/042",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/042",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -91,8 +112,13 @@
           "rank": 49.07
         },
         {
-          "ruleId": "SEC101/042",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/042",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_042.DynatraceToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_042.DynatraceToken.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/042",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_043.NuGetCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_043.NuGetCredentials.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/043",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_043.NuGetCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_043.NuGetCredentials.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/043",
-              "name": "DoNotExposePlaintextSecrets/NuGetCredentials",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/043",
+                "name": "NuGetCredentials",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/043",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/043",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -91,8 +112,13 @@
           "rank": 34.48
         },
         {
-          "ruleId": "SEC101/043",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/043",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -136,8 +162,13 @@
           "rank": 34.48
         },
         {
-          "ruleId": "SEC101/043",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/043",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -181,8 +212,13 @@
           "rank": 34.48
         },
         {
-          "ruleId": "SEC101/043",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/043",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -226,8 +262,13 @@
           "rank": 34.48
         },
         {
-          "ruleId": "SEC101/043",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/043",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -271,8 +312,13 @@
           "rank": 56.25
         },
         {
-          "ruleId": "SEC101/043",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/043",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -316,8 +362,13 @@
           "rank": 56.83
         },
         {
-          "ruleId": "SEC101/043",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/043",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -361,8 +412,13 @@
           "rank": 56.25
         },
         {
-          "ruleId": "SEC101/043",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/043",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_043.NuGetCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_043.NuGetCredentials.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/043",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_043.NuGetCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_043.NuGetCredentials.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/043",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_044.NpmCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_044.NpmCredentials.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/044",
-              "name": "DoNotExposePlaintextSecrets/NpmCredentials",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/044",
+                "name": "NpmCredentials",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://aka.ms/1eslivesecrets/remediation#sec101044---npmcredentials"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://aka.ms/1eslivesecrets/remediation#sec101044---npmcredentials"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/044",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/044",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -91,8 +112,13 @@
           "rank": 42.11
         },
         {
-          "ruleId": "SEC101/044",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/044",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -136,8 +162,13 @@
           "rank": 42.11
         },
         {
-          "ruleId": "SEC101/044",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/044",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -181,8 +212,13 @@
           "rank": 51.67
         },
         {
-          "ruleId": "SEC101/044",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/044",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [
@@ -226,8 +262,13 @@
           "rank": 42.11
         },
         {
-          "ruleId": "SEC101/044",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/044",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_044.NpmCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_044.NpmCredentials.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/044",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_044.NpmCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_044.NpmCredentials.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/044",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_044.NpmCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_044.NpmCredentials.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/044",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_045.PostmanApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_045.PostmanApiKey.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/045",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_045.PostmanApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_045.PostmanApiKey.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/045",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_045.PostmanApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_045.PostmanApiKey.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/045",
-              "name": "DoNotExposePlaintextSecrets/PostmanApiKey",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/045",
+                "name": "PostmanApiKey",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://learning.postman.com/docs/developer/intro-api/"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://learning.postman.com/docs/developer/intro-api/"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/045",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/045",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_045.PostmanApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_045.PostmanApiKey.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/045",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_046.DiscordApiCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_046.DiscordApiCredentials.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/046",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_046.DiscordApiCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_046.DiscordApiCredentials.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/046",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_046.DiscordApiCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_046.DiscordApiCredentials.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/046",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_046.DiscordApiCredentials.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_046.DiscordApiCredentials.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/046",
-              "name": "DoNotExposePlaintextSecrets/DiscordApiCredentials",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/046",
+                "name": "DiscordApiCredentials",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/046",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/046",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_047.CratesApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_047.CratesApiKey.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/047",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_047.CratesApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_047.CratesApiKey.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/047",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_047.CratesApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_047.CratesApiKey.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/047",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_047.CratesApiKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_047.CratesApiKey.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/047",
-              "name": "DoNotExposePlaintextSecrets/CratesApiKey",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/047",
+                "name": "CratesApiKey",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/047",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/047",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_048.SlackWorkflowKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_048.SlackWorkflowKey.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/048",
-              "name": "DoNotExposePlaintextSecrets/SlackWorkflowKey",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/048",
+                "name": "SlackWorkflowKey",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/048",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/048",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_048.SlackWorkflowKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_048.SlackWorkflowKey.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/048",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_048.SlackWorkflowKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_048.SlackWorkflowKey.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/048",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_048.SlackWorkflowKey.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_048.SlackWorkflowKey.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/048",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_049.TelegramBotToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_049.TelegramBotToken.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/049",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_049.TelegramBotToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_049.TelegramBotToken.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/049",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_049.TelegramBotToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_049.TelegramBotToken.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/049",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_049.TelegramBotToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_049.TelegramBotToken.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/049",
-              "name": "DoNotExposePlaintextSecrets/TelegramBotToken",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/049",
+                "name": "TelegramBotToken",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://core.telegram.org/bots#generating-an-authentication-token"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://core.telegram.org/bots#generating-an-authentication-token"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/049",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/049",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_050.NpmIdentifiableAuthorToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_050.NpmIdentifiableAuthorToken.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/050",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_050.NpmIdentifiableAuthorToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_050.NpmIdentifiableAuthorToken.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/050",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_050.NpmIdentifiableAuthorToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_050.NpmIdentifiableAuthorToken.sarif
@@ -5,34 +5,50 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/050",
-              "name": "DoNotExposePlaintextSecrets/NpmIdentifiableAuthorToken",
-              "deprecatedNames": [
-                "DoNotExposePlaintextSecrets/IdentifiableNpmLegacyAuthorToken"
-              ],
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/050",
+                "name": "NpmIdentifiableAuthorToken",
+                "deprecatedNames": [
+                  "IdentifiableNpmLegacyAuthorToken"
+                ],
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://docs.npmjs.com/creating-and-viewing-access-tokens"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://docs.npmjs.com/creating-and-viewing-access-tokens"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -49,8 +65,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/050",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/050",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_050.NpmIdentifiableAuthorToken.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_050.NpmIdentifiableAuthorToken.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/050",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_102.AdoPat.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_102.AdoPat.sarif
@@ -16,8 +16,7 @@
         "extensions": [
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
-            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.2",
+            "name": "DoNotExposePlaintextSecrets",
             "rules": [
               {
                 "id": "SEC101/102",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_102.AdoPat.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_102.AdoPat.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +17,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "3.0.0.1",
+            "version": "3.0.0.2",
             "rules": [
               {
                 "id": "SEC101/102",

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_102.AdoPat.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_102.AdoPat.sarif
@@ -5,31 +5,47 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC101/102",
-              "name": "DoNotExposePlaintextSecrets/AdoPat",
-              "fullDescription": {
-                "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
+            "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
+            "version": "1.11.0",
+            "rules": [
+              {
+                "id": "SEC101/102",
+                "name": "AdoPat",
+                "fullDescription": {
+                  "text": "Do not expose plaintext (or base64-encoded plaintext) secrets in versioned engineering content."
                 },
-                "Default": {
-                  "text": "'{0}' is {1}{2}{3}{4}{5}."
-                }
-              },
-              "helpUri": "https://aka.ms/1eslivesecrets/remediation#sec101102---adopat"
-            }
-          ]
-        }
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' is {1}{2}{3}{4}{5}."
+                  }
+                },
+                "helpUri": "https://aka.ms/1eslivesecrets/remediation#sec101102---adopat"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC101.SecurePlaintextSecrets.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -46,8 +62,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC101/102",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC101/102",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_102.AdoPat.sarif
+++ b/Src/Plugins/Tests.Security/TestData/SecurePlaintextSecrets/ExpectedOutputs/SEC101_102.AdoPat.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }
@@ -19,7 +19,7 @@
           {
             "guid": "6e04e237-f14b-4ff9-9cd8-e037a10cb510",
             "name": "Microsoft/Security/DoNotExposePlaintextSecrets",
-            "version": "1.11.0",
+            "version": "3.0.0.1",
             "rules": [
               {
                 "id": "SEC101/102",

--- a/Src/Plugins/Tests.Security/TestData/UseSecureApi/ExpectedOutputs/SEC104.Memory.Allocation_alloca.sarif
+++ b/Src/Plugins/Tests.Security/TestData/UseSecureApi/ExpectedOutputs/SEC104.Memory.Allocation_alloca.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }

--- a/Src/Plugins/Tests.Security/TestData/UseSecureApi/ExpectedOutputs/SEC104.Memory.Allocation_alloca.sarif
+++ b/Src/Plugins/Tests.Security/TestData/UseSecureApi/ExpectedOutputs/SEC104.Memory.Allocation_alloca.sarif
@@ -5,34 +5,49 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC104/001",
-              "name": "UseSecureApi/Memory/Allocation",
-              "fullDescription": {
-                "text": "Developers should use secure API in preferance of insecure alternates."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "07374f10-f46b-458a-9179-cc937e1857e4",
+            "name": "UseSecureApi",
+            "rules": [
+              {
+                "id": "SEC104/001",
+                "name": "UseSecureApi/Memory/Allocation",
+                "fullDescription": {
+                  "text": "Developers should use secure API in preferance of insecure alternates."
                 },
-                "Default": {
-                  "text": "'{0}' contains a call to '{1}', a potentially insecure API that could be replaced with a more secure alternative: {2}."
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' contains a call to '{1}', a potentially insecure API that could be replaced with a more secure alternative: {2}."
+                  },
+                  "Default_Secure": {
+                    "text": "'{0}' contains a call to '{1}', a more secure alternative to one or more potentially insecure APIs: {2}."
+                  }
                 },
-                "Default_Secure": {
-                  "text": "'{0}' contains a call to '{1}', a more secure alternative to one or more potentially insecure APIs: {2}."
-                }
-              },
-              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
-            }
-          ]
-        }
+                "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC104.UseSecureApi.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -49,8 +64,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC104/001/_alloca",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC104/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "message": {
             "id": "Default",
             "arguments": [

--- a/Src/Plugins/Tests.Security/TestData/UseSecureApi/ExpectedOutputs/SEC104.Memory.Allocation_alloca.sarif
+++ b/Src/Plugins/Tests.Security/TestData/UseSecureApi/ExpectedOutputs/SEC104.Memory.Allocation_alloca.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }

--- a/Src/Plugins/Tests.Security/TestData/UseSecureApi/ExpectedOutputs/SEC104.Memory.Allocation_malloca.sarif
+++ b/Src/Plugins/Tests.Security/TestData/UseSecureApi/ExpectedOutputs/SEC104.Memory.Allocation_malloca.sarif
@@ -8,9 +8,9 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 1.11.0.0",
-          "version": "1.11.0",
-          "dottedQuadFileVersion": "1.11.0.0",
+          "fullName": "Sarif.PatternMatcher 3.0.0.0",
+          "version": "3.0.0.1",
+          "dottedQuadFileVersion": "3.0.0.0",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }

--- a/Src/Plugins/Tests.Security/TestData/UseSecureApi/ExpectedOutputs/SEC104.Memory.Allocation_malloca.sarif
+++ b/Src/Plugins/Tests.Security/TestData/UseSecureApi/ExpectedOutputs/SEC104.Memory.Allocation_malloca.sarif
@@ -5,34 +5,49 @@
     {
       "tool": {
         "driver": {
-          "name": "testhost",
-          "organization": "Microsoft Corporation",
-          "product": "Microsoft.TestHost",
-          "fullName": "testhost 15.0.0.0",
-          "version": "15.0.0.0",
-          "semanticVersion": "15.0.0",
-          "rules": [
-            {
-              "id": "SEC104/001",
-              "name": "UseSecureApi/Memory/Allocation",
-              "fullDescription": {
-                "text": "Developers should use secure API in preferance of insecure alternates."
-              },
-              "messageStrings": {
-                "NotApplicable_InvalidMetadata": {
-                  "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+          "name": "Spmi",
+          "organization": "Microsoft",
+          "product": "Microsoft SARIF Pattern Matcher",
+          "fullName": "Sarif.PatternMatcher 1.11.0.0",
+          "version": "1.11.0",
+          "dottedQuadFileVersion": "1.11.0.0",
+          "properties": {
+            "Comments": "A general pattern matching engine that persist results to SARIF."
+          }
+        },
+        "extensions": [
+          {
+            "guid": "07374f10-f46b-458a-9179-cc937e1857e4",
+            "name": "UseSecureApi",
+            "rules": [
+              {
+                "id": "SEC104/001",
+                "name": "UseSecureApi/Memory/Allocation",
+                "fullDescription": {
+                  "text": "Developers should use secure API in preferance of insecure alternates."
                 },
-                "Default": {
-                  "text": "'{0}' contains a call to '{1}', a potentially insecure API that could be replaced with a more secure alternative: {2}."
+                "messageStrings": {
+                  "NotApplicable_InvalidMetadata": {
+                    "text": "'{0}' was not evaluated for check '{1}' because the analysis is not relevant for the following reason: {2}."
+                  },
+                  "Default": {
+                    "text": "'{0}' contains a call to '{1}', a potentially insecure API that could be replaced with a more secure alternative: {2}."
+                  },
+                  "Default_Secure": {
+                    "text": "'{0}' contains a call to '{1}', a more secure alternative to one or more potentially insecure APIs: {2}."
+                  }
                 },
-                "Default_Secure": {
-                  "text": "'{0}' contains a call to '{1}', a more secure alternative to one or more potentially insecure APIs: {2}."
-                }
-              },
-              "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
-            }
-          ]
-        }
+                "helpUri": "https://github.com/microsoft/sarif-pattern-matcher"
+              }
+            ],
+            "locations": [
+              {
+                "uri": "SEC104.UseSecureApi.json",
+                "uriBaseId": "PLUGIN_ROOT"
+              }
+            ]
+          }
+        ]
       },
       "invocations": [
         {
@@ -49,8 +64,13 @@
       ],
       "results": [
         {
-          "ruleId": "SEC104/001/_malloca",
-          "ruleIndex": 0,
+          "rule": {
+            "id": "SEC104/001",
+            "index": 0,
+            "toolComponent": {
+              "index": 0
+            }
+          },
           "kind": "pass",
           "level": "none",
           "message": {

--- a/Src/Plugins/Tests.Security/TestData/UseSecureApi/ExpectedOutputs/SEC104.Memory.Allocation_malloca.sarif
+++ b/Src/Plugins/Tests.Security/TestData/UseSecureApi/ExpectedOutputs/SEC104.Memory.Allocation_malloca.sarif
@@ -8,9 +8,7 @@
           "name": "Spmi",
           "organization": "Microsoft",
           "product": "Microsoft SARIF Pattern Matcher",
-          "fullName": "Sarif.PatternMatcher 3.0.0.0",
-          "version": "3.0.0.1",
-          "dottedQuadFileVersion": "3.0.0.0",
+          "fullName": "Sarif.PatternMatcher ",
           "properties": {
             "Comments": "A general pattern matching engine that persist results to SARIF."
           }

--- a/Src/Sarif.PatternMatcher.Benchmark/Benchmarks/AnalyzeCommandBenchmarks.cs
+++ b/Src/Sarif.PatternMatcher.Benchmark/Benchmarks/AnalyzeCommandBenchmarks.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Benchmark.Benchmarks
                 PatternMatcher.AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(
                     fileSystemMock.Object,
                     new string[] { searchDefinitionsPath },
-                    out ISet<ToolComponent> toolComponents,
+                    Tool.CreateFromAssemblyData(),
                     engine);
 
             string scanTargetFileName = Path.Combine(@"C:\", Guid.NewGuid().ToString() + ".test");

--- a/Src/Sarif.PatternMatcher.Benchmark/Benchmarks/AnalyzeCommandBenchmarks.cs
+++ b/Src/Sarif.PatternMatcher.Benchmark/Benchmarks/AnalyzeCommandBenchmarks.cs
@@ -105,6 +105,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Benchmark.Benchmarks
                 PatternMatcher.AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(
                     fileSystemMock.Object,
                     new string[] { searchDefinitionsPath },
+                    out ISet<ToolComponent> toolComponents,
                     engine);
 
             string scanTargetFileName = Path.Combine(@"C:\", Guid.NewGuid().ToString() + ".test");

--- a/Src/Sarif.PatternMatcher.Cli/AnalyzeDatabaseCommand.cs
+++ b/Src/Sarif.PatternMatcher.Cli/AnalyzeDatabaseCommand.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
                 aggregatingLogger.Loggers.Add(sarifLogger);
 
                 aggregatingLogger.AnalysisStarted();
-                ISet<Skimmer<AnalyzeContext>> skimmers = AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(FileSystem, options.SearchDefinitionsPaths);
+                ISet<Skimmer<AnalyzeContext>> skimmers = AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(FileSystem, options.SearchDefinitionsPaths, out ISet<ToolComponent> toolComponents);
 
                 var workers = new Task<bool>[options.Threads];
 

--- a/Src/Sarif.PatternMatcher.Cli/AnalyzeDatabaseCommand.cs
+++ b/Src/Sarif.PatternMatcher.Cli/AnalyzeDatabaseCommand.cs
@@ -39,18 +39,20 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
 
                 AggregatingLogger aggregatingLogger = InitializeLogger(options);
 
+                Tool tool = MakeTool();
+
                 var sarifLogger = new SarifLogger(
                     options.OutputFilePath,
                     options.ConvertToLogFilePersistenceOptions(),
                     dataToInsert: options.DataToInsert.ToFlags(),
                     dataToRemove: options.DataToRemove.ToFlags(),
-                    tool: MakeTool(),
+                    tool: tool,
                     levels: options.Level,
                     kinds: options.Kind);
                 aggregatingLogger.Loggers.Add(sarifLogger);
 
                 aggregatingLogger.AnalysisStarted();
-                ISet<Skimmer<AnalyzeContext>> skimmers = AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(FileSystem, options.SearchDefinitionsPaths, out ISet<ToolComponent> toolComponents);
+                ISet<Skimmer<AnalyzeContext>> skimmers = AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(FileSystem, options.SearchDefinitionsPaths, tool);
 
                 var workers = new Task<bool>[options.Threads];
 

--- a/Src/Sarif.PatternMatcher.Cli/StressCommand.cs
+++ b/Src/Sarif.PatternMatcher.Cli/StressCommand.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
 
         public void AnalyzingTarget(IAnalysisContext context) { }
 
-        public void Log(ReportingDescriptor rule, Result result, ToolComponent toolComponent)
+        public void Log(ReportingDescriptor rule, Result result, int? extensionIndex)
         {
             // Build your ADO data contract here
             ViolationsSeen++;
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
         {
             IFileSystem fileSystem = Sarif.FileSystem.Instance;
             s_configurationFiles = new string[] { options.InputFilePath };
-            ISet<Skimmer<AnalyzeContext>> skimmers = AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(fileSystem, s_configurationFiles);
+            ISet<Skimmer<AnalyzeContext>> skimmers = AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(fileSystem, s_configurationFiles, out ISet<ToolComponent> toolComponents);
 
             var logger = new AdoLogger();
             var scanContext = new ScanContext();
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
 
             for (int i = 0; i < 10000000; i++)
             {
-                skimmers ??= AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(fileSystem, s_configurationFiles);
+                skimmers ??= AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(fileSystem, s_configurationFiles, out ISet<ToolComponent> toolComponents);
 
                 var context = new AnalyzeContext
                 {
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
 
             List<string> filesToSearch = GetWhatFilesToSearch(options);
 
-            ISet<Skimmer<AnalyzeContext>> skimmers = AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(fileSystem, options.SearchDefinitionsPaths);
+            ISet<Skimmer<AnalyzeContext>> skimmers = AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(fileSystem, options.SearchDefinitionsPaths, out ISet<ToolComponent> toolComponents);
 
             var totalRunTimer = new Stopwatch();
             totalRunTimer.Start();

--- a/Src/Sarif.PatternMatcher.Cli/StressCommand.cs
+++ b/Src/Sarif.PatternMatcher.Cli/StressCommand.cs
@@ -148,7 +148,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
         {
             IFileSystem fileSystem = Sarif.FileSystem.Instance;
             s_configurationFiles = new string[] { options.InputFilePath };
-            ISet<Skimmer<AnalyzeContext>> skimmers = AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(fileSystem, s_configurationFiles, out ISet<ToolComponent> toolComponents);
+            Tool tool = Tool.CreateFromAssemblyData();
+            ISet<Skimmer<AnalyzeContext>> skimmers = AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(fileSystem, s_configurationFiles, tool);
 
             var logger = new AdoLogger();
             var scanContext = new ScanContext();
@@ -163,7 +164,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
 
             for (int i = 0; i < 10000000; i++)
             {
-                skimmers ??= AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(fileSystem, s_configurationFiles, out ISet<ToolComponent> toolComponents);
+                skimmers ??= AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(fileSystem, s_configurationFiles, tool);
 
                 var context = new AnalyzeContext
                 {
@@ -192,7 +193,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
 
             List<string> filesToSearch = GetWhatFilesToSearch(options);
 
-            ISet<Skimmer<AnalyzeContext>> skimmers = AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(fileSystem, options.SearchDefinitionsPaths, out ISet<ToolComponent> toolComponents);
+            Tool tool = Tool.CreateFromAssemblyData();
+            ISet<Skimmer<AnalyzeContext>> skimmers = AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(fileSystem, options.SearchDefinitionsPaths, tool);
 
             var totalRunTimer = new Stopwatch();
             totalRunTimer.Start();

--- a/Src/Sarif.PatternMatcher.Cli/StressCommand.cs
+++ b/Src/Sarif.PatternMatcher.Cli/StressCommand.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
 
         public void AnalyzingTarget(IAnalysisContext context) { }
 
-        public void Log(ReportingDescriptor rule, Result result)
+        public void Log(ReportingDescriptor rule, Result result, ToolComponent toolComponent)
         {
             // Build your ADO data contract here
             ViolationsSeen++;

--- a/Src/Sarif.PatternMatcher.Function/SpamAnalyzer.cs
+++ b/Src/Sarif.PatternMatcher.Function/SpamAnalyzer.cs
@@ -23,8 +23,11 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Function
             FileSystem = Sarif.FileSystem.Instance;
         }
 
+        private static Tool s_tool = Tool.CreateFromAssemblyData();
+
         public static SarifLog Analyze(string filePath, string text, string rulePath, string originalFileName)
         {
+
             if (Skimmers == null)
             {
                 IEnumerable<string> regexDefinitions = FileSystem.DirectoryGetFiles(Path.Combine(rulePath, @"..\bin\"), "*.json");
@@ -33,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Function
                 // lives alongside the JSON. For a JSON file named PlaintextSecrets.json, the
                 // corresponding validations assembly is named PlaintextSecrets.dll (i.e., only the
                 // extension name changes from .json to .dll).
-                Skimmers = AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(FileSystem, regexDefinitions, out ISet<ToolComponent> toolComponents);
+                Skimmers = AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(FileSystem, regexDefinitions, s_tool);
             }
 
             var sb = new StringBuilder();
@@ -48,6 +51,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Function
                 outputTextWriter,
                 LogFilePersistenceOptions.PrettyPrint,
                 dataToInsert,
+                tool: s_tool,
                 levels: new List<FailureLevel> { FailureLevel.Error, FailureLevel.Warning, FailureLevel.Note, FailureLevel.None },
                 kinds: new List<ResultKind> { ResultKind.Fail }))
             {

--- a/Src/Sarif.PatternMatcher.Function/SpamAnalyzer.cs
+++ b/Src/Sarif.PatternMatcher.Function/SpamAnalyzer.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Function
                 // lives alongside the JSON. For a JSON file named PlaintextSecrets.json, the
                 // corresponding validations assembly is named PlaintextSecrets.dll (i.e., only the
                 // extension name changes from .json to .dll).
-                Skimmers = AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(FileSystem, regexDefinitions);
+                Skimmers = AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(FileSystem, regexDefinitions, out ISet<ToolComponent> toolComponents);
             }
 
             var sb = new StringBuilder();

--- a/Src/Sarif.PatternMatcher.Sdk/ValidatorBase.cs
+++ b/Src/Sarif.PatternMatcher.Sdk/ValidatorBase.cs
@@ -179,8 +179,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk
             }
 
             message = (account == null) ?
-                $"An unexpected exception was caught attempting to validate '{asset}': {e.Message}" :
-                $"An unexpected exception was caught attempting to validate the '{account}' account on '{asset}': {e.Message}";
+                $"An unexpected exception was caught attempting to validate '{asset}': {e}" :
+                $"An unexpected exception was caught attempting to validate the '{account}' account on '{asset}': {e}";
 
             return ValidationState.Unknown;
         }

--- a/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
@@ -81,9 +81,10 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 }
 
                 string name = definitions.ExtensionName;
-                string semanticVersion = null;
                 string version = null;
 
+                /* 
+                string semanticVersion = null;
                 if (!string.IsNullOrEmpty(definitions.ValidatorsAssemblyName))
                 {
                     string directory = Path.GetDirectoryName(searchDefinitionsPath);
@@ -93,6 +94,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                     semanticVersion = fvi?.ProductVersion;
                     version = fvi?.FileVersion;
                 }
+                */
 
                 var toolComponent = new ToolComponent
                 {

--- a/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
@@ -397,9 +397,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             if (resultLists != null && context.TargetUri.ToString().EndsWith(".json", StringComparison.OrdinalIgnoreCase))
             {
                 var aggregatedResults = new List<Result>();
-                foreach (IList<Tuple<Result, ToolComponent>> resultList in resultLists)
+                foreach (IList<Tuple<Result, int?>> resultList in resultLists)
                 {
-                    foreach (Tuple<Result, ToolComponent> tuple in resultList)
+                    foreach (Tuple<Result, int?> tuple in resultList)
                     {
                         aggregatedResults.Add(tuple.Item1);
                     }

--- a/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
@@ -44,10 +44,11 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
         public static ISet<Skimmer<AnalyzeContext>> CreateSkimmersFromDefinitionsFiles(
             IFileSystem fileSystem,
             IEnumerable<string> searchDefinitionsPaths,
-            out ISet<ToolComponent> toolComponents,
+            Tool tool,
             IRegex engine = null)
         {
-            toolComponents = new HashSet<ToolComponent>();
+            tool.Extensions ??= new List<ToolComponent>();
+
             engine ??= RE2Regex.Instance;
 
             var validators = new ValidatorsCache(validatorBinaryPaths: null, fileSystem);
@@ -107,8 +108,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                     }),
                 };
 
-                int extensionIndex = toolComponents.Count;
-                toolComponents.Add(toolComponent);
+                int extensionIndex = tool.Extensions.Count;
+                tool.Extensions.Add(toolComponent);
 
                 string validatorPath = null;
                 string definitionsDirectory = Path.GetDirectoryName(searchDefinitionsPath);
@@ -380,13 +381,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
         protected override ISet<Skimmer<AnalyzeContext>> CreateSkimmers(AnalyzeOptions options, AnalyzeContext context)
         {
             ISet<Skimmer<AnalyzeContext>> skimmers =
-                CreateSkimmersFromDefinitionsFiles(this.FileSystem, options.SearchDefinitionsPaths, out ISet<ToolComponent> toolComponents);
-
-            foreach (ToolComponent toolComponent in toolComponents)
-            {
-                Tool.Extensions ??= new List<ToolComponent>();
-                Tool.Extensions.Add(toolComponent);
-            }
+                CreateSkimmersFromDefinitionsFiles(this.FileSystem, options.SearchDefinitionsPaths, Tool);
 
             return skimmers;
         }

--- a/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                     this.tool.Driver.Name = "Spmi";
                 }
                 return this.tool;
-           }
+            }
 
             set => this.tool = value;
         }

--- a/Src/Sarif.PatternMatcher/SearchDefinition.cs
+++ b/Src/Sarif.PatternMatcher/SearchDefinition.cs
@@ -7,6 +7,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 {
     public class SearchDefinition
     {
+        public string ExtensionName { get; set; }
+
         public Dictionary<string, string> SharedStrings { get; set; }
 
         public string Id { get; set; }

--- a/Src/Sarif.PatternMatcher/SearchDefinitions.cs
+++ b/Src/Sarif.PatternMatcher/SearchDefinitions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
@@ -10,6 +11,10 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
         public string SharedStringsFileName { get; set; }
 
         public string ValidatorsAssemblyName { get; set; }
+
+        public string ExtensionName { get; set; }
+
+        public Guid Guid { get; set; }
 
         public List<SearchDefinition> Definitions { get; set; }
     }

--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -1198,7 +1198,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             // for example, the sub-id may change for every match
             // expression. We will therefore generate a snapshot of
             // current ReportingDescriptor state when logging.
-            context.Logger.Log(reportingDescriptor, result, this.Extension);
+            context.Logger.Log(reportingDescriptor, result, this.ExtensionIndex);
         }
 
         internal static void RedactSecretFromSnippet(Region region, string secret)

--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -1,4 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -1197,7 +1198,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             // for example, the sub-id may change for every match
             // expression. We will therefore generate a snapshot of
             // current ReportingDescriptor state when logging.
-            context.Logger.Log(reportingDescriptor, result);
+            context.Logger.Log(reportingDescriptor, result, this.Extension);
         }
 
         internal static void RedactSecretFromSnippet(Region region, string secret)

--- a/Src/Test.UnitTests.RE2.Managed/Test.UnitTests.RE2.Managed.csproj
+++ b/Src/Test.UnitTests.RE2.Managed/Test.UnitTests.RE2.Managed.csproj
@@ -12,6 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions" Version="6.9.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="xunit" Version="2.4.2" />
   </ItemGroup>
 </Project>

--- a/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/AnalyzeCommandTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/AnalyzeCommandTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Text;
@@ -398,7 +399,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
             string scanTargetPath = Path.Combine(rootDirectory, scanTargetName);
             string searchDefinitionsPath = @$"c:\{Guid.NewGuid()}.json";
 
+
+            var fvi = FileVersionInfo.GetVersionInfo(this.GetType().Assembly.Location);
+
             var mockFileSystem = new Mock<IFileSystem>();
+
+            mockFileSystem.Setup(x => x.FileVersionInfoGetVersionInfo(It.IsAny<string>())).Returns(fvi);
             mockFileSystem.Setup(x => x.DirectoryExists(rootDirectory)).Returns(true);
             mockFileSystem.Setup(x => x.DirectoryEnumerateFiles(rootDirectory,
                                                                 scanTargetName,
@@ -441,6 +447,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
                 };
 
                 int result = Program.Main(args);
+                Program.RuntimeException.Should().BeNull();
                 Program.InstantiatedAnalyzeCommand.RuntimeErrors.Should().Be(0);
                 result.Should().Be(0);
 

--- a/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/AnalyzeCommandTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/AnalyzeCommandTests.cs
@@ -430,6 +430,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
 
             mockFileSystem.Setup(x => x.FileInfoLength(SmallTargetName)).Returns(fileContents.Length);
 
+            Program.ClearUnitTestData();
             Program.FileSystem = mockFileSystem.Object;
 
             string tempFileName = Path.GetTempFileName();
@@ -519,6 +520,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
             mockFileSystem.Setup(x => x.FileInfoLength(smallTargetPath)).Returns(smallFileContents.Length);
             mockFileSystem.Setup(x => x.FileInfoLength(largeTargetPath)).Returns(largeFileSizeInBytes);
 
+            Program.ClearUnitTestData();
             Program.FileSystem = mockFileSystem.Object;
 
             string tempFileName = Path.GetTempFileName();

--- a/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/Test.UnitTests.Sarif.PatternMatcher.Cli.csproj
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/Test.UnitTests.Sarif.PatternMatcher.Cli.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions" Version="6.9.0" />
     <PackageReference Include="Moq" Version="4.15.2" />
   </ItemGroup>
 

--- a/Src/Test.UnitTests.Sarif.PatternMatcher.Function/Test.UnitTests.Sarif.PatternMatcher.Function.csproj
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher.Function/Test.UnitTests.Sarif.PatternMatcher.Function.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(MSBuildThisFileDirectory)..\..\Targets\build.test.props" />
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions" Version="6.9.0" />
     <PackageReference Include="Moq" Version="4.15.2" />
   </ItemGroup>
 
@@ -15,6 +15,10 @@
   <ItemGroup>
     <Content Include="..\Plugins\Tests.Security\TestData\SecurePlaintextSecrets\Inputs\SEC101_102.AdoPat.txt" Link="TestData\SEC101_102.AdoPat.txt" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="..\Plugins\Tests.Security\TestData\SecurePlaintextSecrets\Inputs\SEC101_005.SlackApiKey.py" Link="TestData\SEC101_005.SlackApiKey.py" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="xunit" Version="2.4.2" />
   </ItemGroup>
   
   <Target Name="CopySecFilesAfterBuild" AfterTargets="AfterBuild">

--- a/Src/Test.UnitTests.Sarif.PatternMatcher.Function/TestLogger.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher.Function/TestLogger.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 using Microsoft.Extensions.Logging;
 

--- a/Src/Test.UnitTests.Sarif.PatternMatcher.Sdk/Test.UnitTests.Sarif.PatternMatcher.Sdk.csproj
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher.Sdk/Test.UnitTests.Sarif.PatternMatcher.Sdk.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions" Version="6.9.0" />
     <PackageReference Include="Moq" Version="4.15.2" />
   </ItemGroup>
   

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/AnalyzeCommandTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/AnalyzeCommandTests.cs
@@ -116,10 +116,11 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             mockFileSystem.Setup(x => x.FileReadAllText(searchDefinitionsPath)).Returns(definitionsText);
 
             // Acquire skimmers for searchers
+            Tool tool = Tool.CreateFromAssemblyData();
             ISet<Skimmer<AnalyzeContext>> skimmers = PatternMatcher.AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(
                 mockFileSystem.Object,
                 new string[] { searchDefinitionsPath },
-                out ISet<ToolComponent> toolComponents,
+                tool,
                 RE2Regex.Instance);
 
             string scanTargetFileName = Path.Combine(@"C:\", Guid.NewGuid().ToString() + ".test");
@@ -184,11 +185,13 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             mockFileSystem.Setup(x => x.FileExists(searchDefinitionsPath)).Returns(true);
             mockFileSystem.Setup(x => x.FileReadAllText(searchDefinitionsPath)).Returns(definitionsText);
 
+            Tool tool = Tool.CreateFromAssemblyData();
+
             // Acquire skimmers for searchers
             ISet<Skimmer<AnalyzeContext>> skimmers = PatternMatcher.AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(
                 mockFileSystem.Object,
                 new string[] { searchDefinitionsPath }, 
-                out ISet<ToolComponent> toolComponents,
+                tool,
                 RE2Regex.Instance);
 
             string scanTargetFileName = Path.Combine(@"C:\", Guid.NewGuid().ToString() + ".test");
@@ -413,11 +416,13 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             mockFileSystem.Setup(x => x.FileExists(searchDefinitionsPath)).Returns(true);
             mockFileSystem.Setup(x => x.FileReadAllText(searchDefinitionsPath)).Returns(definitionsText);
 
+            Tool tool = Tool.CreateFromAssemblyData();
+
             // Acquire skimmers for searchers.
             ISet<Skimmer<AnalyzeContext>> skimmers =
                 PatternMatcher.AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(mockFileSystem.Object,
                                                                                  new string[] { searchDefinitionsPath }, 
-                                                                                 out ISet<ToolComponent> toolComponents,
+                                                                                 tool,
                                                                                  RE2Regex.Instance);
 
             string scanTargetFileName = $"C:\\{Guid.NewGuid()}.test";
@@ -429,6 +434,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             var logger = new SarifLogger(writer,
                                          LogFilePersistenceOptions.None,
                                          OptionallyEmittedData.All,
+                                         tool: tool,
                                          closeWriterOnDispose: true);
 
 
@@ -529,11 +535,13 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             mockFileSystem.Setup(x => x.FileExists(searchDefinitionsPath)).Returns(true);
             mockFileSystem.Setup(x => x.FileReadAllText(searchDefinitionsPath)).Returns(definitionsText);
 
+            Tool tool = Tool.CreateFromAssemblyData();
+
             // Acquire skimmers for searchers
             ISet<Skimmer<AnalyzeContext>> skimmers = PatternMatcher.AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(
                 mockFileSystem.Object,
                 new string[] { searchDefinitionsPath },
-                out ISet<ToolComponent> toolComponents,
+                tool,
                 RE2Regex.Instance);
 
             string scanTargetFileName = Path.Combine(@"C:\", Guid.NewGuid().ToString() + ".test");
@@ -569,9 +577,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
             OptionallyEmittedData dataToInsert = OptionallyEmittedData.RegionSnippets | OptionallyEmittedData.ContextRegionSnippets | OptionallyEmittedData.ComprehensiveRegionProperties;
 
+            var tool = Tool.CreateFromAssemblyData();
+
             var logger = new SarifLogger(writer,
                                          LogFilePersistenceOptions.None,
                                          dataToInsert,
+                                         tool: tool,
                                          closeWriterOnDispose: false);
 
             using var context = new AnalyzeContext
@@ -584,7 +595,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             };
 
             var disabledSkimmers = new HashSet<string>();
-            ISet<Skimmer<AnalyzeContext>> skimmers = CreateSkimmers(RE2Regex.Instance);
+            ISet<Skimmer<AnalyzeContext>> skimmers = CreateSkimmers(RE2Regex.Instance, tool);
             IEnumerable<Skimmer<AnalyzeContext>> applicableSkimmers = PatternMatcher.AnalyzeCommand.DetermineApplicabilityForTargetHelper(context, skimmers, disabledSkimmers);
 
             logger.AnalysisStarted();
@@ -606,7 +617,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             physicalLocation.ContextRegion.Should().NotBeNull();
         }
 
-        private static ISet<Skimmer<AnalyzeContext>> CreateSkimmers(IRegex engine)
+        private static ISet<Skimmer<AnalyzeContext>> CreateSkimmers(IRegex engine, Tool tool)
         {
             var definitions = new SearchDefinitions()
             {
@@ -647,18 +658,24 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             mockFileSystem.Setup(x => x.FileReadAllText(searchDefinitionsPath)).Returns(definitionsText);
 
             // Acquire skimmers for searchers
-            return PatternMatcher.AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(
+            ISet<Skimmer<AnalyzeContext>> skimmers =
+                PatternMatcher.AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(
                     mockFileSystem.Object,
                     new string[] { searchDefinitionsPath }, 
-                    out ISet<ToolComponent> toolComponents,
+                    tool,
                     engine);
+
+            return skimmers;
         }
 
         private static void AnalyzeCommand(IRegex engine)
         {
             var testLogger = new TestLogger();
             var disabledSkimmers = new HashSet<string>();
-            ISet<Skimmer<AnalyzeContext>> skimmers = CreateSkimmers(engine);
+
+            var tool = Tool.CreateFromAssemblyData();
+
+            ISet<Skimmer<AnalyzeContext>> skimmers = CreateSkimmers(engine, tool);
 
             string scanTargetFileName = Path.Combine(@"C:\", Guid.NewGuid().ToString() + ".test");
             FlexString fileContents = "bar foo foo";
@@ -690,7 +707,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             var disabledSkimmers = new HashSet<string>();
             var testLogger = new TestLogger();
 
-            ISet<Skimmer<AnalyzeContext>> skimmers = CreateSkimmers(engine);
+            var tool = Tool.CreateFromAssemblyData();
+
+            ISet<Skimmer<AnalyzeContext>> skimmers = CreateSkimmers(engine, tool);
 
             string scanTargetFileName = Path.Combine(Guid.NewGuid().ToString() + ".test");
             FlexString fileContents = "bar foo foo";

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/AnalyzeCommandTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/AnalyzeCommandTests.cs
@@ -190,7 +190,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             // Acquire skimmers for searchers
             ISet<Skimmer<AnalyzeContext>> skimmers = PatternMatcher.AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(
                 mockFileSystem.Object,
-                new string[] { searchDefinitionsPath }, 
+                new string[] { searchDefinitionsPath },
                 tool,
                 RE2Regex.Instance);
 
@@ -421,7 +421,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             // Acquire skimmers for searchers.
             ISet<Skimmer<AnalyzeContext>> skimmers =
                 PatternMatcher.AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(mockFileSystem.Object,
-                                                                                 new string[] { searchDefinitionsPath }, 
+                                                                                 new string[] { searchDefinitionsPath },
                                                                                  tool,
                                                                                  RE2Regex.Instance);
 
@@ -661,7 +661,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             ISet<Skimmer<AnalyzeContext>> skimmers =
                 PatternMatcher.AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(
                     mockFileSystem.Object,
-                    new string[] { searchDefinitionsPath }, 
+                    new string[] { searchDefinitionsPath },
                     tool,
                     engine);
 

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/AnalyzeCommandTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/AnalyzeCommandTests.cs
@@ -119,6 +119,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             ISet<Skimmer<AnalyzeContext>> skimmers = PatternMatcher.AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(
                 mockFileSystem.Object,
                 new string[] { searchDefinitionsPath },
+                out ISet<ToolComponent> toolComponents,
                 RE2Regex.Instance);
 
             string scanTargetFileName = Path.Combine(@"C:\", Guid.NewGuid().ToString() + ".test");
@@ -186,7 +187,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             // Acquire skimmers for searchers
             ISet<Skimmer<AnalyzeContext>> skimmers = PatternMatcher.AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(
                 mockFileSystem.Object,
-                new string[] { searchDefinitionsPath },
+                new string[] { searchDefinitionsPath }, 
+                out ISet<ToolComponent> toolComponents,
                 RE2Regex.Instance);
 
             string scanTargetFileName = Path.Combine(@"C:\", Guid.NewGuid().ToString() + ".test");
@@ -414,7 +416,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             // Acquire skimmers for searchers.
             ISet<Skimmer<AnalyzeContext>> skimmers =
                 PatternMatcher.AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(mockFileSystem.Object,
-                                                                                 new string[] { searchDefinitionsPath },
+                                                                                 new string[] { searchDefinitionsPath }, 
+                                                                                 out ISet<ToolComponent> toolComponents,
                                                                                  RE2Regex.Instance);
 
             string scanTargetFileName = $"C:\\{Guid.NewGuid()}.test";
@@ -530,6 +533,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             ISet<Skimmer<AnalyzeContext>> skimmers = PatternMatcher.AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(
                 mockFileSystem.Object,
                 new string[] { searchDefinitionsPath },
+                out ISet<ToolComponent> toolComponents,
                 RE2Regex.Instance);
 
             string scanTargetFileName = Path.Combine(@"C:\", Guid.NewGuid().ToString() + ".test");
@@ -645,7 +649,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             // Acquire skimmers for searchers
             return PatternMatcher.AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(
                     mockFileSystem.Object,
-                    new string[] { searchDefinitionsPath },
+                    new string[] { searchDefinitionsPath }, 
+                    out ISet<ToolComponent> toolComponents,
                     engine);
         }
 

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/ExtensionMethodsTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/ExtensionMethodsTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             dict.AddProperties(properties);
             dict.Should().BeEmpty();
 
-            // Empty properties sould not affect dictionary
+            // Empty properties should not affect dictionary
             properties = new Dictionary<string, string>();
             dict.Should().BeEmpty();
 
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             dict.Count.Should().Be(2);
             foreach (KeyValuePair<string, string> kv in properties)
             {
-                dict[kv.Key].Value.Should().Be(kv.Value);
+                dict[kv.Key].Value.ToString().Should().Be(kv.Value);
             }
 
             // Duplicated items should not replace original value.
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             properties.Add("key3", "value3");
             dict.AddProperties(properties);
             dict.Count.Should().Be(3);
-            dict["key3"].Value.Should().Be("original");
+            dict["key3"].Value.ToString().Should().Be("original");
         }
     }
 }

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/PatternInvariantTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/PatternInvariantTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             {
                 foreach (MatchExpression matchExpression in searchDefinition.MatchExpressions)
                 {
-                    rules.Add(matchExpression.Name.Split('/')[1]);
+                    rules.Add(matchExpression.Name);
                 }
             }
 

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/PatternInvariantTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/PatternInvariantTests.cs
@@ -221,7 +221,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             {
                 foreach (MatchExpression matchExpression in searchDefinition.MatchExpressions)
                 {
-                    string ruleName = matchExpression.Name.Split('/')[1];
+                    string ruleName = matchExpression.Name;
                     string ruleID = matchExpression.Id;
 
                     if (!ruleNameToIdMap.ContainsKey(ruleName))

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/Test.UnitTests.Sarif.PatternMatcher.csproj
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/Test.UnitTests.Sarif.PatternMatcher.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions" Version="6.9.0" />
     <PackageReference Include="Moq" Version="4.15.2" />
   </ItemGroup>
   

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/TestLogger.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/TestLogger.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
         {
         }
 
-        public void Log(ReportingDescriptor rule, Result result, ToolComponent toolComponent)
+        public void Log(ReportingDescriptor rule, Result result, int? extensionIndex)
         {
             Results ??= new List<Result>();
             Results.Add(result);

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/TestLogger.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/TestLogger.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
         {
         }
 
-        public void Log(ReportingDescriptor rule, Result result)
+        public void Log(ReportingDescriptor rule, Result result, ToolComponent toolComponent)
         {
             Results ??= new List<Result>();
             Results.Add(result);

--- a/Src/Test.UnitTests.Strings.Interop/Test.UnitTests.Strings.Interop.csproj
+++ b/Src/Test.UnitTests.Strings.Interop/Test.UnitTests.Strings.Interop.csproj
@@ -11,4 +11,8 @@
     <ProjectReference Include="..\Strings.Interop\Strings.Interop.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="xunit" Version="2.4.2" />
+  </ItemGroup>
+
 </Project>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.11.0-alpha.{height}",
+  "version": "3.0.0-dev1",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+\\.\\d+\\.\\d+$"


### PR DESCRIPTION
This change moves all rules metadata in the `Run.Tool.Extensions` property.