### PR TITLE
Exposing MatchExpressions in SearchSkimmer

### DIFF
--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -27,6 +27,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
         public const string DynamicValidationNotEnabled = "No validation occurred as it was not enabled. Pass '--dynamic-validation' on the command-line to validate this match";
 
+        public readonly IList<MatchExpression> MatchExpressions;
+
         private const string DefaultHelpUri = "https://github.com/microsoft/sarif-pattern-matcher";
         private const string Base64DecodingFormatString = "\\b(?i)[0-9a-z\\/+]{0}";
 
@@ -39,7 +41,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
         private readonly IRegex _engine;
         private readonly ValidatorsCache _validators;
         private readonly IList<string> _deprecatedNames;
-        private readonly IList<MatchExpression> _matchExpressions;
         private readonly MultiformatMessageString _fullDescription;
         private readonly Dictionary<string, MultiformatMessageString> _messageStrings;
 
@@ -84,7 +85,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 };
             }
 
-            _matchExpressions = definition.MatchExpressions;
+            MatchExpressions = definition.MatchExpressions;
 
             if (definition.MatchExpressions?.Count > 0 &&
                 definition.MatchExpressions[0].MessageArguments != null &&
@@ -132,7 +133,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 return AnalysisApplicability.NotApplicableToSpecifiedTarget;
             }
 
-            foreach (MatchExpression matchExpression in _matchExpressions)
+            foreach (MatchExpression matchExpression in MatchExpressions)
             {
                 if (!string.IsNullOrEmpty(matchExpression.FileNameDenyRegex) && _engine.IsMatch(filePath, matchExpression.FileNameDenyRegex))
                 {
@@ -156,7 +157,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
         {
             string filePath = context.CurrentTarget.Uri.GetFilePath();
 
-            foreach (MatchExpression matchExpression in _matchExpressions)
+            foreach (MatchExpression matchExpression in MatchExpressions)
             {
                 if (!string.IsNullOrEmpty(matchExpression.FileNameAllowRegex))
                 {


### PR DESCRIPTION
## Changes

Various recent activities have the following pattern: we consume the JSON plug-in, and parse the regular expressions. The typical way to do this is to deserialize the JSON into a `SearchDefinitions` object, and then access the `MatchExpressions` list. However, this logic already exists in the `CreateSkimmersFromDefinitions` method, which creates a set of `Skimmer` objects. The problem: the match expressions were private.

This PR exposes the `MatchExpression` set as `public` in the `SearchSkimmer` class. 

### Sample usage:

```
ISet<Skimmer<AnalyzeContext>> skimmers = CreateSkimmersFromDefinitions(pluginsPath);
foreach (Skimmer<AnalyzeContext> skimmer in skimmers)
{
  var ss = (SearchSkimmer)skimmer;
  var regex = ss.MatchExpression.ContentsRegex;
}
```