### PR TITLE
SARIF SDK update for version control provenance.

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -19,7 +19,7 @@
 - UEE => Eliminate unhandled exceptions in engine.
 
 ## v4.3.5 Released 03/21/2023
-- DEP: Update SARIF SDK submodule from [39ea626 to 023b19b](https://github.com/microsoft/sarif-sdk/compare/39ea626..023b19b). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/023b19b/src/ReleaseHistory.md).
+- DEP: Update SARIF SDK submodule from [39ea626 to  53b0246](https://github.com/microsoft/sarif-sdk/compare/39ea626.. 53b0246). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/023b19b/src/ReleaseHistory.md). Adds version control provenance.
 - BRK: `AnalyzeOptions` `DynamicValidation`, `DisableDynamicValidationCaching`, `EnhancedReporting`, `Retry` and `RedactSecrets` properties are now `bool?'. [#727](https://github.com/microsoft/sarif-pattern-matcher/pull/727)
 - BRK: Obsolete `--file-size-in-kb` argument removed. [#727](https://github.com/microsoft/sarif-pattern-matcher/pull/727)
 

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -19,7 +19,7 @@
 - UEE => Eliminate unhandled exceptions in engine.
 
 ## v4.3.5 Released 03/21/2023
-- DEP: Update SARIF SDK submodule from [39ea626 to  53b0246](https://github.com/microsoft/sarif-sdk/compare/39ea626.. 53b0246). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/023b19b/src/ReleaseHistory.md). Adds version control provenance.
+- DEP: Update SARIF SDK submodule from [39ea626 to 53b0246](https://github.com/microsoft/sarif-sdk/compare/39ea626..53b0246). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/53b0246/src/ReleaseHistory.md). Adds version control provenance.
 - BRK: `AnalyzeOptions` `DynamicValidation`, `DisableDynamicValidationCaching`, `EnhancedReporting`, `Retry` and `RedactSecrets` properties are now `bool?'. [#727](https://github.com/microsoft/sarif-pattern-matcher/pull/727)
 - BRK: Obsolete `--file-size-in-kb` argument removed. [#727](https://github.com/microsoft/sarif-pattern-matcher/pull/727)
 

--- a/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
@@ -348,6 +348,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             context.DynamicValidation = options.DynamicValidation != null ? options.DynamicValidation.Value : context.DynamicValidation;
             context.DisableDynamicValidationCaching = options.DisableDynamicValidationCaching != null ? options.DisableDynamicValidationCaching.Value : context.DisableDynamicValidationCaching;
 
+            if (options.VersionControlProvenance != null)
+            {
+                context.VersionControlProvenance = 
+                    JsonConvert.DeserializeObject<List<VersionControlDetails>>(options.VersionControlProvenance);
+            }
+
             context.SearchDefinitionsPaths = options.SearchDefinitionsPaths.Any() ? new StringSet(options.SearchDefinitionsPaths) : context.SearchDefinitionsPaths;
 
             return context;

--- a/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
@@ -350,7 +350,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
             if (options.VersionControlProvenance != null)
             {
-                context.VersionControlProvenance = 
+                context.VersionControlProvenance =
                     JsonConvert.DeserializeObject<List<VersionControlDetails>>(options.VersionControlProvenance);
             }
 

--- a/Src/Sarif.PatternMatcher/AnalyzeContext.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeContext.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis.Sarif.Driver;
-using Microsoft.CodeAnalysis.Sarif.Writers;
 using Microsoft.Strings.Interop;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher

--- a/Src/Sarif.PatternMatcher/AnalyzeOptions.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeOptions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
         [Option(
             "vcp",
             Separator = ';',
-            HelpText = "A serialized JSON version control details object to persist to the output fil.")]
+            HelpText = "A serialized JSON version control details object to persist to the output file.")]
         public string VersionControlProvenance { get; set; }
 
         [Option(

--- a/Src/Sarif.PatternMatcher/AnalyzeOptions.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeOptions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             "vcp",
             Separator = ';',
             HelpText = "A serialized JSON version control details object to persist to the output fil.")]
-        public string VersionControlProvenance{ get; set; }
+        public string VersionControlProvenance { get; set; }
 
         [Option(
             'd',

--- a/Src/Sarif.PatternMatcher/AnalyzeOptions.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeOptions.cs
@@ -13,6 +13,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
     public class AnalyzeOptions : AnalyzeOptionsBase
     {
         [Option(
+            "vcp",
+            Separator = ';',
+            HelpText = "A serialized JSON version control details object to persist to the output fil.")]
+        public string VersionControlProvenance{ get; set; }
+
+        [Option(
             'd',
             "search-definitions",
             Separator = ';',


### PR DESCRIPTION
Update SARIF SDK to 53b0246 to obtain version control provenance in options and context.