### PR TITLE
Release/v4.0.0

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -20,7 +20,7 @@
 
 ## v4.0.0 Released 02/27/2023
 - BRK: This change switches to a new, highly-context driven API provided by the SARIF driver framework.
-- DEP: Update SARIF SDK submodule from [ec93dcc to 11b52ed](https://github.com/microsoft/sarif-sdk/compare/ec93dcc..11b52ed). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/11b52ed/src/ReleaseHistory.md).
+- DEP: Update SARIF SDK submodule from [ec93dcc to  615a31a](https://github.com/microsoft/sarif-sdk/compare/ec93dcc..615a31a). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/615a31a/src/ReleaseHistory.md).
 - BUG: Eliminate `IndexOutOfRangeException` error invoking `Sarif.PatternMatcher.Cli.exe` with no arguments.
 - Re-enable `SEC101/029.AlibabaCloudCredentials` in `Security` removing AlibabaCloud SDK reference.
 

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -20,9 +20,10 @@
 
 ## v4.0.0 Released 02/27/2023
 - BRK: This change switches to a new, highly-context driven API provided by the SARIF driver framework.
-- DEP: Update SARIF SDK submodule from [ec93dcc to  615a31a](https://github.com/microsoft/sarif-sdk/compare/ec93dcc..615a31a). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/615a31a/src/ReleaseHistory.md).
+- DEP: Update SARIF SDK submodule from [ec93dcc to 615a31a](https://github.com/microsoft/sarif-sdk/compare/ec93dcc..615a31a). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/615a31a/src/ReleaseHistory.md).
 - BUG: Eliminate `IndexOutOfRangeException` error invoking `Sarif.PatternMatcher.Cli.exe` with no arguments.
 - Re-enable `SEC101/029.AlibabaCloudCredentials` in `Security` removing AlibabaCloud SDK reference.
+- FPS: Eliminate `SEC101/047.CratesApiKey` false positives due to bad prefix regex pattern. [#713](https://github.com/microsoft/sarif-pattern-matcher/pull/713)
 
 ## v3.0.2 Released 02/14/2023
 - Update SARIF SDK submodule from [fdb2545 to ec93dcc](https://github.com/microsoft/sarif-sdk/compare/fdb2545..ec93dcc). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/ec93dcc/src/ReleaseHistory.md).

--- a/Src/Plugins/Security/Security.SharedStrings.txt
+++ b/Src/Plugins/Security/Security.SharedStrings.txt
@@ -133,10 +133,10 @@
   $SEC101/044.NpmCredentialsPassword=(?i)password\s*=\s*(?P<secret>[^\s]+)(?:\s|$)
   
   $SEC101/045.PostmanApiKey=(?:[^P]|^)(?P<secret>PMAK-[0-9a-z]{24}-[0-9a-z]{34})(?:[^0-9a-z]|$)
-  $SEC101/047.CratesApiKey=(?i)(?:[^c]|^)(?P<secret>cio[0-9a-z]{32})(?:[^0-9a-z]|$)
+  $SEC101/047.CratesApiKey=(?i)(?:[^0-9a-z]|^)(?P<secret>cio[0-9a-z]{32})(?:[^0-9a-z]|$)
   $SEC101/048.SlackWorkflowKey=(?i)https:\/\/hooks\.slack\.com\/workflows\/(?P<id>[0-9a-z]{9,})\/(?P<secret>[0-9a-z]{9,}\/[0-9]+?\/[0-9a-z]{24})
   $SEC101/049.TelegramBotToken=bot(?P<secret>[0-9]{6,12}:AA(?i)[0-9a-z\-_]{32,33})(?:[^0-9a-z\-_]|$)
-  $SEC101/050.NpmIdentifiableAuthorToken=(?:[^n]|^)(?P<secret>npm_(?i)[0-9a-z]{30}(?P<checksum>[\w]{6}))(?:[^0-9a-z]|$)
+  $SEC101/050.NpmIdentifiableAuthorToken=(?:[0-9a-z]|^)(?P<secret>npm_(?i)[0-9a-z]{30}(?P<checksum>[\w]{6}))(?:[^0-9a-z]|$)
   $SEC101/102.AdoPat=(?:[^2-7a-z]|^)(?P<secret>[2-7a-z]{52})(?:[^2-7a-z]|$) 
 
   $SEC102/003.Url=(?P<url>http[s]?:\/\/(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+)

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/AnalyzeCommandTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/AnalyzeCommandTests.cs
@@ -164,13 +164,14 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                     Skimmers = skimmers,
                     Threads = threads,
                     TargetsProvider = provider,
-                    TimeoutInMilliseconds = 5,
+                    TimeoutInMilliseconds = 15,
                 };
 
                 // The rule will pause for 100 ms, provoking our 5 ms timeout;
                 context.Policy.SetProperty(TestRule.DelayInMilliseconds, 100);
 
                 int result = new AnalyzeCommand().Run(options: null, ref context);
+                context.RuntimeExceptions.Should().BeNull();
                 (context.RuntimeErrors & RuntimeConditions.AnalysisTimedOut).Should().Be(RuntimeConditions.AnalysisTimedOut);
                 result.Should().Be(CommandBase.FAILURE);
             }

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/AnalyzeCommandTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/AnalyzeCommandTests.cs
@@ -267,6 +267,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 RuntimeConditions.OneOrMoreWarningsFired |
                 RuntimeConditions.OneOrMoreErrorsFired;
 
+            context.RuntimeExceptions.Should().BeNull();
             context.RuntimeErrors.Should().Be(conditions);
             result.Should().Be(CommandBase.SUCCESS);
 

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/ArtifactProvider.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/ArtifactProvider.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
     public class ZipArchiveArtifact : IEnumeratedArtifact
     {
-        private readonly ZipArchiveEntry entry;
+        private ZipArchiveEntry entry;
         private readonly ZipArchive archive;
         private readonly Uri uri;
         private string contents;

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/ArtifactProvider.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/ArtifactProvider.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
         public IFileSystem FileSystem { get; set; }
     }
-    /*
+    
     public class SinglethreadedZipArchiveArtifactProvider : ArtifactProvider
     {
         public SinglethreadedZipArchiveArtifactProvider(ZipArchive zipArchive, IFileSystem fileSystem) : base(fileSystem)
@@ -45,32 +45,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
             Artifacts = artifacts;
         }
-    }*/
-
-    public class SinglethreadedZipArchiveArtifactProvider : ArtifactProvider
-    {
-        private readonly ZipArchive zipArchive;
-
-        public SinglethreadedZipArchiveArtifactProvider(ZipArchive zipArchive, IFileSystem fileSystem) : base(fileSystem)
-        {
-            this.zipArchive = zipArchive;
-        }
-
-        public override IEnumerable<IEnumeratedArtifact> Artifacts
-        {
-            get
-            {
-                foreach (ZipArchiveEntry entry in this.zipArchive.Entries)
-                {
-                    yield return new EnumeratedArtifact(Sarif.FileSystem.Instance)
-                    {
-                        Uri = new Uri(entry.FullName, UriKind.RelativeOrAbsolute),
-                        Contents = new StreamReader(entry.Open()).ReadToEnd(),
-                    };
-                }
-            }
-        }
     }
+
     public class MultithreadedZipArchiveArtifactProvider : ArtifactProvider
     {
         private readonly ZipArchive zipArchive;

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/ArtifactProvider.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/ArtifactProvider.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using System.Text;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 {
@@ -26,10 +27,10 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
         public IFileSystem FileSystem { get; set; }
     }
-
-    public class MultithreadedZipArchiveArtifactProvider : ArtifactProvider
+    /*
+    public class SinglethreadedZipArchiveArtifactProvider : ArtifactProvider
     {
-        public MultithreadedZipArchiveArtifactProvider(ZipArchive zipArchive, IFileSystem fileSystem) : base(fileSystem)
+        public SinglethreadedZipArchiveArtifactProvider(ZipArchive zipArchive, IFileSystem fileSystem) : base(fileSystem)
         {
             var artifacts = new List<IEnumeratedArtifact>();
 
@@ -44,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
             Artifacts = artifacts;
         }
-    }
+    }*/
 
     public class SinglethreadedZipArchiveArtifactProvider : ArtifactProvider
     {
@@ -68,6 +69,87 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                     };
                 }
             }
+        }
+    }
+    public class MultithreadedZipArchiveArtifactProvider : ArtifactProvider
+    {
+        private readonly ZipArchive zipArchive;
+
+        public MultithreadedZipArchiveArtifactProvider(ZipArchive zipArchive, IFileSystem fileSystem) : base(fileSystem)
+        {
+            this.zipArchive = zipArchive;
+        }
+
+        public override IEnumerable<IEnumeratedArtifact> Artifacts
+        {
+            get
+            {
+                foreach (ZipArchiveEntry entry in this.zipArchive.Entries)
+                {
+                    yield return new ZipArchiveArtifact(this.zipArchive, entry);
+                }
+            }
+        }
+    }
+
+    public class ZipArchiveArtifact : IEnumeratedArtifact
+    {
+        private readonly ZipArchiveEntry entry;
+        private readonly ZipArchive archive;
+        private readonly Uri uri;
+        private string contents;
+
+        public ZipArchiveArtifact(ZipArchive archive, ZipArchiveEntry entry)
+        {
+            this.entry = entry;
+            this.archive = archive;
+            this.uri = new Uri(entry.FullName, UriKind.RelativeOrAbsolute);
+        }
+
+        public Uri Uri => this.uri;
+
+        public Stream Stream { 
+            get
+            { 
+                lock (this.archive)
+                {
+                    return entry.Open();
+                }
+            }
+            set => throw new NotImplementedException(); 
+        }
+
+        public Encoding Encoding { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+        public string Contents
+        {
+            get
+            {
+                lock (this.archive)
+                {
+                    if (this.contents != null) { return this.contents; }
+                    this.contents = new StreamReader(Stream).ReadToEnd();
+                    Stream = null;
+                    return this.contents;
+                }
+            }
+            set => throw new NotImplementedException();
+        }
+
+        public ulong? SizeInBytes 
+        { 
+            get
+            {
+                lock (this.archive)
+                {
+                    if (Stream != null)
+                    {
+                        return (ulong)Stream.Length;
+                    }
+                    return (ulong)this.contents.Length;
+                }
+            }
+            set => throw new NotImplementedException(); 
         }
     }
 }

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/ArtifactProvider.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/ArtifactProvider.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                     yield return new EnumeratedArtifact(Sarif.FileSystem.Instance)
                     {
                         Uri = new Uri(entry.FullName, UriKind.RelativeOrAbsolute),
-                        Stream = entry.Open()
+                        Contents = new StreamReader(entry.Open()).ReadToEnd(),
                     };
                 }
             }
@@ -113,7 +113,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             { 
                 lock (this.archive)
                 {
-                    return entry.Open();
+                    return entry != null
+                        ? entry.Open()
+                        : null;
                 }
             }
             set => throw new NotImplementedException(); 
@@ -129,7 +131,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 {
                     if (this.contents != null) { return this.contents; }
                     this.contents = new StreamReader(Stream).ReadToEnd();
-                    Stream = null;
+                    this.entry = null;
                     return this.contents;
                 }
             }


### PR DESCRIPTION
- DEP: Update SARIF SDK submodule from [ec93dcc to 615a31a](https://github.com/microsoft/sarif-sdk/compare/ec93dcc..615a31a). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/615a31a/src/ReleaseHistory.md).
- FPS: Eliminate `SEC101/047.CratesApiKey` false positives due to bad prefix regex pattern. [#713](https://github.com/microsoft/sarif-pattern-matcher/pull/713)

Update SARIF-SDK to resolve too-large context region bugs. Also introduces a thread-safe zip archive class. This latter class needs to be refined further.