### PR TITLE
Require asset information for unhandled exception reporting.

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -20,6 +20,7 @@
 
 ## v4.3.8 UNRELEASED
 - BRK: `ValidationResult` constructor now sets `ValidationState` to `Unknown`. [#733](https://github.com/microsoft/sarif-pattern-matcher/pull/733)
+- BUG: Consistently report asset data (which may be the truncated secret) when reporting unhandled exceptions in dynamic validators. [#736](https://github.com/microsoft/sarif-pattern-matcher/pull/736)
 
 ## v4.3.7 Released 03/22/2023
 - DEP: Update SARIF SDK submodule from [53b0246 to 1ff3956](https://github.com/microsoft/sarif-sdk/compare/53b0246..1ff3956). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/1ff3956/src/ReleaseHistory.md). Adds version control provenance.

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -20,7 +20,7 @@
 
 ## v4.3.8 UNRELEASED
 - BRK: `ValidationResult` constructor now sets `ValidationState` to `Unknown`. [#733](https://github.com/microsoft/sarif-pattern-matcher/pull/733)
-- BRK: `ValidatorBase.ReturnUnhandledException` not requires an `asset` parameter. [#736](https://github.com/microsoft/sarif-pattern-matcher/pull/736)
+- BRK: `ValidatorBase.ReturnUnhandledException` now requires an `asset` parameter. [#736](https://github.com/microsoft/sarif-pattern-matcher/pull/736)
 - BUG: Consistently report asset data (which may be the truncated secret) when reporting unhandled exceptions in dynamic validators. [#736](https://github.com/microsoft/sarif-pattern-matcher/pull/736)
 
 ## v4.3.7 Released 03/22/2023

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -20,6 +20,7 @@
 
 ## v4.3.8 UNRELEASED
 - BRK: `ValidationResult` constructor now sets `ValidationState` to `Unknown`. [#733](https://github.com/microsoft/sarif-pattern-matcher/pull/733)
+- BRK: `ValidatorBase.ReturnUnhandledException` not requires an `asset` parameter. [#736](https://github.com/microsoft/sarif-pattern-matcher/pull/736)
 - BUG: Consistently report asset data (which may be the truncated secret) when reporting unhandled exceptions in dynamic validators. [#736](https://github.com/microsoft/sarif-pattern-matcher/pull/736)
 
 ## v4.3.7 Released 03/22/2023

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/NpmAuthorTokenHelper.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/NpmAuthorTokenHelper.cs
@@ -59,6 +59,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                                        HttpClient client)
         {
             string secret = fingerprint.Secret;
+            string asset = secret.Truncate();
 
             try
             {
@@ -90,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             }
             catch (Exception e)
             {
-                return ValidatorBase.ReturnUnhandledException(ref message, e, asset: secret.Truncate());
+                return ValidatorBase.ReturnUnhandledException(ref message, e, asset);
             }
         }
 

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/NpmAuthorTokenHelper.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/NpmAuthorTokenHelper.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             }
             catch (Exception e)
             {
-                return ValidatorBase.ReturnUnhandledException(ref message, e);
+                return ValidatorBase.ReturnUnhandledException(ref message, e, asset: secret.Truncate());
             }
         }
 

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_005.SlackApiKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_005.SlackApiKeyValidator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
+using System.Net.Sockets;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -44,13 +45,15 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                                                 ref ResultLevelKind resultLevelKind)
         {
             const string uri = "https://slack.com/api/auth.test";
+            string secret = fingerprint.Secret;
+            string asset = secret.Truncate();
 
             try
             {
                 HttpClient client = CreateOrRetrieveCachedHttpClient();
                 var dict = new Dictionary<string, string>
                 {
-                    { "token", fingerprint.Secret },
+                    { "token", secret },
                 };
 
                 using var request = new HttpRequestMessage(HttpMethod.Post, uri);
@@ -89,7 +92,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             }
             catch (Exception e)
             {
-                return ReturnUnhandledException(ref message, e);
+                return ReturnUnhandledException(ref message, e, asset);
             }
         }
 

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_005.SlackApiKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_005.SlackApiKeyValidator.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
-using System.Net.Sockets;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_006.GitHubLegacyPatValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_006.GitHubLegacyPatValidator.cs
@@ -76,11 +76,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                                                 IDictionary<string, string> options,
                                                                 ref ResultLevelKind resultLevelKind)
         {
-            string pat = fingerprint.Secret;
+            string secret = fingerprint.Secret;
+            string asset = secret.Truncate();
 
             try
             {
-                var credentials = new Credentials(pat);
+                var credentials = new Credentials(secret);
                 var credentialsStore = new InMemoryCredentialStore(credentials);
                 var client = new GitHubClient(new ProductHeaderValue(ScanIdentityGuid), credentialsStore);
 
@@ -93,6 +94,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                     name = $" ({name})";
                 }
 
+                asset = $"{id}{name}";
                 message = $"the compromised GitHub account is '[{id}{name}](https://github.com/{id})'";
 
                 IReadOnlyList<Organization> orgs = client.Organization.GetAllForCurrent().GetAwaiter().GetResult();
@@ -126,7 +128,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             }
             catch (Exception e)
             {
-                return ReturnUnhandledException(ref message, e);
+                return ReturnUnhandledException(ref message, e, asset);
             }
         }
     }

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_010.SquarePatValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_010.SquarePatValidator.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Net.Sockets;
 
 using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk;
 using Microsoft.RE2.Managed;

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_010.SquarePatValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_010.SquarePatValidator.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Net.Sockets;
 
 using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk;
 using Microsoft.RE2.Managed;
@@ -38,7 +39,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                                                 IDictionary<string, string> options,
                                                                 ref ResultLevelKind resultLevelKind)
         {
-            string pat = fingerprint.Secret;
+            string secret = fingerprint.Secret;
+            string asset = secret.Truncate();
 
             const string uri = "https://connect.squareup.com/v2/catalog/list";
 
@@ -47,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                 HttpClient client = CreateOrRetrieveCachedHttpClient();
 
                 using var request = new HttpRequestMessage(HttpMethod.Get, uri);
-                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", pat);
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", secret);
 
                 using HttpResponseMessage response = client
                     .SendAsync(request, HttpCompletionOption.ResponseHeadersRead)
@@ -74,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             }
             catch (Exception e)
             {
-                return ReturnUnhandledException(ref message, e);
+                return ReturnUnhandledException(ref message, e, asset);
             }
         }
     }

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_011.SquareCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_011.SquareCredentialsValidator.cs
@@ -41,6 +41,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
         {
             string id = fingerprint.Id;
             string secret = fingerprint.Secret;
+            string asset = secret.Truncate();
 
             const string codeForRequest = "123";
             const string uri = "https://connect.squareup.com/oauth2/token";
@@ -93,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             }
             catch (Exception e)
             {
-                return ReturnUnhandledException(ref message, e);
+                return ReturnUnhandledException(ref message, e, asset);
             }
         }
     }

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_012.SlackWebhookValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_012.SlackWebhookValidator.cs
@@ -10,8 +10,6 @@ using System.Text;
 using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk;
 using Microsoft.RE2.Managed;
 
