### PR TITLE
Expand the Crc32 class by adding support for Castagnoli's polynomial

### DIFF
--- a/Src/Sarif.PatternMatcher.Sdk/Crc32.cs
+++ b/Src/Sarif.PatternMatcher.Sdk/Crc32.cs
@@ -13,9 +13,17 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk
         // This is the 'reversed representation' polynomial for
         // little-endian implementations, i.e., the bitwise
         // reflection of 0x04C11DB7;
-        private const uint Crc32Polynomial = 0xedb88320u;
+        // CRC-32-IEEE 802.3 polynomial
+        private const uint Crc32IEEEPolynomial = 0xedb88320u;
 
-        private static readonly uint[] Crc32Table = CreateCrcTable(Crc32Polynomial);
+        // Castagnoli's polynomial, used in iSCSI.
+        // Has better error detection characteristics than IEEE.
+        // https://dx.doi.org/10.1109/26.231911
+        private const uint Crc32CastagnoliPolynomial = 0x82f63b78;
+
+        public static readonly uint[] Crc32IEEETable = CreateCrcTable(Crc32IEEEPolynomial);
+
+        public static readonly uint[] Crc32CastagnoliTable = CreateCrcTable(Crc32CastagnoliPolynomial);
 
         public static uint Calculate(string text)
         {
@@ -30,29 +38,45 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk
 
         public static uint Calculate(uint checksum, byte[] buffer, int offset, int length)
         {
+            return Calculate(checksum, buffer, offset, length, Crc32IEEETable);
+        }
+
+        public static uint Calculate(string text, uint[] crc32Table)
+        {
+            byte[] data = Encoding.ASCII.GetBytes(text);
+            return Calculate(data, crc32Table);
+        }
+
+        public static uint Calculate(byte[] buffer, uint[] crc32Table)
+        {
+            return Calculate(0, buffer, 0, buffer.Length, crc32Table);
+        }
+
+        public static uint Calculate(uint checksum, byte[] buffer, int offset, int length, uint[] crc32Table)
+        {
             checksum ^= 0xffffffffU;
 
             while (length >= 16)
             {
-                uint a = Crc32Table[(3 * 256) + buffer[offset + 12]] ^
-                         Crc32Table[(2 * 256) + buffer[offset + 13]] ^
-                         Crc32Table[(1 * 256) + buffer[offset + 14]] ^
-                         Crc32Table[(0 * 256) + buffer[offset + 15]];
+                uint a = crc32Table[(3 * 256) + buffer[offset + 12]] ^
+                         crc32Table[(2 * 256) + buffer[offset + 13]] ^
+                         crc32Table[(1 * 256) + buffer[offset + 14]] ^
+                         crc32Table[(0 * 256) + buffer[offset + 15]];
 
-                uint b = Crc32Table[(7 * 256) + buffer[offset + 8]] ^
-                         Crc32Table[(6 * 256) + buffer[offset + 9]] ^
-                         Crc32Table[(5 * 256) + buffer[offset + 10]] ^
-                         Crc32Table[(4 * 256) + buffer[offset + 11]];
+                uint b = crc32Table[(7 * 256) + buffer[offset + 8]] ^
+                         crc32Table[(6 * 256) + buffer[offset + 9]] ^
+                         crc32Table[(5 * 256) + buffer[offset + 10]] ^
+                         crc32Table[(4 * 256) + buffer[offset + 11]];
 
-                uint c = Crc32Table[(11 * 256) + buffer[offset + 4]] ^
-                         Crc32Table[(10 * 256) + buffer[offset + 5]] ^
-                         Crc32Table[(9 * 256) + buffer[offset + 6]] ^
-                         Crc32Table[(8 * 256) + buffer[offset + 7]];
+                uint c = crc32Table[(11 * 256) + buffer[offset + 4]] ^
+                         crc32Table[(10 * 256) + buffer[offset + 5]] ^
+                         crc32Table[(9 * 256) + buffer[offset + 6]] ^
+                         crc32Table[(8 * 256) + buffer[offset + 7]];
 
-                uint d = Crc32Table[(15 * 256) + ((byte)checksum ^ buffer[offset])] ^
-                         Crc32Table[(14 * 256) + ((byte)(checksum >> 8) ^ buffer[offset + 1])] ^
-                         Crc32Table[(13 * 256) + ((byte)(checksum >> 16) ^ buffer[offset + 2])] ^
-                         Crc32Table[(12 * 256) + ((checksum >> 24) ^ buffer[offset + 3])];
+                uint d = crc32Table[(15 * 256) + ((byte)checksum ^ buffer[offset])] ^
+                         crc32Table[(14 * 256) + ((byte)(checksum >> 8) ^ buffer[offset + 1])] ^
+                         crc32Table[(13 * 256) + ((byte)(checksum >> 16) ^ buffer[offset + 2])] ^
+                         crc32Table[(12 * 256) + ((checksum >> 24) ^ buffer[offset + 3])];
 
                 checksum = d ^ c ^ b ^ a;
                 offset += 16;
@@ -61,7 +85,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk
 
             while (--length >= 0)
             {
-                checksum = Crc32Table[(checksum ^ buffer[offset++]) & 0xFF] ^ (checksum >> 8);
+                checksum = crc32Table[(checksum ^ buffer[offset++]) & 0xFF] ^ (checksum >> 8);
             }
 
             checksum ^= 0xffffffffU;

--- a/Src/Sarif.PatternMatcher.Sdk/Crc32.cs
+++ b/Src/Sarif.PatternMatcher.Sdk/Crc32.cs
@@ -25,35 +25,24 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk
 
         public static readonly uint[] Crc32CastagnoliTable = CreateCrcTable(Crc32CastagnoliPolynomial);
 
-        public static uint Calculate(string text)
-        {
-            byte[] data = Encoding.ASCII.GetBytes(text);
-            return Calculate(data);
-        }
-
-        public static uint Calculate(byte[] buffer)
-        {
-            return Calculate(0, buffer, 0, buffer.Length);
-        }
-
-        public static uint Calculate(uint checksum, byte[] buffer, int offset, int length)
-        {
-            return Calculate(checksum, buffer, offset, length, Crc32IEEETable);
-        }
-
-        public static uint Calculate(string text, uint[] crc32Table)
+        public static uint Calculate(string text, uint[] crc32Table = null)
         {
             byte[] data = Encoding.ASCII.GetBytes(text);
             return Calculate(data, crc32Table);
         }
 
-        public static uint Calculate(byte[] buffer, uint[] crc32Table)
+        public static uint Calculate(byte[] buffer, uint[] crc32Table = null)
         {
             return Calculate(0, buffer, 0, buffer.Length, crc32Table);
         }
 
-        public static uint Calculate(uint checksum, byte[] buffer, int offset, int length, uint[] crc32Table)
+        public static uint Calculate(uint checksum, byte[] buffer, int offset, int length, uint[] crc32Table = null)
         {
+            if (crc32Table == null)
+            {
+                crc32Table = Crc32IEEETable;
+            }
+
             checksum ^= 0xffffffffU;
 
             while (length >= 16)
@@ -95,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk
 
         private static uint[] CreateCrcTable(uint polynomial)
         {
-            var table = new uint[16 * 256];
+            uint[] table = new uint[16 * 256];
 
             for (uint i = 0; i < 256; i++)
             {

--- a/Src/Test.UnitTests.Sarif.PatternMatcher.Sdk/Crc32Tests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher.Sdk/Crc32Tests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Text;
 
 using FluentAssertions;
@@ -14,32 +15,36 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk
         [Fact]
         public void Crc32_GeneratesValidChecksumForSimpleTestValue()
         {
-            uint wellKnownChecksumForTestValue = 0xd87f7e0c;
-
             byte[] input = Encoding.ASCII.GetBytes("test");
 
-            Calculate(input, wellKnownChecksumForTestValue);
+            uint wellKnownIEEEChecksumForTestValue = 0xd87f7e0c;
+            Calculate(input, wellKnownIEEEChecksumForTestValue);
+
+            uint wellKnownCastagnoliChecksumForTestValue = 0x86A072C0;
+            Calculate(input, wellKnownCastagnoliChecksumForTestValue, Crc32.Crc32CastagnoliTable);
         }
 
         [Fact]
         public void Crc32_GeneratesValidChecksumForLongerTestValue()
         {
-            uint wellKnownChecksumForTestValue = 0x89b46555;
-
             byte[] input = Encoding.ASCII.GetBytes(new string('a', 64));
 
-            Calculate(input, wellKnownChecksumForTestValue);
+            uint wellKnownIEEEChecksumForTestValue = 0x89b46555;
+            Calculate(input, wellKnownIEEEChecksumForTestValue);
+
+            uint wellKnownCastagnoliChecksumForTestValue = 0x37AEEE33;
+            Calculate(input, wellKnownCastagnoliChecksumForTestValue, Crc32.Crc32CastagnoliTable);
         }
 
+        // CRC32 algorithms have the interesting property of producing
+        // a constant value when the CRC for an input buffer
+        // is appended to the data and the checksum is recomputed
+        // (for the original data and the appended checksum).
+        // The constant is different for different Polynomial
         [Fact]
-        public void Crc32_ChecksumGeneratesExpectedConstantWhenProcessed()
+        public void Crc32IEEE_ChecksumGeneratesExpectedConstantWhenProcessed()
         {
-            // CRC32 algorithms have the interesting property of producing
-            // a constant value when the CRC for an input buffer
-            // is appended to the data and the checksum is recomputed
-            // (for the original data and the appended checksum).
-            //
-            // This contanst is 0x2144DF1C for CRC-32.
+            // The contanst is 0x2144DF1C for CRC-32 using IEEE Polynomial
             uint crc32Constant = 0x2144DF1C;
 
             byte[] input = new byte[8];
@@ -57,14 +62,67 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk
             input[4] = 0x0c;
 
             Calculate(input, crc32Constant);
+
+            byte[] inputLong = new byte[68];
+            for (int i = 0; i < 64; i++)
+            {
+                inputLong[i] = (byte)'a';
+            }
+
+            // The checksum for 64 bytes of 'a' is 0x89b46555, persisted
+            // to the buffer in little-endian order.
+            inputLong[67] = 0x89;
+            inputLong[66] = 0xb4;
+            inputLong[65] = 0x65;
+            inputLong[64] = 0x55;
+
+            Calculate(inputLong, crc32Constant);
         }
 
-        private static void Calculate(byte[] input, uint expectedChecksum)
+        [Fact]
+        public void Crc32Castagnoli_ChecksumGeneratesExpectedConstantWhenProcessed()
         {
-            uint actual = Crc32.Calculate(input);
+            // The contanst is 0x48674BC7 for CRC-32 using Castagnoli Polynomial
+            uint crc32Constant = 0x48674BC7;
+
+            byte[] input = new byte[8];
+
+            input[0] = (byte)'t';
+            input[1] = (byte)'e';
+            input[2] = (byte)'s';
+            input[3] = (byte)'t';
+
+            // The checksum for 'test' is 0x86A072C0, persisted
+            // to the buffer in little-endian order.
+            input[7] = 0x86;
+            input[6] = 0xA0;
+            input[5] = 0x72;
+            input[4] = 0xC0;
+
+            Calculate(input, crc32Constant, Crc32.Crc32CastagnoliTable);
+
+            byte[] inputLong = new byte[68];
+            for (int i = 0; i < 64; i++)
+            {
+                inputLong[i] = (byte)'a';
+            }
+
+            // The checksum for 64 bytes of 'a' is 0x37AEEE33, persisted
+            // to the buffer in little-endian order.
+            inputLong[67] = 0x37;
+            inputLong[66] = 0xAE;
+            inputLong[65] = 0xEE;
+            inputLong[64] = 0x33;
+
+            Calculate(inputLong, crc32Constant, Crc32.Crc32CastagnoliTable);
+        }
+
+        private static void Calculate(byte[] input, uint expectedChecksum, uint[] crc32Table = null)
+        {
+            uint actual = Crc32.Calculate(input, crc32Table);
             actual.Should().Be(expectedChecksum);
 
-            actual = Crc32.Calculate(0, input, 0, input.Length);
+            actual = Crc32.Calculate(0, input, 0, input.Length, crc32Table);
             actual.Should().Be(expectedChecksum);
         }
     }


### PR DESCRIPTION
## Changes
The static validator of Yandex Cloud Iam Access Secret needs to use Castagnoli's polynomial in Crc32 checksum computation.
This change expands the Crc32 class by adding support for Castagnoli's polynomial without affecting the existing public methods and their reference. 
The default crc32 polynomial will be IEEE polynomial.
