### PR TITLE
Remove test dependency

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -18,6 +18,9 @@
 - UER => Eliminate unhandled exceptions in rule.
 - UEE => Eliminate unhandled exceptions in engine.
 
+## v4.3.9 UNRELEASED
+- BUG: Remove unnecessary `Test.Utilities.Sarif` reference from `Sarif.PatternMatcher` project. This test binary isn't built into our tool NuGet package and the erroneous reference causes missing file messages in some contexts.
+
 ## v4.3.8 Released 04/06/2023
 - BRK: `ValidationResult` constructor now sets `ValidationState` to `Unknown`. [#733](https://github.com/microsoft/sarif-pattern-matcher/pull/733)
 - BRK: `ValidatorBase.ReturnUnhandledException` now requires an `asset` parameter. [#736](https://github.com/microsoft/sarif-pattern-matcher/pull/736)

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -19,7 +19,7 @@
 - UEE => Eliminate unhandled exceptions in engine.
 
 ## v4.3.9 UNRELEASED
-- BUG: Remove unnecessary `Test.Utilities.Sarif` reference from `Sarif.PatternMatcher` project. This test binary isn't built into our tool NuGet package and the erroneous reference causes missing file messages in some contexts.
+- BUG: Remove unnecessary `Test.Utilities.Sarif` reference from `Sarif.PatternMatcher` project. This test binary isn't built into our tool NuGet package and the erroneous reference causes missing file messages in some contexts. [#749](https://github.com/microsoft/sarif-pattern-matcher/pull/749)
 
 ## v4.3.8 Released 04/06/2023
 - BRK: `ValidationResult` constructor now sets `ValidationState` to `Unknown`. [#733](https://github.com/microsoft/sarif-pattern-matcher/pull/733)

--- a/Src/Sarif.PatternMatcher/Sarif.PatternMatcher.csproj
+++ b/Src/Sarif.PatternMatcher/Sarif.PatternMatcher.csproj
@@ -17,7 +17,6 @@
     <ProjectReference Include="..\RE2.Managed\RE2.Managed.csproj" />
     <ProjectReference Include="..\sarif-sdk\src\Sarif.Driver\Sarif.Driver.csproj" />
     <ProjectReference Include="..\sarif-sdk\src\Sarif\Sarif.csproj" />
-    <ProjectReference Include="..\sarif-sdk\src\Test.Utilities.Sarif\Test.Utilities.Sarif.csproj" />
     <ProjectReference Include="..\Sarif.PatternMatcher.Sdk\Sarif.PatternMatcher.Sdk.csproj" />
     <ProjectReference Include="..\Strings.Interop\Strings.Interop.csproj" />
   </ItemGroup>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "4.3.8",
+  "version": "4.3.9",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+\\.\\d+\\.\\d+$"


### PR DESCRIPTION
- BUG: Remove unnecessary `Test.Utilities.Sarif` reference from `Sarif.PatternMatcher` project. This test binary isn't built into our tool NuGet package and the erroneous reference causes missing file messages in some contexts.

@Jeremiah-Johnson @suvamM 