### PR TITLE
Code cleanup - eliminate build warnings

### DIFF
--- a/Src/Plugins/AzureDevOpsConfiguration/AzureDevOpsConfiguration.csproj
+++ b/Src/Plugins/AzureDevOpsConfiguration/AzureDevOpsConfiguration.csproj
@@ -11,6 +11,12 @@
     <PackageId>Sarif.PatternMatcher.AzureDevOpsConfiguration</PackageId>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <MSBuildWarningsAsMessages>
+	    $(MSBuildWarningsAsMessages);MSB3277;MSB3030
+    </MSBuildWarningsAsMessages>
+  </PropertyGroup>
+	
   <ItemGroup>
     <None Remove="AdoPat.txt" />
     <None Remove="AZC102.ServiceConnectionSecurity.json" />

--- a/Src/Plugins/AzureDevOpsConfiguration/AzureDevOpsConfiguration.csproj
+++ b/Src/Plugins/AzureDevOpsConfiguration/AzureDevOpsConfiguration.csproj
@@ -13,8 +13,17 @@
 
   <PropertyGroup>
     <MSBuildWarningsAsMessages>
-        $(MSBuildWarningsAsMessages);MSB3277;MSB3030
-    </MSBuildWarningsAsMessages>
+		// MSB3277 - Found conflicts with different versions of the same
+		//  dependent assembly that could not be resolved. Specifically
+		//  for Newtonsoft where we need older versions for compatibility
+		// MSB3030 - This error occurs when a file that was supposed to be
+		//  copied isn't found at the expected location.
+		//  There are copy commands that have a continueOnError=true because
+		//  there is a time in the copy process where a copy fails before it
+		//  succeeds for those commands with the continueOnError. Those copy
+		//  commands have been set to continueOnError for almost two years.
+		$(MSBuildWarningsAsMessages);MSB3277;MSB3030
+	</MSBuildWarningsAsMessages>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/Plugins/AzureDevOpsConfiguration/AzureDevOpsConfiguration.csproj
+++ b/Src/Plugins/AzureDevOpsConfiguration/AzureDevOpsConfiguration.csproj
@@ -13,10 +13,10 @@
 
   <PropertyGroup>
     <MSBuildWarningsAsMessages>
-	    $(MSBuildWarningsAsMessages);MSB3277;MSB3030
+        $(MSBuildWarningsAsMessages);MSB3277;MSB3030
     </MSBuildWarningsAsMessages>
   </PropertyGroup>
-	
+
   <ItemGroup>
     <None Remove="AdoPat.txt" />
     <None Remove="AZC102.ServiceConnectionSecurity.json" />

--- a/Src/Plugins/SalModernization/SalModernization.csproj
+++ b/Src/Plugins/SalModernization/SalModernization.csproj
@@ -11,6 +11,12 @@
     <PackageId>Sarif.PatternMatcher.SalModernization</PackageId>
   </PropertyGroup>
 
+  <PropertyGroup>
+	<MSBuildWarningsAsMessages>
+	    $(MSBuildWarningsAsMessages);MSB3277;MSB3030
+	</MSBuildWarningsAsMessages>
+  </PropertyGroup>
+	
   <ItemGroup>
     <Content Include="build\Sarif.PatternMatcher.SalModernization.targets">
       <PackagePath>build\</PackagePath>

--- a/Src/Plugins/SalModernization/SalModernization.csproj
+++ b/Src/Plugins/SalModernization/SalModernization.csproj
@@ -13,8 +13,17 @@
 
   <PropertyGroup>
     <MSBuildWarningsAsMessages>
