### PR TITLE
Update to SDK with new TargetAnalyzed method.

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -18,6 +18,10 @@
 - UER => Eliminate unhandled exceptions in rule.
 - UEE => Eliminate unhandled exceptions in engine.
 
+## v4.2.0 Released 03/07/2023
+- DEP: Update SARIF SDK submodule from [2f79183 to 420fe9c](https://github.com/microsoft/sarif-sdk/compare/2f79183..420fe9c). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/420fe9c/src/ReleaseHistory.md).
+- BUG: Dependency update above resolve an issue where `IAnalysisLogger.AnalyzeTarget` callbacks did not occur.
+
 ## v4.1.0 Released 03/01/2023
 - DEP: Update SARIF SDK submodule from [615a31a to 2f79183](https://github.com/microsoft/sarif-sdk/compare/615a31a..2f79183). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/2f79183/src/ReleaseHistory.md).
 

--- a/Src/Sarif.PatternMatcher.Cli/Program.cs
+++ b/Src/Sarif.PatternMatcher.Cli/Program.cs
@@ -22,10 +22,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
         {
             try
             {
-                ulong a = BitConverter.ToUInt64(Encoding.ASCII.GetBytes("IoTHub00").Reverse().ToArray());
-                ulong b = BitConverter.ToUInt64(Encoding.ASCII.GetBytes("Device00").Reverse().ToArray());
-                ulong c = BitConverter.ToUInt64(Encoding.ASCII.GetBytes("Passwd00").Reverse().ToArray());
-
                 Console.OutputEncoding = Encoding.UTF8;
                 GlobalContext ??= new AnalyzeContext();
 


### PR DESCRIPTION
Update SARIF SDK.

- Resolves issue where `IAnalysisLogger.AnalyzeTarget` callbacks did not occur
- Adds `IAnalysisLogger.TargetAnalyzed` callback as per @rtaket .
@cfaucon 