### PR TITLE
Update to various renames for plugin arg, automation id and guid.

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -18,6 +18,14 @@
 - UER => Eliminate unhandled exceptions in rule.
 - UEE => Eliminate unhandled exceptions in engine.
 
+## v4.3.7 Released 03/22/2023
+- DEP: Update SARIF SDK submodule from [53b0246 to 6c5825c](https://github.com/microsoft/sarif-sdk/compare/53b0246..6c5825c). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/6c5825c/src/ReleaseHistory.md). Adds version control provenance.
+- BRK: SARIF SDK update changes `--automationId` and `--automationGuid` command-line arguments to `--automation-id` and `--automation-guid`.
+- BRK: `--search-definitions`/`-s` argument deprecated in favor of `plugin`/`-p`. [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/6c5825c/src/ReleaseHistory.md). Adds version control provenance.
+
+- BUG: Resolve bug where console failed to emit `Note` messages. [#732](https://github.com/microsoft/sarif-pattern-matcher/pull/732)
+
+
 ## v4.3.5 Released 03/21/2023
 - DEP: Update SARIF SDK submodule from [39ea626 to 53b0246](https://github.com/microsoft/sarif-sdk/compare/39ea626..53b0246). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/53b0246/src/ReleaseHistory.md). Adds version control provenance.
 - BRK: `AnalyzeOptions` `DynamicValidation`, `DisableDynamicValidationCaching`, `EnhancedReporting`, `Retry` and `RedactSecrets` properties are now `bool?'. [#727](https://github.com/microsoft/sarif-pattern-matcher/pull/727)

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -19,12 +19,10 @@
 - UEE => Eliminate unhandled exceptions in engine.
 
 ## v4.3.7 Released 03/22/2023
-- DEP: Update SARIF SDK submodule from [53b0246 to 6c5825c](https://github.com/microsoft/sarif-sdk/compare/53b0246..6c5825c). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/6c5825c/src/ReleaseHistory.md). Adds version control provenance.
-- BRK: SARIF SDK update changes `--automationId` and `--automationGuid` command-line arguments to `--automation-id` and `--automation-guid`.
+- DEP: Update SARIF SDK submodule from [53b0246 to 1ff3956](https://github.com/microsoft/sarif-sdk/compare/53b0246..1ff3956). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/1ff3956/src/ReleaseHistory.md). Adds version control provenance.
+- BRK: SARIF SDK update changes `--automationId` and `--automationGuid` command-line arguments to `--automation-id` and `--automation-guid`. [#732](https://github.com/microsoft/sarif-pattern-matcher/pull/732)
 - BRK: `--search-definitions`/`-s` argument deprecated in favor of `plugin`/`-p`. [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/6c5825c/src/ReleaseHistory.md). Adds version control provenance.
-
 - BUG: Resolve bug where console failed to emit `Note` messages. [#732](https://github.com/microsoft/sarif-pattern-matcher/pull/732)
-
 
 ## v4.3.5 Released 03/21/2023
 - DEP: Update SARIF SDK submodule from [39ea626 to 53b0246](https://github.com/microsoft/sarif-sdk/compare/39ea626..53b0246). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/53b0246/src/ReleaseHistory.md). Adds version control provenance.

--- a/Src/Sarif.PatternMatcher.Cli/AnalyzeDatabaseCommand.cs
+++ b/Src/Sarif.PatternMatcher.Cli/AnalyzeDatabaseCommand.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
                 aggregatingLogger.Loggers.Add(sarifLogger);
 
                 aggregatingLogger.AnalysisStarted();
-                ISet<Skimmer<AnalyzeContext>> skimmers = AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(FileSystem, options.SearchDefinitionsPaths, run.Tool);
+                ISet<Skimmer<AnalyzeContext>> skimmers = AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(FileSystem, options.PluginFilePaths, run.Tool);
 
                 var workers = new Task<bool>[options.Threads];
 

--- a/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
@@ -354,7 +354,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                     JsonConvert.DeserializeObject<List<VersionControlDetails>>(options.VersionControlProvenance);
             }
 
-            context.SearchDefinitionsPaths = options.SearchDefinitionsPaths.Any() ? new StringSet(options.SearchDefinitionsPaths) : context.SearchDefinitionsPaths;
+            context.PluginFilePaths = options.PluginFilePaths.Any() ? new StringSet(options.PluginFilePaths) : context.PluginFilePaths;
 
             return context;
         }
@@ -363,7 +363,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
         {
             context = base.ValidateContext(context);
 
-            if (ValidateFiles(context, context.SearchDefinitionsPaths, shouldExist: true))
+            if (ValidateFiles(context, context.PluginFilePaths, shouldExist: true))
             {
 
             }
@@ -380,9 +380,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 aggregatedSkimmers = new HashSet<Skimmer<AnalyzeContext>>(context.Skimmers);
             }
 
-            if (context.SearchDefinitionsPaths?.Any() == true)
+            if (context.PluginFilePaths?.Any() == true)
             {
-                foreach (Skimmer<AnalyzeContext> skimmer in CreateSkimmersFromDefinitionsFiles(context.FileSystem, context.SearchDefinitionsPaths, Tool))
+                foreach (Skimmer<AnalyzeContext> skimmer in CreateSkimmersFromDefinitionsFiles(context.FileSystem, context.PluginFilePaths, Tool))
                 {
                     aggregatedSkimmers.Add(skimmer);
                 }

--- a/Src/Sarif.PatternMatcher/AnalyzeContext.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeContext.cs
@@ -19,12 +19,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             IsValidAnalysisTarget = true;
         }
 
-        public StringSet SearchDefinitionsPaths
-        {
-            get => this.Policy.GetProperty(SearchDefinitionsPathsProperty);
-            set => this.Policy.SetProperty(SearchDefinitionsPathsProperty, value);
-        }
-
         public bool RedactSecrets { get; set; }
 
         public IEnumerable<Skimmer<AnalyzeContext>> Skimmers { get; set; }
@@ -100,11 +94,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 "An upper bound on the size of the RE2 DFA cache. When the cache size exceeds this " +
                 "limit RE2 will fallback to an alternate (much less performant) search mechanism. " +
                 "Negative values will be discarded in favor of the default of 5096 KB.");
-
-        public static PerLanguageOption<StringSet> SearchDefinitionsPathsProperty { get; } =
-                    new PerLanguageOption<StringSet>(
-                        "CoreSettings", nameof(SearchDefinitionsPaths), defaultValue: () => new StringSet(),
-                        "One or more paths to files containing one or more search definitions to drive analysis.");
 
         public static PerLanguageOption<string> GlobalFileDenyRegexProperty { get; } =
                     new PerLanguageOption<string>(

--- a/Src/Sarif.PatternMatcher/AnalyzeOptions.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeOptions.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
-
 using CommandLine;
 
 using Microsoft.CodeAnalysis.Sarif.Driver;
@@ -17,13 +15,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             Separator = ';',
             HelpText = "A serialized JSON version control details object to persist to the output file.")]
         public string VersionControlProvenance { get; set; }
-
-        [Option(
-            'd',
-            "search-definitions",
-            Separator = ';',
-            HelpText = "A path to a file containing one or more search definitions to drive analysis.")]
-        public IEnumerable<string> SearchDefinitionsPaths { get; set; }
 
         [Option(
             "dynamic-validation",

--- a/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/AnalyzeCommandTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/AnalyzeCommandTests.cs
@@ -277,7 +277,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
                 "analyze",
                 largeTargetPath,
                 smallTargetPath,
-                $"-d", searchDefinitionsPath,
+                $"-p", searchDefinitionsPath,
                 $"-o", sarifLogFileName,
                 $"--file-size-in-kb", fileSizeInKilobytes.ToString(),
                 $"--max-file-size-in-kb", maxFileSizeInKilobytes.ToString(),
@@ -389,7 +389,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
 
         private SarifLog RunAnalyzeCommand(string definitionsText, string fileContents)
         {
-            string sarifOutput;
             string rootDirectory = @"e:\repros";
             string scanTargetName = SmallTargetName;
             string scanTargetPath = Path.Combine(rootDirectory, scanTargetName);
@@ -440,7 +439,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
                 {
                     "analyze",
                     scanTargetPath,
-                    $"-d", searchDefinitionsPath,
+                    $"-p", searchDefinitionsPath,
                     $"-o", sarifLogFileName,
                 };
 
@@ -545,7 +544,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
                         largeTargetPath,
                         smallTargetPath,
                         "--insert", "Hashes",
-                        "-d", searchDefinitionsPath,
+                        "-p", searchDefinitionsPath,
                         "-o", sarifLogFileName,
                         "--max-file-size-in-kb", maxFileSizeInKilobytes.ToString(),
                 };
@@ -636,7 +635,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
                 {
                     "analyze",
                     scanTargetPath,
-                    $"-d", searchDefinitionsPath,
+                    $"-p", searchDefinitionsPath,
                     $"-o", sarifLogFileName,
                     "--level", levels,
                     "--rich-return-code"
@@ -647,7 +646,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
                 {
                     "analyze",
                     scanTargetPath,
-                    $"-d", searchDefinitionsPath,
+                    $"-p", searchDefinitionsPath,
                     $"-o", sarifLogFileName,
                     "--level", levels,
                     "--dynamic-validation",

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/AnalyzeCommandTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/AnalyzeCommandTests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
             var options = new AnalyzeOptions
             {
-                SearchDefinitionsPaths = new[] { "SEC101.SecurePlaintextSecrets.json" },
+                PluginFilePaths = new[] { "SEC101.SecurePlaintextSecrets.json" },
                 Trace = new string[] { nameof(DefaultTraces.RuleScanTime) },
             };
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "4.3.5",
+  "version": "4.3.7",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+\\.\\d+\\.\\d+$"


### PR DESCRIPTION
- DEP: Update SARIF SDK submodule from [53b0246 to 6c5825c](https://github.com/microsoft/sarif-sdk/compare/53b0246..6c5825c). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/6c5825c/src/ReleaseHistory.md). Adds version control provenance.
- BRK: SARIF SDK update changes `--automationId` and `--automationGuid` command-line arguments to `--automation-id` and `--automation-guid`. [#732](https://github.com/microsoft/sarif-pattern-matcher/pull/732)
- BRK: `--search-definitions`/`-s` argument deprecated in favor of `plugin`/`-p`. [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/6c5825c/src/ReleaseHistory.md). Adds version control provenance.
- BUG: Resolve bug where console failed to emit `Note` messages. [#732](https://github.com/microsoft/sarif-pattern-matcher/pull/732)
