### PR TITLE
Remove AWSSDK dependencies and refactor AwsCredentials validator to use HTTP request instead

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -18,6 +18,10 @@
 - UER => Eliminate unhandled exceptions in rule.
 - UEE => Eliminate unhandled exceptions in engine.
 
+## v4.5.2 Unreleased
+- RRR: Update `SEC101/008.AwsCredentials` in `Security` validating AWS credentials using HTTP requests.
+- DEP: Remove `AWSSDK.IdentityManagement` from `Security`.
+
 ## v4.5.1 5/31/2023
 - DEP: Update SARIF SDK submodule from [441fa8b to dd8b7b8](https://github.com/microsoft/sarif-sdk/compare/441fa8b..dd8b7b8). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/dd8b7b8/ReleaseHistory.md). Additional eventing work.
 

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/AwsHttpRequestSigner.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/AwsHttpRequestSigner.cs
@@ -3,12 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Security.Cryptography;
 using System.Text;
 
 using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk;
+
+using Org.BouncyCastle.Utilities.Encoders;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
@@ -18,56 +20,52 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
     {
         private const string ISO8601BasicDateTimeFormat = "yyyyMMddTHHmmssZ";
 
+        [ThreadStatic]
+        private static StringBuilder s_hex;
+
         private readonly SHA256 sha256;
         private readonly string accessKey;
         private readonly string accessSecret;
 
-        public AwsHttpRequestSigner(string accessKey, string accessSecret)
+        internal AwsHttpRequestSigner(string accessKey, string accessSecret)
         {
             this.accessKey = accessKey;
             this.accessSecret = accessSecret;
             this.sha256 = SHA256.Create();
         }
 
-        public virtual string Version => "AWS4";
+        internal virtual string Version => "AWS4";
 
-        public virtual string RequestType => "aws4_request";
+        internal virtual string RequestType => "aws4_request";
 
-        public virtual string Algorithm => "AWS4-HMAC-SHA256";
+        internal virtual string Algorithm => "AWS4-HMAC-SHA256";
 
-        public virtual string HostHeaderName => "host";
+        internal virtual string HostHeaderName => "host";
 
-        public virtual string DateHeaderName => "x-amz-date";
+        internal virtual string DateHeaderName => "x-amz-date";
 
-        public virtual string ContentSha256HeaderName => "x-amz-content-sha256";
+        internal virtual string ContentSha256HeaderName => "x-amz-content-sha256";
 
-        public void SignRequest(HttpRequestMessage request,
-                                string region,
-                                string service,
-                                DateTime? dateTime = null)
+        public void Dispose()
         {
-            this.CleanHeaders(request.Headers);
+            sha256?.Dispose();
+        }
 
+        internal void SignRequest(HttpRequestMessage request, string region, string service, DateTime? dateTime = null)
+        {
             string host = request.RequestUri.Host;
-            byte[] content = request.Content?.ReadAsByteArrayAsync().GetAwaiter().GetResult() ?? Array.Empty<byte>();
-            string contentHash = GetHash(content);
+
+            byte[] content = request.Content?.ReadAsByteArrayAsync().Result ?? Array.Empty<byte>();
+
+            string contentHash = this.GetHash(content);
 
             DateTime date = dateTime ?? DateTime.UtcNow;
-            string requestDateString = date.ToString(ISO8601BasicDateTimeFormat);
+
             string dateStamp = date.ToString("yyyyMMdd");
 
+            string requestDateString = date.ToString(ISO8601BasicDateTimeFormat);
+
             string credentialScope = $"{dateStamp}/{region}/{service}/{this.RequestType}";
-            string signedHeaderNames = $"{this.HostHeaderName};{this.ContentSha256HeaderName};{this.DateHeaderName}";
-
-            string canonicalRequest = this.ConstructCanonicalRequest(request.Method.ToString(), signedHeaderNames, host, contentHash, requestDateString);
-
-            string stringToSign = this.ConstructStringToSign(credentialScope, canonicalRequest, requestDateString);
-
-            byte[] signingKey = this.GetSignatureKey(this.accessSecret, dateStamp, region, service, this.RequestType);
-
-            string signature = ToHexString(HmacSha256Hash(signingKey, stringToSign));
-
-            string authorizationHeader = $"{this.Algorithm} Credential={this.accessKey}/{credentialScope}, SignedHeaders={signedHeaderNames}, Signature={signature}";
 
             request.Headers.Merge(new Dictionary<string, string>
             {
@@ -75,68 +73,120 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                 { this.ContentSha256HeaderName, contentHash },
                 { this.DateHeaderName, requestDateString },
             });
+
+            string canonicalRequest = this.ConstructCanonicalRequest(
+                request,
+                contentHash,
+                out string signedHeaders);
+
+            string stringToSign = this.ConstructStringToSign(
+                credentialScope,
+                canonicalRequest,
+                requestDateString);
+
+            string signature = this.GetSignature(
+                this.accessSecret,
+                dateStamp,
+                region,
+                service,
+                this.RequestType,
+                stringToSign);
+
+            string authorizationHeader = string.Format("{0} Credential={1}/{2}, SignedHeaders={3}, Signature={4}",
+                this.Algorithm,
+                this.accessKey,
+                credentialScope,
+                signedHeaders,
+                signature);
+
             request.Headers.TryAddWithoutValidation("Authorization", authorizationHeader);
         }
 
-        public void Dispose()
+        private string ConstructCanonicalRequest(HttpRequestMessage request, string hashPayload, out string signedHeaders)
         {
-            sha256?.Dispose();
-        }
+            string httpMethod = request.Method.ToString();
 
-        private static byte[] HmacSha256Hash(byte[] key, string msg)
-        {
-            using (var hmac = new HMACSHA256(key))
-            {
-                return hmac.ComputeHash(Encoding.UTF8.GetBytes(msg));
-            }
-        }
-
-        private static string ToHexString(IReadOnlyCollection<byte> array)
-        {
-            var hex = new StringBuilder(array.Count * 2);
-            foreach (byte b in array)
-            {
-                hex.AppendFormat("{0:x2}", b);
-            }
-
-            return hex.ToString();
-        }
-
-        private string ConstructCanonicalRequest(string httpMethod, string signedHeaderNames, string host, string contentSha256, string dateString)
-        {
             string canonicalUri = "/";
+
             string canonicalQuerystring = string.Empty;
-            string canonicalHeaders = $"{this.HostHeaderName}:{host}\n{this.ContentSha256HeaderName}:{contentSha256}\n{this.DateHeaderName}:{dateString}";
-            return $"{httpMethod}\n{canonicalUri}\n{canonicalQuerystring}\n{canonicalHeaders}\n\n{signedHeaderNames}\n{contentSha256}";
+
+            var headerKeyList = new List<string>();
+
+            var headerKeyValuePairList = new List<string>();
+
+            foreach (KeyValuePair<string, IEnumerable<string>> header in request.Headers.OrderBy(a => a.Key, StringComparer.OrdinalIgnoreCase))
+            {
+                headerKeyList.Add(header.Key.ToLower());
+
+                headerKeyValuePairList.Add($"{header.Key.ToLower()}:{string.Join(",", header.Value.Select(s => s.Trim()))}");
+            }
+
+            signedHeaders = string.Join(";", headerKeyList);
+
+            string canonicalHeaders = string.Join("\n", headerKeyValuePairList) + "\n";
+
+            return string.Format("{0}\n{1}\n{2}\n{3}\n{4}\n{5}",
+                                  httpMethod,
+                                  canonicalUri,
+                                  canonicalQuerystring,
+                                  canonicalHeaders,
+                                  signedHeaders,
+                                  hashPayload);
         }
 
         private string ConstructStringToSign(string credentialScope, string canonicalRequest, string dateString)
         {
-            string stringToSign = $"{this.Algorithm}\n{dateString}\n{credentialScope}\n";
-            stringToSign += GetHash(Encoding.UTF8.GetBytes(canonicalRequest));
-            return stringToSign;
+            return string.Format("{0}\n{1}\n{2}\n{3}",
+                this.Algorithm,
+                dateString,
+                credentialScope,
+                this.GetHash(Encoding.UTF8.GetBytes(canonicalRequest)));
         }
 
-        private void CleanHeaders(HttpRequestHeaders headers)
+        private string GetSignature(string key, string dateStamp, string regionName, string serviceName, string requestType, string stringToSign)
         {
-            headers.Remove(this.HostHeaderName);
-            headers.Remove(this.ContentSha256HeaderName);
-            headers.Remove(this.DateHeaderName);
-            headers.Remove("Authorization");
-        }
+            byte[] keyBytes = this.HmacSha256Hash(Encoding.UTF8.GetBytes(this.Version + key), dateStamp);
 
-        private byte[] GetSignatureKey(string key, string date_stamp, string regionName, string serviceName, string requestType)
-        {
-            byte[] key_date = HmacSha256Hash(Encoding.UTF8.GetBytes(this.Version + key), date_stamp);
-            byte[] key_region = HmacSha256Hash(key_date, regionName);
-            byte[] key_service = HmacSha256Hash(key_region, serviceName);
-            return HmacSha256Hash(key_service, requestType);
+            keyBytes = this.HmacSha256Hash(keyBytes, regionName);
+
+            keyBytes = this.HmacSha256Hash(keyBytes, serviceName);
+
+            keyBytes = this.HmacSha256Hash(keyBytes, requestType);
+
+            keyBytes = this.HmacSha256Hash(keyBytes, stringToSign);
+
+            return this.ToHexString(keyBytes);
         }
 
         private string GetHash(byte[] bytes)
         {
             byte[] result = this.sha256.ComputeHash(bytes);
-            return ToHexString(result);
+
+            return this.ToHexString(result);
+        }
+
+        private byte[] HmacSha256Hash(byte[] key, string message)
+        {
+            using (var hmac = new HMACSHA256(key))
+            {
+                return hmac.ComputeHash(Encoding.UTF8.GetBytes(message));
+            }
+        }
+
+        private string ToHexString(IReadOnlyCollection<byte> array)
+        {
+            s_hex ??= new StringBuilder();
+
+            s_hex.Clear();
+
+            s_hex.Capacity = array.Count * 2;
+
+            foreach (byte b in array)
+            {
+                s_hex.AppendFormat("{0:x2}", b);
+            }
+
+            return s_hex.ToString();
         }
     }
 }

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/AwsHttpRequestSigner.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/AwsHttpRequestSigner.cs
@@ -1,0 +1,142 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+
+using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk;
+
+namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
+{
+    // https://docs.aws.amazon.com/general/latest/gr/create-signed-request.html
+
+    internal class AwsHttpRequestSigner : IDisposable
+    {
+        private const string ISO8601BasicDateTimeFormat = "yyyyMMddTHHmmssZ";
+
+        private readonly SHA256 sha256;
+        private readonly string accessKey;
+        private readonly string accessSecret;
+
+        public AwsHttpRequestSigner(string accessKey, string accessSecret)
+        {
+            this.accessKey = accessKey;
+            this.accessSecret = accessSecret;
+            this.sha256 = SHA256.Create();
+        }
+
+        public virtual string Version => "AWS4";
+
+        public virtual string RequestType => "aws4_request";
+
+        public virtual string Algorithm => "AWS4-HMAC-SHA256";
+
+        public virtual string HostHeaderName => "host";
+
+        public virtual string DateHeaderName => "x-amz-date";
+
+        public virtual string ContentSha256HeaderName => "x-amz-content-sha256";
+
+        public void SignRequest(HttpRequestMessage request,
+                                string region,
+                                string service,
+                                DateTime? dateTime = null)
+        {
+            this.CleanHeaders(request.Headers);
+
+            string host = request.RequestUri.Host;
+            byte[] content = request.Content?.ReadAsByteArrayAsync().GetAwaiter().GetResult() ?? Array.Empty<byte>();
+            string contentHash = GetHash(content);
+
+            DateTime date = dateTime ?? DateTime.UtcNow;
+            string requestDateString = date.ToString(ISO8601BasicDateTimeFormat);
+            string dateStamp = date.ToString("yyyyMMdd");
+
+            string credentialScope = $"{dateStamp}/{region}/{service}/{this.RequestType}";
+            string signedHeaderNames = $"{this.HostHeaderName};{this.ContentSha256HeaderName};{this.DateHeaderName}";
+
+            string canonicalRequest = this.ConstructCanonicalRequest(request.Method.ToString(), signedHeaderNames, host, contentHash, requestDateString);
+
+            string stringToSign = this.ConstructStringToSign(credentialScope, canonicalRequest, requestDateString);
+
+            byte[] signingKey = this.GetSignatureKey(this.accessSecret, dateStamp, region, service, this.RequestType);
+
+            string signature = ToHexString(HmacSha256Hash(signingKey, stringToSign));
+
+            string authorizationHeader = $"{this.Algorithm} Credential={this.accessKey}/{credentialScope}, SignedHeaders={signedHeaderNames}, Signature={signature}";
+
+            request.Headers.Merge(new Dictionary<string, string>
+            {
+                { this.HostHeaderName, host },
+                { this.ContentSha256HeaderName, contentHash },
+                { this.DateHeaderName, requestDateString },
+            });
+            request.Headers.TryAddWithoutValidation("Authorization", authorizationHeader);
+        }
+
+        public void Dispose()
+        {
+            sha256?.Dispose();
+        }
+
+        private static byte[] HmacSha256Hash(byte[] key, string msg)
+        {
+            using (var hmac = new HMACSHA256(key))
+            {
+                return hmac.ComputeHash(Encoding.UTF8.GetBytes(msg));
+            }
+        }
+
+        private static string ToHexString(IReadOnlyCollection<byte> array)
+        {
+            var hex = new StringBuilder(array.Count * 2);
+            foreach (byte b in array)
+            {
+                hex.AppendFormat("{0:x2}", b);
+            }
+
+            return hex.ToString();
+        }
+
+        private string ConstructCanonicalRequest(string httpMethod, string signedHeaderNames, string host, string contentSha256, string dateString)
+        {
+            string canonicalUri = "/";
+            string canonicalQuerystring = string.Empty;
+            string canonicalHeaders = $"{this.HostHeaderName}:{host}\n{this.ContentSha256HeaderName}:{contentSha256}\n{this.DateHeaderName}:{dateString}";
+            return $"{httpMethod}\n{canonicalUri}\n{canonicalQuerystring}\n{canonicalHeaders}\n\n{signedHeaderNames}\n{contentSha256}";
+        }
+
+        private string ConstructStringToSign(string credentialScope, string canonicalRequest, string dateString)
+        {
+            string stringToSign = $"{this.Algorithm}\n{dateString}\n{credentialScope}\n";
+            stringToSign += GetHash(Encoding.UTF8.GetBytes(canonicalRequest));
+            return stringToSign;
+        }
+
+        private void CleanHeaders(HttpRequestHeaders headers)
+        {
+            headers.Remove(this.HostHeaderName);
+            headers.Remove(this.ContentSha256HeaderName);
+            headers.Remove(this.DateHeaderName);
+            headers.Remove("Authorization");
+        }
+
+        private byte[] GetSignatureKey(string key, string date_stamp, string regionName, string serviceName, string requestType)
+        {
+            byte[] key_date = HmacSha256Hash(Encoding.UTF8.GetBytes(this.Version + key), date_stamp);
+            byte[] key_region = HmacSha256Hash(key_date, regionName);
+            byte[] key_service = HmacSha256Hash(key_region, serviceName);
+            return HmacSha256Hash(key_service, requestType);
+        }
+
+        private string GetHash(byte[] bytes)
+        {
+            byte[] result = this.sha256.ComputeHash(bytes);
+            return ToHexString(result);
+        }
+    }
+}

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/AwsHttpRequestSigner.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/AwsHttpRequestSigner.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
     // https://docs.aws.amazon.com/general/latest/gr/create-signed-request.html
 