-using static System.Net.WebRequestMethods;
-
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
     public class SlackWebhookValidator : DynamicValidatorBase

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_012.SlackWebhookValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_012.SlackWebhookValidator.cs
@@ -10,6 +10,8 @@ using System.Text;
 using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk;
 using Microsoft.RE2.Managed;
 
+using static System.Net.WebRequestMethods;
+
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
     public class SlackWebhookValidator : DynamicValidatorBase
@@ -42,7 +44,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
         {
             string id = fingerprint.Id;
             string secret = fingerprint.Secret;
-            string uri = $"https://hooks.slack.com/services/{id}/{secret}";
+            string asset = $"https://hooks.slack.com/services/{id}";
+            string uri = $"{asset}/{secret}";
 
             HttpClient client = CreateOrRetrieveCachedHttpClient();
 
@@ -93,7 +96,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             }
             catch (Exception e)
             {
-                return ReturnUnhandledException(ref message, e);
+                return ReturnUnhandledException(ref message, e, asset);
             }
         }
     }

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_015.AkamaiCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_015.AkamaiCredentialsValidator.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             string id = fingerprint.Id;
             string host = fingerprint.Host;
             string secret = fingerprint.Secret;
-            string asset = secret.Truncate(); // TBD
+            string asset = secret.Truncate();
             string resource = fingerprint.Resource;
 
             string date;

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_015.AkamaiCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_015.AkamaiCredentialsValidator.cs
@@ -60,9 +60,11 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             string id = fingerprint.Id;
             string host = fingerprint.Host;
             string secret = fingerprint.Secret;
+            string asset = secret.Truncate(); // TBD
             string resource = fingerprint.Resource;
-            string scanIdentityGuid = string.Empty;
-            string date = string.Empty;
+
+            string date;
+            string scanIdentityGuid;
             DateTime datetime = DateTime.UtcNow;
 
             if (options.TryGetValue("datetime", out date))
