### PR TITLE
Sniff support

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -18,8 +18,9 @@
 - UER => Eliminate unhandled exceptions in rule.
 - UEE => Eliminate unhandled exceptions in engine.
 
-## v4.3.11 Unreleased
+## v4.4.1 5/9/2023
 - BRK: Disable `SEC101/047.CratesApiKey`. Current dynamic validator returns status code 200 to all tokens. No API endpoint seems to return different status codes to valid or invalid API Keys.
+- NEW: Provide new `AnalyzeContext.SniffRegex` property that applies a pre-filter contents regex to all scan targets, when configured.
 
 ## v4.3.10 04/19/2023
 - DEP: Update SARIF SDK submodule from [36b4792 to 51ae42](https://github.com/microsoft/sarif-sdk/compare/36b4792..51ae42). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/51ae42/ReleaseHistory.md).

--- a/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis.Sarif.Driver;
 using Microsoft.CodeAnalysis.Sarif.Writers;
 using Microsoft.RE2.Managed;
+using Microsoft.Strings.Interop;
 
 using Newtonsoft.Json;
 
@@ -389,6 +390,16 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
         protected override AnalyzeContext DetermineApplicabilityAndAnalyze(AnalyzeContext context, IEnumerable<Skimmer<AnalyzeContext>> skimmers, ISet<string> disabledSkimmers)
         {
+            if (!string.IsNullOrWhiteSpace(context.SniffRegex))
+            {
+                byte[] buffer = null;
+                var string8 = String8.Convert(context.CurrentTarget.Contents, ref buffer);
+                if (!Regex2.IsMatch(string8, context.SniffRegex))
+                {
+                    return context;
+                }
+            }
+
             context = base.DetermineApplicabilityAndAnalyze(context, skimmers, disabledSkimmers);
 
             ICollection<IList<Tuple<Result, int?>>> resultLists = ((CachingLogger)context.Logger).Results?.Values;

--- a/Src/Sarif.PatternMatcher/AnalyzeContext.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeContext.cs
@@ -31,6 +31,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
         public override bool AnalysisComplete { get; set; }
 
+        public string SniffRegex
+        {
+            get => this.Policy.GetProperty(SniffRegexProperty);
+            set => this.Policy.SetProperty(SniffRegexProperty, value);
+        }
+
         public bool DynamicValidation
         {
             get => this.Policy.GetProperty(DynamicValidationProperty);
@@ -98,6 +104,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             RollingHashMap?.Clear();
             RollingHashMap = null;
         }
+
+        public static PerLanguageOption<string> SniffRegexProperty =>
+            new PerLanguageOption<string>(
+                "CoreSettings", nameof(SniffRegex), defaultValue: () => string.Empty,
+                "An optional regex applied to all scan targets as a filter. Files that" +
+                "do not match the sniff regex will be skipped at analysis time. ");
 
         public static PerLanguageOption<bool> EnhancedReportingProperty =>
             new PerLanguageOption<bool>(

--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -952,11 +952,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                                                    ? Decode(binary64DecodedMatch.Value).String
                                                    : context.CurrentTarget.Contents;
 
-            long maxMemoryInKB =
-                context.MaxMemoryInKilobytes == -1
-                    ? context.MaxMemoryInKilobytes
-                    : 1024 * context.MaxMemoryInKilobytes;
-
             // INTERESTING BREAKPPOINT: debug static analysis match failures.
             // Set a conditional breakpoint on 'matchExpression.Name' to filter by specific rules.
             // Set a conditional breakpoint on 'searchText' to filter on specific target text patterns.


### PR DESCRIPTION
This changes provides a new `SniffRegex` pattern to the `AnalyzeContext` object. When populated, this regex is applied to the contents of each scan target and any files that do not match against the regex will be skipped at analysis time.

This is a clean but limited change for testing. Certainly we should author notes or trace messages for skipped files in the future if we retain this functionality.