### PR TITLE
Update ctor init of ValidationResult.ValidationState (to Unknown).

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -19,7 +19,7 @@
 - UEE => Eliminate unhandled exceptions in engine.
 
 ## v4.3.8 UNRELEASED
-- BRK: `ValidationResult` constructor now sets `ValidationState` to `Unknown`.
+- BRK: `ValidationResult` constructor now sets `ValidationState` to `Unknown`. [#733](https://github.com/microsoft/sarif-pattern-matcher/pull/733)
 
 ## v4.3.7 Released 03/22/2023
 - DEP: Update SARIF SDK submodule from [53b0246 to 1ff3956](https://github.com/microsoft/sarif-sdk/compare/53b0246..1ff3956). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/1ff3956/src/ReleaseHistory.md). Adds version control provenance.

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -18,6 +18,9 @@
 - UER => Eliminate unhandled exceptions in rule.
 - UEE => Eliminate unhandled exceptions in engine.
 
+## v4.3.8 UNRELEASED
+- BRK: `ValidationResult` constructor now sets `ValidationState` to `Unknown`.
+
 ## v4.3.7 Released 03/22/2023
 - DEP: Update SARIF SDK submodule from [53b0246 to 1ff3956](https://github.com/microsoft/sarif-sdk/compare/53b0246..1ff3956). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/1ff3956/src/ReleaseHistory.md). Adds version control provenance.
 - BRK: SARIF SDK update changes `--automationId` and `--automationGuid` command-line arguments to `--automation-id` and `--automation-guid`. [#732](https://github.com/microsoft/sarif-pattern-matcher/pull/732)

--- a/Src/Plugins/Security/ReviewPotentiallySensitiveDataValidators/SEC102_001.EmailAddressValidator.cs
+++ b/Src/Plugins/Security/ReviewPotentiallySensitiveDataValidators/SEC102_001.EmailAddressValidator.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                         Id = id.Value,
                         Host = host.Value,
                     },
-                    };
+                };
 
                 return new[] { validationResult };
             }

--- a/Src/Plugins/Security/ReviewPotentiallySensitiveDataValidators/SEC102_001.EmailAddressValidator.cs
+++ b/Src/Plugins/Security/ReviewPotentiallySensitiveDataValidators/SEC102_001.EmailAddressValidator.cs
@@ -36,8 +36,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                         Id = id.Value,
                         Host = host.Value,
                     },
-                    ValidationState = ValidationState.Unknown,
-                };
+                    };
 
                 return new[] { validationResult };
             }

--- a/Src/Plugins/Security/SEC102_003.UrlValidator.cs
+++ b/Src/Plugins/Security/SEC102_003.UrlValidator.cs
@@ -38,7 +38,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Part = query,
                     Port = uri.Port.ToString(),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_001.HttpAuthorizationRequestHeaderValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_001.HttpAuthorizationRequestHeaderValidator.cs
@@ -34,7 +34,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Scheme = scheme.Value,
                     Secret = secret.Value,
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_002.GoogleOAuthCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_002.GoogleOAuthCredentialsValidator.cs
@@ -26,7 +26,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.Google),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_003.GoogleApiKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_003.GoogleApiKeyValidator.cs
@@ -33,7 +33,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.Google),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_004.FacebookAppCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_004.FacebookAppCredentialsValidator.cs
@@ -38,7 +38,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.Facebook),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_005.SlackApiKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_005.SlackApiKeyValidator.cs
@@ -33,7 +33,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.Slack),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_006.GitHubLegacyPatValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_006.GitHubLegacyPatValidator.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                         Secret = secret.Value,
                         Platform = nameof(AssetPlatform.GitHub),
                     },
-                    };
+                };
 
                 return new[] { validationResult };
             }

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_006.GitHubLegacyPatValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_006.GitHubLegacyPatValidator.cs
@@ -31,8 +31,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                         Secret = secret.Value,
                         Platform = nameof(AssetPlatform.GitHub),
                     },
-                    ValidationState = ValidationState.Unknown,
-                };
+                    };
 
                 return new[] { validationResult };
             }