@@ -101,7 +103,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             }
             catch (Exception e)
             {
-                return ReturnUnhandledException(ref message, e);
+                return ReturnUnhandledException(ref message, e, asset);
             }
         }
 

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_018.TwilioCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_018.TwilioCredentialsValidator.cs
@@ -45,6 +45,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
         {
             string id = fingerprint.Id;
             string secret = fingerprint.Secret;
+            string asset = secret.Truncate();
 
             const string uri = "https://api.twilio.com/2010-04-01/Accounts.json";
 
@@ -93,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             }
             catch (Exception e)
             {
-                return ReturnUnhandledException(ref message, e);
+                return ReturnUnhandledException(ref message, e, asset);
             }
         }
     }

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_020.DropboxAccessTokenValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_020.DropboxAccessTokenValidator.cs
@@ -45,6 +45,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             const string uri = "https://api.dropboxapi.com/2/file_requests/count";
 
             string secret = fingerprint.Secret;
+            string asset = secret.Truncate();
+
             HttpClient httpClient = CreateOrRetrieveCachedHttpClient();
 
             try
@@ -79,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                         {
                             if (secret.Length != 64)
                             {
-                                // Short expiration token (4h).
+                                // Short-lived token (4h).
                                 resultLevelKind = new ResultLevelKind { Level = FailureLevel.Warning };
                             }
 
@@ -102,7 +104,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             }
             catch (Exception e)
             {
-                return ReturnUnhandledException(ref message, e);
+                return ReturnUnhandledException(ref message, e, asset);
             }
         }
     }

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_021.DropboxAppCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_021.DropboxAppCredentialsValidator.cs
@@ -57,11 +57,13 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
         {
             string id = fingerprint.Id;
             string secret = fingerprint.Secret;
+            string asset = secret.Truncate();
+
             HttpClient httpClient = CreateOrRetrieveCachedHttpClient();
 
             try
             {
-                using var request = GenerateRequestMessage(id, secret);
+                using HttpRequestMessage request = GenerateRequestMessage(id, secret);
                 using HttpResponseMessage response = httpClient
                     .SendAsync(request, HttpCompletionOption.ResponseHeadersRead)
                     .GetAwaiter()
@@ -101,7 +103,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             }
             catch (Exception e)
             {
-                return ReturnUnhandledException(ref message, e);
+                return ReturnUnhandledException(ref message, e, asset);
             }
         }
     }

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_025.SendGridApiKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_025.SendGridApiKeyValidator.cs
@@ -40,6 +40,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                                                 ref ResultLevelKind resultLevelKind)
         {
             string secret = fingerprint.Secret;
+            string asset = secret.Truncate();
 
             try
             {
@@ -80,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             }
             catch (Exception e)
             {
-                return ReturnUnhandledException(ref message, e);
+                return ReturnUnhandledException(ref message, e, asset);
             }
         }
 

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_027.MailChimpApiKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_027.MailChimpApiKeyValidator.cs
@@ -40,6 +40,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                                                 ref ResultLevelKind resultLevelKind)
         {
             string secret = fingerprint.Secret;
+            string asset = secret.Truncate();
 
             try
             {
@@ -77,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             }
             catch (Exception e)
             {
-                return ReturnUnhandledException(ref message, e);
+                return ReturnUnhandledException(ref message, e, asset);
             }
         }
 

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_029.AlibabaCloudCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_029.AlibabaCloudCredentialsValidator.cs
@@ -56,6 +56,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 
             string id = fingerprint.Id;
             string secret = fingerprint.Secret;