-    internal class AwsHttpRequestSigner : IDisposable
+    public class AwsHttpRequestSigner : IDisposable
     {
         private const string ISO8601BasicDateTimeFormat = "yyyyMMddTHHmmssZ";
 
@@ -27,31 +27,26 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
         private readonly string accessKey;
         private readonly string accessSecret;
 
-        internal AwsHttpRequestSigner(string accessKey, string accessSecret)
+        public AwsHttpRequestSigner(string accessKey, string accessSecret)
         {
             this.accessKey = accessKey;
             this.accessSecret = accessSecret;
             this.sha256 = SHA256.Create();
         }
 
-        internal virtual string Version => "AWS4";
+        public virtual string Version => "AWS4";
 
-        internal virtual string RequestType => "aws4_request";
+        public virtual string RequestType => "aws4_request";
 
-        internal virtual string Algorithm => "AWS4-HMAC-SHA256";
+        public virtual string Algorithm => "AWS4-HMAC-SHA256";
 
-        internal virtual string HostHeaderName => "host";
+        public virtual string HostHeaderName => "host";
 
-        internal virtual string DateHeaderName => "x-amz-date";
+        public virtual string DateHeaderName => "x-amz-date";
 
-        internal virtual string ContentSha256HeaderName => "x-amz-content-sha256";
+        public virtual string ContentSha256HeaderName => "x-amz-content-sha256";
 
-        public void Dispose()
-        {
-            sha256?.Dispose();
-        }
-
-        internal void SignRequest(HttpRequestMessage request, string region, string service, DateTime? dateTime = null)
+        public void SignRequest(HttpRequestMessage request, string region, string service, DateTime? dateTime = null)
         {
             string host = request.RequestUri.Host;
 
@@ -100,6 +95,11 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                 signature);
 
             request.Headers.TryAddWithoutValidation("Authorization", authorizationHeader);
+        }
+
+        public void Dispose()
+        {
+            sha256?.Dispose();
         }
 
         private string ConstructCanonicalRequest(HttpRequestMessage request, string hashPayload, out string signedHeaders)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_008.AwsCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_008.AwsCredentialsValidator.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -106,7 +105,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 
                                 if (match.Success)
                                 {
-                                    int trimmedChars = "User: ".Length + "is not authorized ".Length;
+                                    int trimmedChars = UserPrefix.Length + UserSuffix.Length;
                                     string iamUser = match.Value.String.Substring("User: ".Length, match.Value.String.Length - trimmedChars);
                                     message = $"the compromised AWS identity is '{iamUser}";
                                 }

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_008.AwsCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_008.AwsCredentialsValidator.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Collections.Generic;
-
-using Amazon.IdentityManagement;
-using Amazon.IdentityManagement.Model;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Xml;
 
 using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk;
 using Microsoft.RE2.Managed;