@@ -67,7 +66,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.GitHub),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_007.GitHubAppCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_007.GitHubAppCredentialsValidator.cs
@@ -37,7 +37,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.GitHub),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_008.AwsCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_008.AwsCredentialsValidator.cs
@@ -43,7 +43,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.Aws),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_009.LinkedInCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_009.LinkedInCredentialsValidator.cs
@@ -26,7 +26,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.LinkedIn),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_010.SquarePatValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_010.SquarePatValidator.cs
@@ -28,7 +28,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.Square),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_011.SquareCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_011.SquareCredentialsValidator.cs
@@ -29,7 +29,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.Square),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_012.SlackWebhookValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_012.SlackWebhookValidator.cs
@@ -30,7 +30,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.Slack),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_014.FacebookAccessTokenValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_014.FacebookAccessTokenValidator.cs
@@ -21,7 +21,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.Facebook),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_015.AkamaiCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_015.AkamaiCredentialsValidator.cs
@@ -47,7 +47,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Resource = resource.Value,
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_017.NpmLegacyAuthorTokenValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_017.NpmLegacyAuthorTokenValidator.cs
@@ -22,7 +22,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.Npm),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_018.TwilioCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_018.TwilioCredentialsValidator.cs
@@ -33,7 +33,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.Twilio),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_019.PicaticApiKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_019.PicaticApiKeyValidator.cs
@@ -21,7 +21,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.Picatic),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_020.DropboxAccessTokenValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_020.DropboxAccessTokenValidator.cs
@@ -30,7 +30,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.Dropbox),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_021.DropboxAppCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_021.DropboxAppCredentialsValidator.cs
@@ -45,7 +45,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.Dropbox),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_022.PayPalBraintreeAccessTokenValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_022.PayPalBraintreeAccessTokenValidator.cs
@@ -21,7 +21,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.PayPal),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_023.AmazonMwsAuthTokenValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_023.AmazonMwsAuthTokenValidator.cs
@@ -21,7 +21,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.Aws),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_024.TwilioApiKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_024.TwilioApiKeyValidator.cs
@@ -21,7 +21,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.Twilio),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_025.SendGridApiKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_025.SendGridApiKeyValidator.cs
@@ -29,7 +29,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.SendGrid),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_026.MailgunApiCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_026.MailgunApiCredentialsValidator.cs
@@ -43,7 +43,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.Mailgun),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_027.MailChimpApiKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_027.MailChimpApiKeyValidator.cs
@@ -29,7 +29,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.MailChimp),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_029.AlibabaCloudCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_029.AlibabaCloudCredentialsValidator.cs
@@ -40,7 +40,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.AlibabaCloud),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_030.GoogleServiceAccountKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_030.GoogleServiceAccountKeyValidator.cs
@@ -24,7 +24,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Id = id?.Value,
                     Secret = secret.Value,
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_031.NuGetApiKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_031.NuGetApiKeyValidator.cs
@@ -21,7 +21,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.NuGet),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_032.GpgCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_032.GpgCredentialsValidator.cs
@@ -23,7 +23,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Id = id?.Value,
                     Secret = secret.Value,
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_033.MongoDbCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_033.MongoDbCredentialsValidator.cs
@@ -27,7 +27,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Host = host.Value,
                     Secret = secret.Value,
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_034.CredentialObjectValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_034.CredentialObjectValidator.cs
@@ -25,7 +25,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Id = id.Value,
                     Secret = secret.Value,
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_035.CloudantCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_035.CloudantCredentialsValidator.cs
@@ -35,7 +35,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Resource = resource?.Value,
                     Platform = nameof(AssetPlatform.Cloudant),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_036.MySqlCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_036.MySqlCredentialsValidator.cs
@@ -73,7 +73,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             var validationResult = new ValidationResult
             {
                 Fingerprint = fingerprint,
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_037.SqlCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_037.SqlCredentialsValidator.cs
@@ -79,7 +79,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             var validationResult = new ValidationResult
             {
                 Fingerprint = fingerprint,
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_038.PostgreSqlCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_038.PostgreSqlCredentialsValidator.cs
@@ -75,7 +75,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             var validationResult = new ValidationResult
             {
                 Fingerprint = fingerprint,
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_039.ShopifyAccessTokenValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_039.ShopifyAccessTokenValidator.cs
@@ -21,7 +21,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.Shopify),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_040.ShopifySharedSecretValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_040.ShopifySharedSecretValidator.cs
@@ -21,7 +21,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.Shopify),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_041.RabbitMqCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_041.RabbitMqCredentialsValidator.cs
@@ -35,7 +35,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Resource = resource.Value,
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_042.DynatraceTokenValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_042.DynatraceTokenValidator.cs
@@ -21,7 +21,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.Dynatrace),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_043.NuGetCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_043.NuGetCredentialsValidator.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                             Secret = password,
                             Platform = nameof(AssetPlatform.NuGet),
                         },
-                            });
+                    });
                 }
             }
 

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_043.NuGetCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_043.NuGetCredentialsValidator.cs
@@ -74,8 +74,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                             Secret = password,
                             Platform = nameof(AssetPlatform.NuGet),
                         },
-                        ValidationState = ValidationState.Unknown,
-                    });
+                            });
                 }
             }
 

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_044.NpmCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_044.NpmCredentialsValidator.cs
@@ -75,7 +75,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = password,
                     Platform = nameof(AssetPlatform.Npm),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_045.PostmanApiKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_045.PostmanApiKeyValidator.cs
@@ -38,7 +38,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.Postman),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_046.DiscordApiCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_046.DiscordApiCredentialsValidator.cs
@@ -36,7 +36,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.Discord),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_047.CratesApiKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_047.CratesApiKeyValidator.cs
@@ -29,7 +29,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.Crates),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_048.SlackWorkflowKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_048.SlackWorkflowKeyValidator.cs
@@ -33,7 +33,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.Slack),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_049.TelegramBotTokenValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_049.TelegramBotTokenValidator.cs
@@ -29,7 +29,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.Telegram),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_050.NpmIdentifiableAuthorTokenValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_050.NpmIdentifiableAuthorTokenValidator.cs
@@ -36,7 +36,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.Npm),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/StripeApiKeyValidatorBase.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/StripeApiKeyValidatorBase.cs
@@ -39,7 +39,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     Secret = secret.Value,
                     Platform = nameof(AssetPlatform.Stripe),
                 },
-                ValidationState = ValidationState.Unknown,
             };
 
             return new[] { validationResult };

--- a/Src/Sarif.PatternMatcher.Sdk/ValidationResult.cs
+++ b/Src/Sarif.PatternMatcher.Sdk/ValidationResult.cs
@@ -9,6 +9,11 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk
 {
     public class ValidationResult
     {
+        public ValidationResult()
+        {
+            ValidationState = ValidationState.Unknown;
+        }
+
         public string Message { get; set; }
 
         public Fingerprint Fingerprint { get; set; }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "4.3.7",
+  "version": "4.3.8",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+\\.\\d+\\.\\d+$"


### PR DESCRIPTION
`Unknown` clearly seems like the appropriate default state for `ValidationState` in a newly allocated `ValidationResult` instance.

We not init to this in the ctor. Allows us to drop this explicit initialization in 50 rules.