### PR TITLE
Restore schedule as part of solving GitHub action that is broken.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,6 +16,8 @@ on:
     branches: "*"
   pull_request:
     branches: [ main ]
+  schedule:
+    - cron: '0 0 * * 0'
 
 jobs:
   analyze:


### PR DESCRIPTION
## Restoring cron schedule that was pulled out in #718 

For now, we will leave the schedule on so the GitHub actions will trigger on every action to increase likelihood of hitting the bug.