@@ -55,71 +57,122 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
         {
             string id = fingerprint.Id;
             string secret = fingerprint.Secret;
+            string endpointUri = "https://iam.amazonaws.com/";
+            string payload = "Action=GetAccountAuthorizationDetails&Version=2010-05-08";
 
             try
             {
-                var iamClient = new AmazonIdentityManagementServiceClient(id, secret);
+                HttpClient client = CreateOrRetrieveCachedHttpClient();
 
-                GetAccountAuthorizationDetailsRequest request;
-                GetAccountAuthorizationDetailsResponse response;
+                using var request = new HttpRequestMessage(HttpMethod.Post, endpointUri);
 
-                request = new GetAccountAuthorizationDetailsRequest();
-                response = iamClient.GetAccountAuthorizationDetailsAsync(request).GetAwaiter().GetResult();
+                request.Content = new StringContent(payload, Encoding.UTF8, "application/x-www-form-urlencoded");
 
-                message = BuildAuthorizedMessage(id, response);
-            }
-            catch (AmazonIdentityManagementServiceException e)
-            {
-                switch (e.ErrorCode)
+                using var requestSigner = new AwsHttpRequestSigner(id, secret);
+
+                requestSigner.SignRequest(request, "us-east-1", "iam");
+
+                using HttpResponseMessage response = client.ReadResponseHeaders(request);
+
+                switch (response.StatusCode)
                 {
-                    case "AccessDenied":
+                    case HttpStatusCode.OK:
                     {
-                        FlexMatch match = RegexEngine.Match(e.Message, AwsUserExpression);
+                        Stream responseStream = response.Content.ReadAsStreamAsync().Result;
 
-                        // May return a message containing user id details such as:
-                        // User: arn:aws:iam::123456123456:user/example.com@@dead1234dead1234dead1234 is not
-                        // authorized to perform: iam:GetAccountAuthorizationDetails on resource: *
-
-                        if (match.Success)
-                        {
-                            int trimmedChars = "User: ".Length + "is not authorized ".Length;
-                            string iamUser = match.Value.String.Substring("User: ".Length, match.Value.String.Length - trimmedChars);
-                            message = $"the compromised AWS identity is '{iamUser}";
-                        }
+                        message = BuildAuthorizedMessage(id, responseStream);
 
                         return ValidationState.Authorized;
                     }
 
-                    case "InvalidClientTokenId":
-                    case "SignatureDoesNotMatch":
+                    case HttpStatusCode.Forbidden:
                     {
-                        return ValidationState.NoMatch;
+                        Stream responseStream = response.Content.ReadAsStreamAsync().Result;
+
+                        ReadErrorCodeMessage(responseStream, out string errorCode, out string errorMessage);
+
+                        switch (errorCode)
+                        {
+                            case "AccessDenied":
+                            {
+                                FlexMatch match = RegexEngine.Match(errorMessage, AwsUserExpression);
+
+                                // May return a message containing user id details such as:
+                                // User: arn:aws:iam::123456123456:user/example.com@@dead1234dead1234dead1234 is not
+                                // authorized to perform: iam:GetAccountAuthorizationDetails on resource: *
+
+                                if (match.Success)
+                                {
+                                    int trimmedChars = "User: ".Length + "is not authorized ".Length;
+                                    string iamUser = match.Value.String.Substring("User: ".Length, match.Value.String.Length - trimmedChars);
+                                    message = $"the compromised AWS identity is '{iamUser}";
+                                }
+
+                                return ValidationState.Authorized;
+                            }
+
+                            case "InvalidClientTokenId":
+                            case "SignatureDoesNotMatch":
+                            {
+                                return ValidationState.NoMatch;
+                            }
+                        }
+
+                        return ValidationState.Unauthorized;
+                    }
+
+                    default:
+                    {
+                        return ReturnUnexpectedResponseCode(ref message, response.StatusCode, id);
                     }
                 }
-
-                message = $"An unexpected exception was caught attempting to authenticate AWS id '{id}': {e.Message}";
-                return ValidationState.Unknown;
             }
             catch (Exception e)
             {
-                message = $"An unexpected exception was caught attempting to authentic AWS id '{id}': {e.Message}";
+                message = $"An unexpected exception was caught attempting to authenticate AWS id '{id}': {e.Message}";
                 return ValidationState.Unknown;
             }
-
-            return ValidationState.Authorized;
         }
 