+            string asset = secret.Truncate();
 
             try
             {
@@ -105,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             }
             catch (Exception e)
             {
-                return ReturnUnhandledException(ref message, e);
+                return ReturnUnhandledException(ref message, e, asset);
             }
         }
     }

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_045.PostmanApiKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_045.PostmanApiKeyValidator.cs
@@ -49,6 +49,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                                                 ref ResultLevelKind resultLevelKind)
         {
             string secret = fingerprint.Secret;
+            string asset = secret.Truncate();
 
             HttpClient client = CreateOrRetrieveCachedHttpClient();
 
@@ -81,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             }
             catch (Exception e)
             {
-                return ReturnUnhandledException(ref message, e);
+                return ReturnUnhandledException(ref message, e, asset);
             }
         }
     }

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_046.DiscordApiCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_046.DiscordApiCredentialsValidator.cs
@@ -48,6 +48,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
         {
             string id = fingerprint.Id;
             string secret = fingerprint.Secret;
+            string asset = secret.Truncate();
 
             const string uri = "https://discord.com/api/v8/oauth2/token";
 
@@ -91,7 +92,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             }
             catch (Exception e)
             {
-                return ReturnUnhandledException(ref message, e);
+                return ReturnUnhandledException(ref message, e, asset);
             }
         }
     }

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_047.CratesApiKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_047.CratesApiKeyValidator.cs
@@ -40,6 +40,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                                                 ref ResultLevelKind resultLevelKind)
         {
             string secret = fingerprint.Secret;
+            string asset = secret.Truncate();
 
             const string uri = "https://crates.io/api/v1/crates/sarif-pattern-matcher/owners";
 
@@ -76,7 +77,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             }
             catch (Exception e)
             {
-                return ReturnUnhandledException(ref message, e);
+                return ReturnUnhandledException(ref message, e, asset);
             }
         }
     }

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_048.SlackWorkflowKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_048.SlackWorkflowKeyValidator.cs
@@ -45,7 +45,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
         {
             string id = fingerprint.Id;
             string secret = fingerprint.Secret;
-            string uri = string.Format(WorkflowUri, id, secret);
+            string asset = $"https://hooks.slack.com/workflows/{id}";
+            string uri = $"{asset}/{secret}";
 
             try
             {
@@ -85,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             }
             catch (Exception e)
             {
-                return ReturnUnhandledException(ref message, e);
+                return ReturnUnhandledException(ref message, e, asset);
             }
         }
     }

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_049.TelegramBotTokenValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_049.TelegramBotTokenValidator.cs
@@ -40,6 +40,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                                                 ref ResultLevelKind resultLevelKind)
         {
             string secret = fingerprint.Secret;
+            string asset = secret.Truncate();
             string uri = string.Format(GetMeApi, secret);
 
             try
@@ -79,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             }
             catch (Exception e)
             {
-                return ReturnUnhandledException(ref message, e);
+                return ReturnUnhandledException(ref message, e, asset);
             }
         }
 

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/StripeApiKeyValidatorBase.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/StripeApiKeyValidatorBase.cs
@@ -50,6 +50,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                                                                 ref ResultLevelKind resultLevelKind)
         {
             string secret = fingerprint.Secret;
+            string asset = secret.Truncate();
 
             string keyKind = secret.Contains("_test_") ? "test" : "live production";
 
@@ -92,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
             }
             catch (Exception e)
             {
-                return ReturnUnhandledException(ref message, e);
+                return ReturnUnhandledException(ref message, e, asset);
             }
         }
     }

--- a/Src/Plugins/Security/Utilities/CertificateHelper.cs
+++ b/Src/Plugins/Security/Utilities/CertificateHelper.cs
@@ -73,6 +73,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Utilities
                                                          ref Fingerprint fingerprint,
                                                          ref string message)
         {
+            string asset = "[TBD]";
             try
             {
                 // If this certificate needs a password or it is a bundle, it will throw an exception.
@@ -102,7 +103,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Utilities
                     }
                 }
 
-                return ValidatorBase.ReturnUnhandledException(ref message, e);
+                return ValidatorBase.ReturnUnhandledException(ref message, e, asset);
             }
         }
 
@@ -110,6 +111,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Utilities
                                                                    ref Fingerprint fingerprint,
                                                                    ref string message)
         {
+            string asset = "[TBD]";
             var certificates = new X509Certificate2Collection();
             try
             {
@@ -119,7 +121,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Utilities
             }
             catch (Exception e)
             {
-                return ValidatorBase.ReturnUnhandledException(ref message, e);
+                return ValidatorBase.ReturnUnhandledException(ref message, e, asset);
             }
         }
 

