### PR TITLE
Set redact secrets via workaround until we get a driver framework fix.

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -18,8 +18,9 @@
 - UER => Eliminate unhandled exceptions in rule.
 - UEE => Eliminate unhandled exceptions in engine.
 
-## v4.3.8 UNRELEASED
+## v4.3.8 Released 04/06/2023
 - BRK: `ValidationResult` constructor now sets `ValidationState` to `Unknown`. [#733](https://github.com/microsoft/sarif-pattern-matcher/pull/733)
+- BUG: We do not flow `--redact-secrets` argument properly to analysis. [#746](https://github.com/microsoft/sarif-pattern-matcher/pull/746)
 
 ## v4.3.7 Released 03/22/2023
 - DEP: Update SARIF SDK submodule from [53b0246 to 1ff3956](https://github.com/microsoft/sarif-sdk/compare/53b0246..1ff3956). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/1ff3956/src/ReleaseHistory.md). Adds version control provenance.

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -21,6 +21,7 @@
 ## v4.3.8 Released 04/06/2023
 - BRK: `ValidationResult` constructor now sets `ValidationState` to `Unknown`. [#733](https://github.com/microsoft/sarif-pattern-matcher/pull/733)
 - BUG: We do not flow `--redact-secrets` argument properly to analysis. [#746](https://github.com/microsoft/sarif-pattern-matcher/pull/746)
+- NEW: All `AnalyzeOptions` properties now settable. [#746](https://github.com/microsoft/sarif-pattern-matcher/pull/746)
 
 ## v4.3.7 Released 03/22/2023
 - DEP: Update SARIF SDK submodule from [53b0246 to 1ff3956](https://github.com/microsoft/sarif-sdk/compare/53b0246..1ff3956). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/1ff3956/src/ReleaseHistory.md). Adds version control provenance.

--- a/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
@@ -7,6 +7,7 @@ using System.Composition;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis.Sarif.Driver;
@@ -355,7 +356,16 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             }
 
             context.PluginFilePaths = options.PluginFilePaths.Any() ? new StringSet(options.PluginFilePaths) : context.PluginFilePaths;
+            this.redactSecrets = context.RedactSecrets;
+            return context;
+        }
 
+        private bool redactSecrets;
+
+        protected override AnalyzeContext CreateContext(AnalyzeOptions options, IAnalysisLogger logger, RuntimeConditions runtimeErrors, IFileSystem fileSystem = null, PropertiesDictionary policy = null)
+        {
+            AnalyzeContext context = base.CreateContext(options, logger, runtimeErrors, fileSystem, policy);
+            context.RedactSecrets = this.redactSecrets;
             return context;
         }
 

--- a/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
@@ -3,15 +3,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Composition;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Security.Cryptography.X509Certificates;
-using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis.Sarif.Driver;
-using Microsoft.CodeAnalysis.Sarif.Visitors;
 using Microsoft.CodeAnalysis.Sarif.Writers;
 using Microsoft.RE2.Managed;
 

--- a/Src/Sarif.PatternMatcher/AnalyzeOptions.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeOptions.cs
@@ -20,22 +20,22 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             "dynamic-validation",
             HelpText = "Enable dynamic validations, if any (may compromise " +
                        "performance and/or result in calls across the network).")]
-        public bool? DynamicValidation { get; internal set; }
+        public bool? DynamicValidation { get; set; }
 
         [Option(
             "deny-regex",
             HelpText = "A regular expression used to suppress scanning for any file or directory path that matches the regex.")]
-        public string FileNameDenyRegex { get; internal set; }
+        public string FileNameDenyRegex { get; set; }
 
         [Option(
             "disable-dynamic-validation-caching",
             HelpText = "Disable caching from dynamic validation.")]
-        public bool? DisableDynamicValidationCaching { get; internal set; }
+        public bool? DisableDynamicValidationCaching { get; set; }
 
         [Option(
             "enhanced-reporting",
             HelpText = "Enable enhanced reporting provided by dynamic validators (when --dynamic-validation is also enabled).")]
-        public bool? EnhancedReporting { get; internal set; }
+        public bool? EnhancedReporting { get; set; }
 
         [Option(
             "retry",
@@ -46,11 +46,11 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             "max-memory-in-kb",
             HelpText = "The maximum memory (in kilobytes) that can be used for RE2.",
             Default = -1)]
-        public long MaxMemoryInKilobytes { get; internal set; }
+        public long MaxMemoryInKilobytes { get; set; }
 
         [Option(
             "redact-secrets",
             HelpText = "Redact sensitive credential components from log files.")]
-        public bool? RedactSecrets { get; internal set; }
+        public bool? RedactSecrets { get; set; }
     }
 }

--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Net.Mime;
 using System.Resources;
 using System.Text;
 using System.Text.RegularExpressions;

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/AnalyzeCommandTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/AnalyzeCommandTests.cs
@@ -872,7 +872,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
             var logger = new SarifLogger(writer,
                                          FilePersistenceOptions.None,
-                                         OptionallyEmittedData.None,
+                                         OptionallyEmittedData.All,
                                          run: run,
                                          closeWriterOnDispose: true);
 
@@ -886,6 +886,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             {
                 Logger = logger,
                 RedactSecrets = true,
+                DataToInsert = OptionallyEmittedData.All,
                 CurrentTarget = target,
                 Skimmers = skimmers,
                 TargetsProvider = new ArtifactProvider(new[] { target }),


### PR DESCRIPTION
- BUG: We do not flow `--redact-secrets` argument properly to analysis. [#746](https://github.com/microsoft/sarif-pattern-matcher/pull/746)
- NEW: All `AnalyzeOptions` properties now settable. [#746](https://github.com/microsoft/sarif-pattern-matcher/pull/746)