-        private string BuildAuthorizedMessage(string id, GetAccountAuthorizationDetailsResponse response)
+        private string BuildAuthorizedMessage(string id, Stream responseStream)
         {
             var policyNames = new List<string>();
 
-            foreach (ManagedPolicyDetail policy in response.Policies)
+            using var reader = XmlReader.Create(responseStream);
+
+            if (reader.ReadToFollowing("Policies"))
             {
-                policyNames.Add(policy.PolicyName);
+                using XmlReader policyReader = reader.ReadSubtree();
+
+                while (policyReader.ReadToFollowing("member"))
+                {
+                    if (policyReader.ReadToFollowing("PolicyName"))
+                    {
+                        policyNames.Add(reader.ReadElementContentAsString());
+                    }
+                }
             }
 
             string policyNamesText = string.Join(", ", policyNames);
+
             return $"id '{id}' is authorized for role policies '{policyNamesText}'.";
+        }
+
+        private void ReadErrorCodeMessage(Stream responseStream, out string code, out string message)
+        {
+            code = message = string.Empty;
+
+            using var reader = XmlReader.Create(responseStream);
+
+            if (reader.ReadToFollowing("Code"))
+            {
+                code = reader.ReadElementContentAsString();
+            }
+
+            if (reader.ReadToFollowing("Message"))
+            {
+                message = reader.ReadElementContentAsString();
+            }
         }
     }
 }