--- a/Src/Plugins/Security/Utilities/CertificateHelper.cs
+++ b/Src/Plugins/Security/Utilities/CertificateHelper.cs
@@ -73,6 +73,10 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Utilities
                                                          ref Fingerprint fingerprint,
                                                          ref string message)
         {
+            // @michaelcfanning 3/28/23
+            // https://github.com/microsoft/sarif-pattern-matcher/issues/737
+            // We should encode the 'rawData' here and grab the first six
+            // characters of it to use as a slug/thumbprint for this finding.
             string asset = "[TBD]";
             try
             {
@@ -111,6 +115,10 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Utilities
                                                                    ref Fingerprint fingerprint,
                                                                    ref string message)
         {
+            // @michaelcfanning 3/28/23
+            // https://github.com/microsoft/sarif-pattern-matcher/issues/737
+            // We should encode the 'rawData' here and grab the first six
+            // characters of it to use as a slug/thumbprint for this finding.
             string asset = "[TBD]";
             var certificates = new X509Certificate2Collection();
             try

--- a/Src/Plugins/Tests.AzureDevOpsConfiguration/Validators/AZC102_190.DoNotShareWithAllPipelines.cs
+++ b/Src/Plugins/Tests.AzureDevOpsConfiguration/Validators/AZC102_190.DoNotShareWithAllPipelines.cs
@@ -17,7 +17,6 @@ using Newtonsoft.Json;
 
 using Xunit;
 
-using static System.Net.WebRequestMethods;
 using static Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.AzureDevOpsConfiguration.DoNotGrantAllPipelinesAccessValidator;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.AzureDevOpsConfiguration.Validators
@@ -39,23 +38,20 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.AzureDevOpsConfigu
                 Resource = "TestProject",
                 Id = "A1B326D6-0D73-4C01-A64B-FB43FE5E2A13",
             };
-            string adoPat = "testpat";
+            string secret = "testpat";
             string asset = $"https://{host}/{resource}/_apis/pipelines/pipelinePermissions/endpoint/{id}";
 
-            string pipelinePermissionAPI = "https://{0}/{1}/_apis/pipelines/pipelinePermissions/endpoint/{2}?api-version=6.1-preview.1";
+            string pipelinePermissionUri = $"{asset}/{secret}?api-version=6.1-preview.1";
 
             var defaultRequest = new HttpRequestMessage(
                     HttpMethod.Get,
-                    string.Format(pipelinePermissionAPI,
-                                  fingerprint.Host,
-                                  fingerprint.Resource,
-                                  fingerprint.Id));
+                    pipelinePermissionUri);
 
             defaultRequest.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             defaultRequest.Headers.Authorization = new AuthenticationHeaderValue("Basic",
                 Convert.ToBase64String(
                     ASCIIEncoding.ASCII.GetBytes(
-                        string.Format("{0}:{1}", string.Empty, adoPat))));
+                        string.Format("{0}:{1}", string.Empty, secret))));
 
             string allPipelinesHaveAccessResponseJson = JsonConvert.SerializeObject(
                     new PipelinePermission
@@ -172,7 +168,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.AzureDevOpsConfigu
 
                 using var httpClient = new HttpClient(mockHandler);
                 pipelineAccessValidator.SetHttpClient(httpClient);
-                SetAdoPat(adoPat);
+                SetAdoPat(secret);
                 ValidationState currentState = pipelineAccessValidator.IsValidDynamic(ref fingerprint,
                                                                                       ref message,
                                                                                       keyValuePairs,

--- a/Src/Plugins/Tests.AzureDevOpsConfiguration/Validators/AZC102_190.DoNotShareWithAllPipelines.cs
+++ b/Src/Plugins/Tests.AzureDevOpsConfiguration/Validators/AZC102_190.DoNotShareWithAllPipelines.cs
@@ -17,6 +17,7 @@ using Newtonsoft.Json;
 
 using Xunit;
 
+using static System.Net.WebRequestMethods;
 using static Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.AzureDevOpsConfiguration.DoNotGrantAllPipelinesAccessValidator;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.AzureDevOpsConfiguration.Validators
@@ -29,6 +30,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.AzureDevOpsConfigu
         [Fact]
         public void DoNotGrantAllPipelinesAccessValidator_MockHttpTests()
         {
+            string host = "testorg.visualstudio.com";
+            string resource = "TestProject";
+            string id = "A1B326D6-0D73-4C01-A64B-FB43FE5E2A13";
             var fingerprint = new Fingerprint
             {
                 Host = "testorg.visualstudio.com",
@@ -36,13 +40,16 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.AzureDevOpsConfigu
                 Id = "A1B326D6-0D73-4C01-A64B-FB43FE5E2A13",
             };
             string adoPat = "testpat";
+            string asset = $"https://{host}/{resource}/_apis/pipelines/pipelinePermissions/endpoint/{id}";
+
+            string pipelinePermissionAPI = "https://{0}/{1}/_apis/pipelines/pipelinePermissions/endpoint/{2}?api-version=6.1-preview.1";
 
             var defaultRequest = new HttpRequestMessage(
-                HttpMethod.Get,
-                string.Format(PipelinePermissionAPI,
-                              fingerprint.Host,
-                              fingerprint.Resource,
-                              fingerprint.Id));
+                    HttpMethod.Get,
+                    string.Format(pipelinePermissionAPI,
+                                  fingerprint.Host,
+                                  fingerprint.Resource,
+                                  fingerprint.Id));
 
             defaultRequest.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             defaultRequest.Headers.Authorization = new AuthenticationHeaderValue("Basic",
@@ -143,7 +150,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.AzureDevOpsConfigu
                     Title = "Null Reference Exception",
                     HttpRequestMessages = new List<HttpRequestMessage> { null },
                     HttpResponseMessages = new List<HttpResponseMessage> { null },
-                    ExpectedValidationState = ValidatorBase.ReturnUnhandledException(ref unhandledMessage, new NullReferenceException()),
+                    ExpectedValidationState = ValidatorBase.ReturnUnhandledException(ref unhandledMessage, new NullReferenceException(), asset),
                     ExpectedMessage = unhandledMessage
                 }
             };

--- a/Src/Plugins/Tests.AzureDevOpsConfiguration/Validators/AZC102_190.DoNotShareWithAllPipelines.cs
+++ b/Src/Plugins/Tests.AzureDevOpsConfiguration/Validators/AZC102_190.DoNotShareWithAllPipelines.cs
@@ -34,14 +34,13 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.AzureDevOpsConfigu
             string id = "A1B326D6-0D73-4C01-A64B-FB43FE5E2A13";
             var fingerprint = new Fingerprint
             {
-                Host = "testorg.visualstudio.com",
-                Resource = "TestProject",
-                Id = "A1B326D6-0D73-4C01-A64B-FB43FE5E2A13",
+                Host = host,
+                Resource = resource,
+                Id = id,
             };
             string secret = "testpat";
             string asset = $"https://{host}/{resource}/_apis/pipelines/pipelinePermissions/endpoint/{id}";
-
-            string pipelinePermissionUri = $"{asset}/{secret}?api-version=6.1-preview.1";
+            string pipelinePermissionUri = $"{asset}?api-version=6.1-preview.1";
 
             var defaultRequest = new HttpRequestMessage(
                     HttpMethod.Get,

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/NpmAuthorTokenTestCases.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/NpmAuthorTokenTestCases.cs
@@ -23,6 +23,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
             const string fingerprintText = "[secret=abc123]";
             fingerprint = new Fingerprint(fingerprintText);
             string secret = fingerprint.Secret;
+            string asset = secret.Truncate();
 
             var defaultRequest = new HttpRequestMessage(HttpMethod.Get, NpmLegacyAuthorTokenHelper.Uri);
             defaultRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", secret);
@@ -171,7 +172,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     Title = "Null Reference Exception",
                     HttpRequestMessages = new List<HttpRequestMessage> { null },
                     HttpResponseMessages = new List<HttpResponseMessage> { null },
-                    ExpectedValidationState = ValidatorBase.ReturnUnhandledException(ref unhandledMessage, new NullReferenceException()),
+                    ExpectedValidationState = ValidatorBase.ReturnUnhandledException(ref unhandledMessage, new NullReferenceException(), asset),
                     ExpectedMessage = unhandledMessage
                 }
             };

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_015.AkamaiCredentialsValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_015.AkamaiCredentialsValidatorTests.cs
@@ -32,6 +32,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
             string id = fingerprint.Id;
             string host = fingerprint.Host;
             string secret = fingerprint.Secret;