-        $(MSBuildWarningsAsMessages);MSB3277;MSB3030
-    </MSBuildWarningsAsMessages>
+		// MSB3277 - Found conflicts with different versions of the same
+		//  dependent assembly that could not be resolved. Specifically
+		//  for Newtonsoft where we need older versions for compatibility
+		// MSB3030 - This error occurs when a file that was supposed to be
+		//  copied isn't found at the expected location.
+		//  There are copy commands that have a continueOnError=true because
+		//  there is a time in the copy process where a copy fails before it
+		//  succeeds for those commands with the continueOnError. Those copy
+		//  commands have been set to continueOnError for almost two years.
+		$(MSBuildWarningsAsMessages);MSB3277;MSB3030
+	</MSBuildWarningsAsMessages>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/Plugins/SalModernization/SalModernization.csproj
+++ b/Src/Plugins/SalModernization/SalModernization.csproj
@@ -12,11 +12,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
-	<MSBuildWarningsAsMessages>
-	    $(MSBuildWarningsAsMessages);MSB3277;MSB3030
-	</MSBuildWarningsAsMessages>
+    <MSBuildWarningsAsMessages>
+        $(MSBuildWarningsAsMessages);MSB3277;MSB3030
+    </MSBuildWarningsAsMessages>
   </PropertyGroup>
-	
+
   <ItemGroup>
     <Content Include="build\Sarif.PatternMatcher.SalModernization.targets">
       <PackagePath>build\</PackagePath>

--- a/Src/Plugins/Security/Security.csproj
+++ b/Src/Plugins/Security/Security.csproj
@@ -11,7 +11,13 @@
     <PackageId>Sarif.PatternMatcher.Security</PackageId>
   </PropertyGroup>
 
-  <ItemGroup>
+  <PropertyGroup>
+	<MSBuildWarningsAsMessages>
+	    $(MSBuildWarningsAsMessages);MSB3030
+    </MSBuildWarningsAsMessages>
+  </PropertyGroup>
+
+	<ItemGroup>
     <Content Include="*.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/Src/Plugins/Security/Security.csproj
+++ b/Src/Plugins/Security/Security.csproj
@@ -12,12 +12,12 @@
   </PropertyGroup>
 
   <PropertyGroup>
-	<MSBuildWarningsAsMessages>
-	    $(MSBuildWarningsAsMessages);MSB3030
+    <MSBuildWarningsAsMessages>
+        $(MSBuildWarningsAsMessages);MSB3030
     </MSBuildWarningsAsMessages>
   </PropertyGroup>
 
-	<ItemGroup>
+  <ItemGroup>
     <Content Include="*.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/Src/Plugins/Security/Security.csproj
+++ b/Src/Plugins/Security/Security.csproj
@@ -13,8 +13,14 @@
 
   <PropertyGroup>
     <MSBuildWarningsAsMessages>
-        $(MSBuildWarningsAsMessages);MSB3030
-    </MSBuildWarningsAsMessages>
+		// MSB3030 - This error occurs when a file that was supposed to be
+		//  copied isn't found at the expected location.
+		//  There are copy commands that have a continueOnError=true because
+		//  there is a time in the copy process where a copy fails before it
+		//  succeeds for those commands with the continueOnError. Those copy
+		//  commands have been set to continueOnError for almost two years.
+		$(MSBuildWarningsAsMessages);MSB3030
+	</MSBuildWarningsAsMessages>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/Plugins/Security/Utilities/AlibabaEcsRequestSigner.cs
+++ b/Src/Plugins/Security/Utilities/AlibabaEcsRequestSigner.cs
@@ -39,6 +39,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
         /// Sign the HTTP request using Alibaba Cloud access key and secret so it
         /// can be used to access Alibaba Cloud service REST API.
         /// </summary>