--- a/Src/Plugins/Security/Security.csproj
+++ b/Src/Plugins/Security/Security.csproj
@@ -24,7 +24,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.5.0.61" />
     <PackageReference Include="GoogleApi" Version="4.0.4" />
     <PackageReference Include="Microsoft.Security.Utilities" Version="1.4.0" />
     <PackageReference Include="MySqlConnector" Version="1.2.1" />

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/AwsHttpRequestSignerTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/AwsHttpRequestSignerTests.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+
+using FluentAssertions;
+using FluentAssertions.Execution;
+
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validators
+{
+    public class AwsHttpRequestSignerTests
+    {
+        [Fact]
+        public void SignRequest_Tests()
+        {
+            string id = "ASIAABC";
+            string secret = "abc";
+            string service = "service";
+            string region = "us-east-1";
+            string endpointUri = "https://service.example.com";
+            DateTime timestamp = DateTime.UtcNow;
+
+            using var signer = new AwsHttpRequestSigner(id, secret);
+            using var request = new HttpRequestMessage(HttpMethod.Get, endpointUri);
+            signer.SignRequest(request, service, region, timestamp);
+
+            using (new AssertionScope())
+            {
+                request.Headers.Should().HaveCount(4);
+                request.Headers.TryGetValues(signer.HostHeaderName, out IEnumerable<string> hostValues).Should().BeTrue();
+                request.Headers.TryGetValues(signer.DateHeaderName, out IEnumerable<string> dateValues).Should().BeTrue();
+                request.Headers.TryGetValues(signer.ContentSha256HeaderName, out IEnumerable<string> sha256Values).Should().BeTrue();
+                request.Headers.TryGetValues("Authorization", out IEnumerable<string> authValues).Should().BeTrue();
+
+                hostValues.First().Should().Be(new Uri(endpointUri).Host);
+                dateValues.First().Should().Be(timestamp.ToString("yyyyMMddTHHmmssZ"));
+                sha256Values.First().Length.Should().BeGreaterThan(1);
+                authValues.First().Should().StartWith(signer.Algorithm);
+            }
+        }
+
+        [Fact]
+        public void Ctor_Tests()
+        {
+            string id = "ASIAABC";
+            string secret = "abc";
+
+            Action act = null;
+            using (new AssertionScope())
+            {
+                act = () => new AwsHttpRequestSigner(null, secret);
+                act.Should().Throw<ArgumentNullException>().WithParameterName("accessKey");
+
+                act = () => new AwsHttpRequestSigner(id, null);
+                act.Should().Throw<ArgumentNullException>().WithParameterName("secretKey");
+
+                act = () => new AwsHttpRequestSigner(id, secret);
+                act.Should().NotThrow();
+            }
+        }
+
+        [Fact]
+        public void SignRequest_NullArguments_Tests()
+        {
+            string id = "ASIAABC";
+            string secret = "abc";
+            string service = "service";
+            string region = "us-east-1";
+            string endpointUri = "https://service.example.com";
+
+            using var signer = new AwsHttpRequestSigner(id, secret);
+            using var request = new HttpRequestMessage(HttpMethod.Get, endpointUri);
+
+            Action act = null;
+            using (new AssertionScope())
+            {
+                act = () => signer.SignRequest(null, region, service);
+                act.Should().Throw<ArgumentNullException>().WithParameterName("request");
+
+                act = () => signer.SignRequest(request, null, service);
+                act.Should().Throw<ArgumentNullException>().WithParameterName("region");
+
+                act = () => signer.SignRequest(request, region, null);
+                act.Should().Throw<ArgumentNullException>().WithParameterName("service");
+
+                act = () => signer.SignRequest(request, region, service);
+                act.Should().NotThrow();
+            }
+        }
+    }
+}

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_008.AwsCredentialsValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_008.AwsCredentialsValidatorTests.cs
@@ -1,0 +1,146 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+
+using FluentAssertions;
+
+using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Helpers;
+using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk;
+
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validators
+{
+    /// <summary>
+    /// Testing SEC101/008.AwsCredentialsValidator
+    /// </summary
+    public class AwsCredentialsValidatorTests
+    {
+        [Fact]
+        public void AwsCredentialsValidatorValidator_MockHttpTests()
+        {
+            const string uri = "https://iam.amazonaws.com/";
+            const string payload = "Action=GetAccountAuthorizationDetails&Version=2010-05-08";
+            const string id = "AKIAABC";
+            const string secret = "abc123";
+            string fingerprintText = $"[id={id}][secret={secret}]";
+            var awsCredentialsValidator = new AwsCredentialsValidator();
+
+            using var requestWithToken = new HttpRequestMessage(HttpMethod.Post, uri);
+            requestWithToken.Content = new StringContent(payload, Encoding.UTF8, "application/x-www-form-urlencoded");
+            using var requestSigner = new AwsHttpRequestSigner(id, secret);
+            requestSigner.SignRequest(requestWithToken, "us-east-1", "iam", awsCredentialsValidator.TimeStamp);
+
+            string errorMessage = string.Empty;
+
+            var testCases = new HttpMockTestCase[]
+            {
+                new HttpMockTestCase
+                {
+                    Title = "Returns OK Status with policies",
+                    HttpStatusCodes = new List<HttpStatusCode> { HttpStatusCode.OK },
+                    HttpContents = new List<HttpContent> { new StringContent("<GetAccountAuthorizationDetailsResponse xmlns=\"https://iam.amazonaws.com/doc/2010-05-08/\"><GetAccountAuthorizationDetailsResult><Policies><member><PolicyName>AWSSupportServiceRolePolicy</PolicyName></member><member><PolicyName>AWSTrustedAdvisorServiceRolePolicy</PolicyName></member></Policies></GetAccountAuthorizationDetailsResult></GetAccountAuthorizationDetailsResponse>") },
+                    HttpRequestMessages = new List<HttpRequestMessage>{ requestWithToken },
+                    ExpectedMessage = $"id '{id}' is authorized for role policies 'AWSSupportServiceRolePolicy, AWSTrustedAdvisorServiceRolePolicy'.",
+                    ExpectedValidationState = ValidationState.Authorized
+                },
+                new HttpMockTestCase
+                {
+                    Title = "Returns OK Status with no policies",
+                    HttpStatusCodes = new List<HttpStatusCode> { HttpStatusCode.OK },
+                    HttpContents = new List<HttpContent> { new StringContent("<GetAccountAuthorizationDetailsResponse xmlns=\"https://iam.amazonaws.com/doc/2010-05-08/\"><GetAccountAuthorizationDetailsResult><Policies></Policies></GetAccountAuthorizationDetailsResult></GetAccountAuthorizationDetailsResponse>") },
+                    HttpRequestMessages = new List<HttpRequestMessage>{ requestWithToken },
+                    ExpectedMessage = $"id '{id}' is authorized for role policies ''.",
+                    ExpectedValidationState = ValidationState.Authorized
+                },
+                new HttpMockTestCase
+                {
+                    Title = "Returns Forbidden with invalid token error",
+                    HttpStatusCodes = new List<HttpStatusCode> { HttpStatusCode.Forbidden },
+                    HttpContents = new List<HttpContent> { new StringContent("<ErrorResponse xmlns=\"https://iam.amazonaws.com/doc/2010-05-08/\"><Error><Code>InvalidClientTokenId</Code> <Message>The security token included in the request is invalid.</Message></Error></ErrorResponse>") },
+                    HttpRequestMessages = new List<HttpRequestMessage>{ requestWithToken },
+                    ExpectedMessage = string.Empty,
+                    ExpectedValidationState = ValidationState.NoMatch
+                },
+                new HttpMockTestCase
+                {
+                    Title = "Returns Forbidden with signature doesn't match error",
+                    HttpStatusCodes = new List<HttpStatusCode> { HttpStatusCode.Forbidden },
+                    HttpContents = new List<HttpContent> { new StringContent("<ErrorResponse xmlns=\"https://iam.amazonaws.com/doc/2010-05-08/\"><Error><Code>SignatureDoesNotMatch</Code></Error></ErrorResponse>") },
+                    HttpRequestMessages = new List<HttpRequestMessage>{ requestWithToken },
+                    ExpectedMessage = string.Empty,
+                    ExpectedValidationState = ValidationState.NoMatch
+                },
+                new HttpMockTestCase
+                {
+                    Title = "Returns Forbidden with access denied error",
+                    HttpStatusCodes = new List<HttpStatusCode> { HttpStatusCode.Forbidden },
+                    HttpContents = new List<HttpContent> { new StringContent("<ErrorResponse xmlns=\"https://iam.amazonaws.com/doc/2010-05-08/\"><Error><Code>AccessDenied</Code> <Message>User: arn:aws:iam::123:user/example.com@@ead123 is not authorized to perform: iam:GetAccountAuthorizationDetails on resource: *</Message></Error></ErrorResponse>") },
+                    HttpRequestMessages = new List<HttpRequestMessage>{ requestWithToken },
+                    ExpectedMessage = "the compromised AWS identity is 'arn:aws:iam::123:user/example.com@@ead123",
+                    ExpectedValidationState = ValidationState.Authorized
+                },
+                new HttpMockTestCase
+                {
+                    Title = "Returns Forbidden with unknown error",
+                    HttpStatusCodes = new List<HttpStatusCode> { HttpStatusCode.Forbidden },
+                    HttpContents = new List<HttpContent> { new StringContent("<ErrorResponse xmlns=\"https://iam.amazonaws.com/doc/2010-05-08/\"><Error><Code>Unknown</Code></Error></ErrorResponse>") },
+                    HttpRequestMessages = new List<HttpRequestMessage>{ requestWithToken },
+                    ExpectedMessage = string.Empty,
+                    ExpectedValidationState = ValidationState.Unauthorized
+                },
+                new HttpMockTestCase
+                {
+                    Title = "Returns Unexpected Response Code",
+                    HttpStatusCodes = new List<HttpStatusCode> { HttpStatusCode.BadRequest },
+                    HttpContents = new List<HttpContent> { new StringContent("<Unexpected/>") },
+                    HttpRequestMessages = new List<HttpRequestMessage>{ requestWithToken },
+                    ExpectedValidationState = ValidatorBase.ReturnUnexpectedResponseCode(ref errorMessage, HttpStatusCode.BadRequest, id),
+                    ExpectedMessage = errorMessage
+                },
+            };
+
+            var sb = new StringBuilder();
+            var mockHandler = new HttpMockHelper();
+
+            foreach (HttpMockTestCase testCase in testCases)
+            {
+                for (int i = 0; i < testCase.HttpStatusCodes.Count; i++)
+                {
+                    mockHandler.Mock(testCase.HttpRequestMessages[i], testCase.HttpStatusCodes[i], testCase.HttpContents[i]);
+                }
+
+                string message = string.Empty;
+                ResultLevelKind resultLevelKind = default;
+                var fingerprint = new Fingerprint(fingerprintText);
+                var keyValuePairs = new Dictionary<string, string>();
+
+                using var httpClient = new HttpClient(mockHandler);
+                awsCredentialsValidator.SetHttpClient(httpClient);
+
+                ValidationState currentState = awsCredentialsValidator.IsValidDynamic(ref fingerprint,
+                                                                                      ref message,
+                                                                                      keyValuePairs,
+                                                                                      ref resultLevelKind);
+                if (currentState != testCase.ExpectedValidationState)
+                {
+                    sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedValidationState}' but found '{currentState}'.");
+                }
+
+                if (testCase.ExpectedMessage != message?.Split(Environment.NewLine)[0])
+                {
+                    sb.AppendLine($"The test case '{testCase.Title}' was expecting '{testCase.ExpectedMessage}' but found '{message}'.");
+                }
+
+                mockHandler.Clear();
+            }
+
+            sb.Length.Should().Be(0, sb.ToString());
+        }
+    }
+}

