### PR TITLE
Disable rule in memory test

### DIFF
--- a/Src/Test.UnitTests.Sarif.PatternMatcher/AnalyzeCommandTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/AnalyzeCommandTests.cs
@@ -878,7 +878,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             sarifLog = JsonConvert.DeserializeObject<SarifLog>(sb.ToString());
             results = sarifLog.Runs?[0].Results;
 
-            results?.Count().Should().Be(fooCount); 
+            results?.Count().Should().Be(fooCount);
             results.Where(r => r.Rule.Id == FooRuleId).Count().Should().Be(fooCount);
             results.Where(r => r.Level == FailureLevel.Error).Count().Should().Be(fooCount);
         }


### PR DESCRIPTION
This change provides an explicit test to show how to disable a specific rule in an API-driven context.

It also creates a helper for creating a couple of test rules. We could/should clean up other tests to more closely conform to the pattern shown in the new test.

@cfaucon @suvamM @HulonJenkins 