+            string asset = secret.Truncate();
             string resource = fingerprint.Resource;
             var options = new Dictionary<string, string>();
             options.Add("datetime", DateTime.UtcNow.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture));
@@ -52,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     Title = "Raise NullReferenceException",
                     HttpRequestMessages = new List<HttpRequestMessage>{ null },
                     HttpResponseMessages = new List<HttpResponseMessage>{ null },
-                    ExpectedValidationState = ValidatorBase.ReturnUnhandledException(ref nullRefResponseMessage, new NullReferenceException()),
+                    ExpectedValidationState = ValidatorBase.ReturnUnhandledException(ref nullRefResponseMessage, new NullReferenceException(), asset),
                     ExpectedMessage = nullRefResponseMessage,
                 },
                 new HttpMockTestCase

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_016.StripeApiKeyValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_016.StripeApiKeyValidatorTests.cs
@@ -43,6 +43,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
             var sb = new StringBuilder();
             var fingerprint = new Fingerprint(fingerprintText);
             string secret = fingerprint.Secret;
+            string asset = secret.Truncate();
 
             sb.AppendLine($"Running tests for: {fingerprintText}");
             expectedLength += sb.Length;
@@ -87,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     Title = "Generates Null Reference Exception",
                     HttpRequestMessages = new List<HttpRequestMessage> { null },
                     HttpResponseMessages = new List<HttpResponseMessage> { null },
-                    ExpectedValidationState = ValidatorBase.ReturnUnhandledException(ref unhandledErrorResponseMessage, new NullReferenceException()),
+                    ExpectedValidationState = ValidatorBase.ReturnUnhandledException(ref unhandledErrorResponseMessage, new NullReferenceException(), asset),
                     ExpectedMessage = unhandledErrorResponseMessage
                 },
             };

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_021.DropboxAppCredentialsValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_021.DropboxAppCredentialsValidatorTests.cs
@@ -29,6 +29,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
 
             string id = fingerprint.Id;
             string secret = fingerprint.Secret;
+            string asset = secret.Truncate();
 
             using HttpRequestMessage defaultRequest = DropboxAppCredentialsValidator.GenerateRequestMessage(id, secret);
 
@@ -57,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     Title = "Nullref Exception",
                     HttpRequestMessages = new List<HttpRequestMessage> { null },
                     HttpResponseMessages = new List<HttpResponseMessage> { null },