--- a/Src/Sarif.PatternMatcher/ValidatorsCache.cs
+++ b/Src/Sarif.PatternMatcher/ValidatorsCache.cs
@@ -7,13 +7,9 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using System.Text.RegularExpressions;
 
 using Microsoft.CodeAnalysis.Sarif.Driver;
-using Microsoft.CodeAnalysis.Sarif.Driver.Sdk;
 using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk;
-using Microsoft.Diagnostics.Tracing;
-using Microsoft.Diagnostics.Tracing.Parsers.IIS_Trace;
 using Microsoft.RE2.Managed;
 
 using Newtonsoft.Json;

--- a/Src/SarifPatternMatcher.sln
+++ b/Src/SarifPatternMatcher.sln
@@ -23,6 +23,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "root", "root", "{B599D6C7-9
 		..\BuildAndTest.cmd = ..\BuildAndTest.cmd
 		..\CONTRIBUTING.md = ..\CONTRIBUTING.md
 		..\README.md = ..\README.md
+		..\ReleaseHistory.md = ..\ReleaseHistory.md
 		..\version.json = ..\version.json
 	EndProjectSection
 EndProject
@@ -46,7 +47,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Src", "Src", "{BB9FC0F2-57E
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		.ruleset = .ruleset
-		ReleaseHistory.md = ReleaseHistory.md
 		SarifPatternMatcher.runsettings = SarifPatternMatcher.runsettings
 		stylecop.json = stylecop.json
 	EndProjectSection


### PR DESCRIPTION
## Changes

Updated `SEC101/008.AwsCredentials` validator to validate AWS access key/access secret using signed HTTP request.
- Get ride of AWS SDK dependencies
- Validate by calling AWS iam REST API using HTTP request with AWS signature V4 format.
- Parse the XML response instead of using SDK data model.