+        /// <param name="request">httpRequest.</param>
+        /// <param name="accessKey">Alibbaba Cloud access key.</param>
+        /// <param name="secret">Alibaba Cloud secret.</param>
         public void SignRequest(HttpRequestMessage request, string accessKey, string secret)
         {
             const string format = "JSON";

--- a/Src/Plugins/Security/Utilities/AlibabaEcsRequestSigner.cs
+++ b/Src/Plugins/Security/Utilities/AlibabaEcsRequestSigner.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
         /// can be used to access Alibaba Cloud service REST API.
         /// </summary>
         /// <param name="request">Unsigned httpRequest passed in that will be signed for Alibaba Cloud service REST API.</param>
-        /// <param name="accessKey">Alibbaba Cloud access key.</param>
+        /// <param name="accessKey">Alibaba Cloud access key.</param>
         /// <param name="secret">Alibaba Cloud secret.</param>
         public void SignRequest(HttpRequestMessage request, string accessKey, string secret)
         {

--- a/Src/Plugins/Security/Utilities/AlibabaEcsRequestSigner.cs
+++ b/Src/Plugins/Security/Utilities/AlibabaEcsRequestSigner.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
         /// Sign the HTTP request using Alibaba Cloud access key and secret so it
         /// can be used to access Alibaba Cloud service REST API.
         /// </summary>
-        /// <param name="request">httpRequest.</param>
+        /// <param name="request">Unsigned httpRequest passed in that will be signed for Alibaba Cloud service REST API.</param>
         /// <param name="accessKey">Alibbaba Cloud access key.</param>
         /// <param name="secret">Alibaba Cloud secret.</param>
         public void SignRequest(HttpRequestMessage request, string accessKey, string secret)

--- a/Src/Sarif.PatternMatcher.Cli/Program.cs
+++ b/Src/Sarif.PatternMatcher.Cli/Program.cs
@@ -125,6 +125,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
                         {
                             rewritten.Add("True");
                         }
+
                         break;
                     }
 

--- a/Src/Sarif.PatternMatcher.Function/SpamAnalyzer.cs
+++ b/Src/Sarif.PatternMatcher.Function/SpamAnalyzer.cs
@@ -19,12 +19,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Function
         internal static readonly IFileSystem FileSystem;
         internal static ISet<Skimmer<AnalyzeContext>> Skimmers;
 
+        private static readonly Tool s_tool = Tool.CreateFromAssemblyData();
+
         static SpamAnalyzer()
         {
             FileSystem = Sarif.FileSystem.Instance;
         }
-
-        private static readonly Tool s_tool = Tool.CreateFromAssemblyData();
 
         public static SarifLog Analyze(string filePath, string text, string rulePath, string originalFileName)
         {

--- a/Src/Sarif.PatternMatcher.Sdk/Crc32.cs
+++ b/Src/Sarif.PatternMatcher.Sdk/Crc32.cs
@@ -7,9 +7,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk
 {
     public static class Crc32
     {
-        public static readonly uint[] Crc32IEEETable = CreateCrcTable(Crc32IEEEPolynomial);
-
         public static readonly uint[] Crc32CastagnoliTable = CreateCrcTable(Crc32CastagnoliPolynomial);
+        private static readonly uint[] Crc32IEEETable = CreateCrcTable(Crc32IEEEPolynomial);
 
         // https://crc32.online/
         // https://github.com/force-net/Crc32.NET

--- a/Src/Sarif.PatternMatcher.Sdk/Crc32.cs
+++ b/Src/Sarif.PatternMatcher.Sdk/Crc32.cs
@@ -7,6 +7,10 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk
 {
     public static class Crc32
     {
+        public static readonly uint[] Crc32IEEETable = CreateCrcTable(Crc32IEEEPolynomial);
+
+        public static readonly uint[] Crc32CastagnoliTable = CreateCrcTable(Crc32CastagnoliPolynomial);
+
         // https://crc32.online/
         // https://github.com/force-net/Crc32.NET
         // https://en.wikipedia.org/wiki/Cyclic_redundancy_check
@@ -20,10 +24,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk
         // Has better error detection characteristics than IEEE.
         // https://dx.doi.org/10.1109/26.231911
         private const uint Crc32CastagnoliPolynomial = 0x82f63b78;
-
-        public static readonly uint[] Crc32IEEETable = CreateCrcTable(Crc32IEEEPolynomial);
-
-        public static readonly uint[] Crc32CastagnoliTable = CreateCrcTable(Crc32CastagnoliPolynomial);
 
         public static uint Calculate(string text, uint[] crc32Table = null)
         {

--- a/Src/Sarif.PatternMatcher.Sdk/ExtensionMethods.cs
+++ b/Src/Sarif.PatternMatcher.Sdk/ExtensionMethods.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk
 {
     public static class ExtensionMethods
     {
-        public static char RedactionChar => '?';
+        public const char RedactionChar = '?';
 
         /// <summary>
         /// Use an <cref>HttpClient</cref> instance to retrieve request response headers only.

--- a/Src/Sarif.PatternMatcher.Sdk/ExtensionMethods.cs
+++ b/Src/Sarif.PatternMatcher.Sdk/ExtensionMethods.cs
@@ -10,6 +10,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk
 {
     public static class ExtensionMethods
     {
+        public static char RedactionChar => '?';
+
         /// <summary>
         /// Use an <cref>HttpClient</cref> instance to retrieve request response headers only.
         /// </summary>
@@ -83,8 +85,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk
                    truncatedText.Substring(truncatedText.Length - lengthExclusiveOfEllipsis) +
                    (charsElided ? suffix : string.Empty);
         }
-
-        public static char RedactionChar => '?';
 
         public static string Anonymize(this string text, int lengthExclusiveOfEllipsis = 6)
         {

--- a/Src/Sarif.PatternMatcher.Sdk/StaticValidatorBase.cs
+++ b/Src/Sarif.PatternMatcher.Sdk/StaticValidatorBase.cs
@@ -91,7 +91,6 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk
             return new[] { validationResult };
         }
 
-
         /// <summary>
         /// Evaluates secret to determine whether is a false positive or if it perhaps
         /// is a true positive but one that belongs to another security model.

--- a/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
@@ -80,6 +80,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                     // TBD add version details. Breaks test baselines currently.
                     // semanticVersion = fvi?.ProductVersion;
                     // version = fvi?.FileVersion;
+                    // ADO Work item: https://dev.azure.com/mseng/1ES/_workitems/edit/2066916
                 }
 
                 var toolComponent = new ToolComponent

--- a/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 SearchDefinitions definitions =
                     JsonConvert.DeserializeObject<SearchDefinitions>(searchDefinitionsText);
 
-                // This would skip files that does not look like rules.
+                // This would skip files that do not look like rules.
                 if (definitions == null || definitions.Definitions == null)
                 {
                     continue;

--- a/Src/Sarif.PatternMatcher/JsonLogicalLocationProcessor.cs
+++ b/Src/Sarif.PatternMatcher/JsonLogicalLocationProcessor.cs
@@ -67,9 +67,9 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
         ///     - For arrays, one might report the whole array, but this gets "closer" to the match.
         ///     - For objects, spanning properties will get "closer" to the match.
         /// </remarks>
-        /// <param name="results">collection of JSON results to process.</param>
-        /// <param name="fileContents">JSON file contents.</param>
-        /// <param name="fileRegionsCache">file cache that can be used to populate regions with comprehensive data.</param>
+        /// <param name="results">A collection of 'Result' objects produced by an analysis tool where each object contains many details such as RuleId, Kind, Level, Locations, etc.</param>
+        /// <param name="fileContents">This is the litteral JSON file contents.</param>
+        /// <param name="fileRegionsCache">This file cache can be used to populate regions with comprehensive data.</param>
         public void Process(ICollection<Result> results, string fileContents, FileRegionsCache fileRegionsCache = null)
         {
             if (results?.Count == 0) { return; }

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/SpamTestRule.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/SpamTestRule.cs
@@ -29,11 +29,11 @@ namespace Microsoft.CodeAnalysis.Sarif
         internal static Random s_random = new Random(s_seed);
 
         [ThreadStatic]
-        internal static TestRuleBehaviors s_testRuleBehaviors;
+        private static TestRuleBehaviors s_testRuleBehaviors;
 
         public SpamTestRule()
         {
-            if (s_testRuleBehaviors.HasFlag(TestRuleBehaviors.RaiseExceptionInvokingConstructor))
+            if (S_testRuleBehaviors.HasFlag(TestRuleBehaviors.RaiseExceptionInvokingConstructor))
             {
                 throw new InvalidOperationException(nameof(TestRuleBehaviors.RaiseExceptionInvokingConstructor));
             }
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             get
             {
-                if (s_testRuleBehaviors.HasFlag(TestRuleBehaviors.TreatPlatformAsInvalid))
+                if (S_testRuleBehaviors.HasFlag(TestRuleBehaviors.TreatPlatformAsInvalid))
                 {
                     return SupportedPlatform.Unknown;
                 }
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             get
             {
-                if (s_testRuleBehaviors == TestRuleBehaviors.RaiseExceptionAccessingId)
+                if (S_testRuleBehaviors == TestRuleBehaviors.RaiseExceptionAccessingId)
                 {
                     throw new InvalidOperationException(nameof(TestRuleBehaviors.RaiseExceptionAccessingId));
                 }
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             get
             {
-                if (s_testRuleBehaviors == TestRuleBehaviors.RaiseExceptionAccessingName)
+                if (S_testRuleBehaviors == TestRuleBehaviors.RaiseExceptionAccessingName)
                 {
                     throw new InvalidOperationException(nameof(TestRuleBehaviors.RaiseExceptionAccessingId));
                 }
@@ -136,6 +136,8 @@ namespace Microsoft.CodeAnalysis.Sarif
         }
 
         public override MultiformatMessageString FullDescription { get { return new MultiformatMessageString { Text = "This is the full description for TST1001" }; } }
+
+        internal static TestRuleBehaviors S_testRuleBehaviors { get => s_testRuleBehaviors; set => s_testRuleBehaviors = value; }
 
         public override void Analyze(AnalyzeContext context)
         {

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/SpamTestRule.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/SpamTestRule.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         internal static Random s_random = new Random(s_seed);
 
         [ThreadStatic]
-        private static TestRuleBehaviors s_testRuleBehaviors;
+        internal static TestRuleBehaviors s_testRuleBehaviors;
 
         public SpamTestRule()
         {

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/SpamTestRule.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/SpamTestRule.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
         public SpamTestRule()
         {
-            if (S_testRuleBehaviors.HasFlag(TestRuleBehaviors.RaiseExceptionInvokingConstructor))
+            if (s_testRuleBehaviors.HasFlag(TestRuleBehaviors.RaiseExceptionInvokingConstructor))
             {
                 throw new InvalidOperationException(nameof(TestRuleBehaviors.RaiseExceptionInvokingConstructor));
             }
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             get
             {
-                if (S_testRuleBehaviors.HasFlag(TestRuleBehaviors.TreatPlatformAsInvalid))
+                if (s_testRuleBehaviors.HasFlag(TestRuleBehaviors.TreatPlatformAsInvalid))
                 {
                     return SupportedPlatform.Unknown;
                 }
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             get
             {
-                if (S_testRuleBehaviors == TestRuleBehaviors.RaiseExceptionAccessingId)
+                if (s_testRuleBehaviors == TestRuleBehaviors.RaiseExceptionAccessingId)
                 {
                     throw new InvalidOperationException(nameof(TestRuleBehaviors.RaiseExceptionAccessingId));
                 }
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Sarif
         {
             get
             {
-                if (S_testRuleBehaviors == TestRuleBehaviors.RaiseExceptionAccessingName)
+                if (s_testRuleBehaviors == TestRuleBehaviors.RaiseExceptionAccessingName)
                 {
                     throw new InvalidOperationException(nameof(TestRuleBehaviors.RaiseExceptionAccessingId));
                 }
@@ -136,8 +136,6 @@ namespace Microsoft.CodeAnalysis.Sarif
         }
 
         public override MultiformatMessageString FullDescription { get { return new MultiformatMessageString { Text = "This is the full description for TST1001" }; } }
-
-        internal static TestRuleBehaviors S_testRuleBehaviors { get => s_testRuleBehaviors; set => s_testRuleBehaviors = value; }
 
         public override void Analyze(AnalyzeContext context)
         {


### PR DESCRIPTION
The only purpose of this PR is to eliminate build warnings.
There are no new features or changes to logic or fixes.

## Changes
For two warnings that could not be eliminated, $(MSBuildWarningsAsMessages) was used.
For the Newtonsoft version conflicts, MSB3277.
For the copy files errors, MSB3030.
The copy file error occurs even though the files eventually do copy.

Here is an example of the MSBuildWarningsAsMessages
  <PropertyGroup>
 <MSBuildWarningsAsMessages>
     $(MSBuildWarningsAsMessages);MSB3277;MSB3030
 </MSBuildWarningsAsMessages>
  </PropertyGroup>

The rest of the fixes are like xml comments missing, and correcting order of static vs public, fields vs properties.


For significant contributions please make sure you have completed the following items:

* [ ] `ReleaseHistory.md` updated for non-trivial changes
* [ ] Added unit tests