-                    ExpectedValidationState = ValidatorBase.ReturnUnhandledException(ref nullRefResponseMessage, new NullReferenceException()),
+                    ExpectedValidationState = ValidatorBase.ReturnUnhandledException(ref nullRefResponseMessage, new NullReferenceException(), asset),
                     ExpectedMessage = nullRefResponseMessage
                 },
                 new HttpMockTestCase

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_025.SendGridApiKeyValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_025.SendGridApiKeyValidatorTests.cs
@@ -28,6 +28,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
         public void SendGridApiKeyValidator_MockHttpTests()
         {
             const string secret = "secret";
+            string asset = secret.Truncate();
             string fingerprintText = $"[secret={secret}]";
             string unknownMessage = null, unhandledMessage = null;
 
@@ -72,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     Title = "Unhandled Exception",
                     HttpRequestMessages = new HttpRequestMessage[] { null },
                     HttpResponseMessages = new HttpResponseMessage[] { null },
-                    ExpectedValidationState = ValidatorBase.ReturnUnhandledException(ref unhandledMessage, new NullReferenceException()),
+                    ExpectedValidationState = ValidatorBase.ReturnUnhandledException(ref unhandledMessage, new NullReferenceException(), asset),
                     ExpectedMessage = unhandledMessage,
                 },
                 new HttpMockTestCase

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_027.MailChimpApiKeyValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_027.MailChimpApiKeyValidatorTests.cs
@@ -30,8 +30,10 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
             const string key1 = "key1";
             const string key2 = "key2";
             const string accountName = "account";
-            string secret = $"[secret={key1}-{key2}]";
-
+            string secret = $"{key1}-{key2}";
+            string secretFingerprint = $"[secret={secret}]";
+            string asset = secret.Truncate();
+            
             string authorizedMessage = null, unknownMessage = null, exceptionMessage = null;
 
             var request = new HttpRequestMessage(HttpMethod.Get, string.Format(MailChimpApiKeyValidator.ApiUri, key2));
@@ -78,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     Title = "HttpClient throwing NullReferenceException",
                     HttpRequestMessages = new List<HttpRequestMessage>{ null },
                     HttpResponseMessages = new List<HttpResponseMessage>{ null },
-                    ExpectedValidationState = ValidatorBase.ReturnUnhandledException(ref exceptionMessage, new NullReferenceException()),
+                    ExpectedValidationState = ValidatorBase.ReturnUnhandledException(ref exceptionMessage, new NullReferenceException(), asset),
                     ExpectedMessage = exceptionMessage,
                 },
             };
@@ -96,7 +98,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
 
                 string message = string.Empty;
                 ResultLevelKind resultLevelKind = default;
-                var fingerprint = new Fingerprint(secret);
+                var fingerprint = new Fingerprint(secretFingerprint);
                 var keyValuePairs = new Dictionary<string, string>();
 
                 using var httpClient = new HttpClient(mockHandler);

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_027.MailChimpApiKeyValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_027.MailChimpApiKeyValidatorTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
             string secret = $"{key1}-{key2}";
             string secretFingerprint = $"[secret={secret}]";
             string asset = secret.Truncate();
-            
+
             string authorizedMessage = null, unknownMessage = null, exceptionMessage = null;
 
             var request = new HttpRequestMessage(HttpMethod.Get, string.Format(MailChimpApiKeyValidator.ApiUri, key2));

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_029.AlibabaCloudCredentialsValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_029.AlibabaCloudCredentialsValidatorTests.cs
@@ -28,6 +28,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
 
             var fingerprint = new Fingerprint("[id=LTAIid1][secret=abc]");
             var expectedFingerprint = new Fingerprint("[id=LTAIid1][secret=abc]");
+            string asset = expectedFingerprint.Secret.Truncate();
             string uri = string.Format(AlibabaCloudCredentialsValidator.UriTemplate);
 
             DateTime timestamp = DateTime.UtcNow;
@@ -37,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
             signer.SignRequest(defaultRequest, fingerprint.Id, fingerprint.Secret);
 
             ValidatorBase.ReturnUnexpectedResponseCode(ref unknownStatusCodeMessage, HttpStatusCode.InternalServerError);
