### PR TITLE
Update analyzers to 7.0.1

### DIFF
--- a/Targets/build.common.props
+++ b/Targets/build.common.props
@@ -31,7 +31,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Common Packages">
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Build only change, so no change to release notes is necessary.

@yongyan-gh 