-            ValidatorBase.ReturnUnhandledException(ref unhandledExceptionMessage, new NullReferenceException());
+            ValidatorBase.ReturnUnhandledException(ref unhandledExceptionMessage, new NullReferenceException(), asset);
 
             var okResponse = new HttpResponseMessage(HttpStatusCode.OK)
             {

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_045.PostmanApiKeyValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_045.PostmanApiKeyValidatorTests.cs
@@ -28,6 +28,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
         {
             var fingerprint = new Fingerprint(fingerprintText);
             string secret = fingerprint.Secret;
+            string asset = secret.Truncate();
             HttpRequestMessage request = PostmanApiKeyValidator.GenerateRequestMessage(secret);
 
             string unexpectedResponseMessage = string.Empty;
@@ -40,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     Title = "Raise NullReferenceException",
                     HttpRequestMessages = new List<HttpRequestMessage>{ null },
                     HttpResponseMessages = new List<HttpResponseMessage>{ null },
-                    ExpectedValidationState = ValidatorBase.ReturnUnhandledException(ref nullRefResponseMessage, new NullReferenceException()),
+                    ExpectedValidationState = ValidatorBase.ReturnUnhandledException(ref nullRefResponseMessage, new NullReferenceException(), asset),
                     ExpectedMessage = nullRefResponseMessage,
                 },
                 new HttpMockTestCase

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_048.SlackWorkflowKeyValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_048.SlackWorkflowKeyValidatorTests.cs
@@ -30,7 +30,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
             string unexpectedResponseCodeMessage = null, nullRefResponseMessage = null;
             string id = fingerprint.Id;
             string secret = fingerprint.Secret;
-            string uri = string.Format(SlackWorkflowKeyValidator.WorkflowUri, id, secret);
+            string asset = $"https://hooks.slack.com/workflows/{id}";
+            string uri = $"{asset}/{secret}";
 
             var request = new HttpRequestMessage(HttpMethod.Post, uri);
 
@@ -41,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     Title = "Raise NullReferenceException",
                     HttpRequestMessages = new List<HttpRequestMessage>{ null },
                     HttpResponseMessages = new List<HttpResponseMessage>{ null },
-                    ExpectedValidationState = ValidatorBase.ReturnUnhandledException(ref nullRefResponseMessage, new NullReferenceException()),
+                    ExpectedValidationState = ValidatorBase.ReturnUnhandledException(ref nullRefResponseMessage, new NullReferenceException(), asset),
                     ExpectedMessage = nullRefResponseMessage,
                 },
                 new HttpMockTestCase

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_049.TelegramBotTokenValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_049.TelegramBotTokenValidatorTests.cs
@@ -28,6 +28,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
         {
             const string fingerprintText = "[secret=secret]";
             var fingerprint = new Fingerprint(fingerprintText);
+            string asset = fingerprint.Secret.Truncate();
 
             string unexpectedResponseCodeMessage = null, nullRefResponseMessage = null;
             string secret = fingerprint.Secret;
@@ -54,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
                     Title = "Raise NullReferenceException",
                     HttpRequestMessages = new List<HttpRequestMessage>{ null },
                     HttpResponseMessages = new List<HttpResponseMessage>{ null },
-                    ExpectedValidationState = ValidatorBase.ReturnUnhandledException(ref nullRefResponseMessage, new NullReferenceException()),
+                    ExpectedValidationState = ValidatorBase.ReturnUnhandledException(ref nullRefResponseMessage, new NullReferenceException(), asset),
                     ExpectedMessage = nullRefResponseMessage,
                 },
                 new HttpMockTestCase

--- a/Src/Sarif.PatternMatcher.Sdk/ValidatorBase.cs
+++ b/Src/Sarif.PatternMatcher.Sdk/ValidatorBase.cs
@@ -141,7 +141,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk
 
         public static ValidationState ReturnUnhandledException(ref string message,
                                                                Exception e,
-                                                               string asset = null,
+                                                               string asset,
                                                                string account = null)
         {
             if (TestExceptionForMessage(e, s_noSuchHostIsKnown, ref asset))


### PR DESCRIPTION
- BRK: `ValidatorBase.ReturnUnhandledException` not requires an `asset` parameter. [#736](https://github.com/microsoft/sarif-pattern-matcher/pull/736)
- BUG: Consistently report asset data (which may be the truncated secret) when reporting unhandled exceptions in dynamic validators. [#736](https://github.com/microsoft/sarif-pattern-matcher/pull/736)

@LingZhou-gh previously discovered an issue with our unhandled exception reporting, which would report an empty asset name when users failed to provide that argument to  `ValidatorBase.ReturnUnhandledException`
~~~
An unexpected exception was caught attempting to validate '': System.NullReferenceException: Object reference not set to an instance of an object.
~~~

The obvious immediate fix is to simply require this parameter, which will prompt us to review all rules to confirm whether we are passing an available asset id. Ideally, this data points to the compromised thing. Only as a fallback should we provide the truncated secret as an asset. We do this to provide some uniqueness to the reporting output, so that users know what credential provoked the unhandled exception.

There is an open item here, we need to find a find to convert certificate data that we process into some identifier. The easiest solution here would be to base64 encoded it and take the first 6 characters or so.