### PR TITLE
filter out the noise password={anything} in regex

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -18,7 +18,7 @@
 - UER => Eliminate unhandled exceptions in rule.
 - UEE => Eliminate unhandled exceptions in engine.
 
-## v4.5.5 unreleased
+## v4.5.6 unreleased
 - FPC: Updated `SEC101/036.MySqlCredentials` and `SEC101/037.SqlCredentials` regular expression to exclude the text inside curly bracket for password detection. [#777](https://github.com/microsoft/sarif-pattern-matcher/pull/777)
 
 ## v4.5.4 6/25/2023

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -18,6 +18,9 @@
 - UER => Eliminate unhandled exceptions in rule.
 - UEE => Eliminate unhandled exceptions in engine.
 
+## v4.5.5 unreleased
+- FPC: Updated `SEC101/036.MySqlCredentials` and `SEC101/037.SqlCredentials` regular expression to exclude the text inside curly bracket for password detection. [#777](https://github.com/microsoft/sarif-pattern-matcher/pull/777)
+
 ## v4.5.4 6/25/2023
 - NEW: Allow for swapping regex engines (between `RE2`, `DotNet` and `CachedDotNet`) via `--engine` command-line argument and `RegexEngine` context property. [#776](https://github.com/microsoft/sarif-pattern-matcher/pull/776)
 

--- a/Src/Plugins/Security/Security.SharedStrings.txt
+++ b/Src/Plugins/Security/Security.SharedStrings.txt
@@ -104,7 +104,7 @@
   $SEC101/036.MySqlCredentialsAdoId=(?i)(?:user|user id|uid)\s*=\s*(?P<id>[^,;"'=|&\]\[><\s]+)(?:[,;"'=|&\]\[><\s]|$)
   $SEC101/036.MySqlCredentialsAdoHost=(?i)server\s*=\s*(tcp:)?(?P<host>[^,;"'=|\(\)\]\[><\s]+)(?:[,;"'=|\(\)\]\[><\s]|$)
   $SEC101/036.MySqlCredentialsAdoPort=(?i)port\s*=\s*(?P<port>[0-9]{4,5})(?:[^0-9]|$)
-  $SEC101/036.MySqlCredentialsAdoSecret=(?i)(?:password|pwd)\s*=\s*(?P<secret>[^;"<'\s]{8,128})(?:[;"<'\s]|$)
+  $SEC101/036.MySqlCredentialsAdoSecret=(?i)(?:password|pwd)\s*=\s*(?P<secret>[^{;"<'\s]{8,128})(?:[;"<'\s]|$)
   $SEC101/036.MySqlCredentialsAdoResource=(?i)database\s*=\s*(?P<resource>[^,;"'=|&\]\[><\s]{8,128})(?:[,;"'=|&\]\[><\s]|$)
   
   $SEC101/036.MySqlCredentialsPlainJdbc=(?:jdbc:mysql:\/\/(?P<host>[\w.:-]{1,131})?(?s).{1,200}(?-s))?DriverManager\.getConnection\(\s*(?P<url>[^,(?:]+),\s*"(?P<id>[\w@-]{1,200})",\s*"(?P<secret>[^"';<>=]{7,200})"
@@ -112,13 +112,13 @@
   $SEC101/037.SqlCredentialsJdbcId=(?i)user\s*=\s*(?P<id>[^@]+?)@[^;"<'\s]+(?:[;"<'\s]|$)
   $SEC101/037.SqlCredentialsJdbcHost=(?i)jdbc:sqlserver:\/\/(?P<host>[^:;"<'\s]+)(?:[:;"<'\s]|$)
   $SEC101/037.SqlCredentialsJdbcPort=(?i):\s*(?P<port>[0-9]{4,5})(?:[^0-9]|$)
-  $SEC101/037.SqlCredentialsJdbcSecret=(?i)password\s*=\s*(?P<secret>[^;"<'\s]+)(?:[;"<'\s]|$)
+  $SEC101/037.SqlCredentialsJdbcSecret=(?i)password\s*=\s*(?P<secret>[^{;"<'\s]+)(?:[;"<'\s]|$)
   $SEC101/037.SqlCredentialsJdbcResource=(?i)database\s*=\s*(?P<resource>[^;"<>*%&\/?'\s]+)(?:[;"<>*%&\/?'\s]|$)
 
   $SEC101/037.SqlCredentialsAdoId=(?i)(?:user id|uid)\s*=\s*(?P<id>[^;"<'\s]+)(?:[;"<'\s]|$)
   $SEC101/037.SqlCredentialsAdoHost=(?i)(?:server|data source)\s*=\s*(tcp:)?(?P<host>[^;,"<'\s]+)(?:[;,"<'\s]|$)
   $SEC101/037.SqlCredentialsAdoPort=(?i),\s*(?P<port>[0-9]{4,5})(?:[^0-9]|$)
-  $SEC101/037.SqlCredentialsAdoSecret=(?i)(?:password|pwd)\s*=\s*(?P<secret>[^;"<'\s]+)(?:[;"<'\s]|$)
+  $SEC101/037.SqlCredentialsAdoSecret=(?i)(?:password|pwd)\s*=\s*(?P<secret>[^{;"<'\s]+)(?:[;"<'\s]|$)
   $SEC101/037.SqlCredentialsAdoResource=(?i)(?:initial catalog|database)\s*=\s*(?P<resource>[^;"<>*%&:\/?'\s]+)(?:[;"<>*%&:\/?'\s]|$)
 
   $SEC101/037.SqlCredentialsPhp=(?i)sqlsrv:server\s*=\s*(tcp:)?(?P<host>[^,;"<]+)(?:,(?P<port>[0-9]{4,5}))?;\s*Database\s*=\s*(?P<resource>[^;"<>*%&:\/?\s]+)",\s*"(?P<id>[^"]+)",\s*"(?P<secret>[^"]+)"

--- a/Src/Plugins/Security/Security.SharedStrings.txt
+++ b/Src/Plugins/Security/Security.SharedStrings.txt
@@ -104,7 +104,7 @@
   $SEC101/036.MySqlCredentialsAdoId=(?i)(?:user|user id|uid)\s*=\s*(?P<id>[^,;"'=|&\]\[><\s]+)(?:[,;"'=|&\]\[><\s]|$)
   $SEC101/036.MySqlCredentialsAdoHost=(?i)server\s*=\s*(tcp:)?(?P<host>[^,;"'=|\(\)\]\[><\s]+)(?:[,;"'=|\(\)\]\[><\s]|$)
   $SEC101/036.MySqlCredentialsAdoPort=(?i)port\s*=\s*(?P<port>[0-9]{4,5})(?:[^0-9]|$)
-  $SEC101/036.MySqlCredentialsAdoSecret=(?i)(?:password|pwd)\s*=\s*(?P<secret>[^{;"<'\s]{8,128})(?:[;"<'\s]|$)
+  $SEC101/036.MySqlCredentialsAdoSecret=(?i)(?:password|pwd)\s*=\s*(?P<secret>[^\[\({;"<'\s]{8,128})(?:[;"<'\s]|$)
   $SEC101/036.MySqlCredentialsAdoResource=(?i)database\s*=\s*(?P<resource>[^,;"'=|&\]\[><\s]{8,128})(?:[,;"'=|&\]\[><\s]|$)
   
   $SEC101/036.MySqlCredentialsPlainJdbc=(?:jdbc:mysql:\/\/(?P<host>[\w.:-]{1,131})?(?s).{1,200}(?-s))?DriverManager\.getConnection\(\s*(?P<url>[^,(?:]+),\s*"(?P<id>[\w@-]{1,200})",\s*"(?P<secret>[^"';<>=]{7,200})"
@@ -112,13 +112,13 @@
   $SEC101/037.SqlCredentialsJdbcId=(?i)user\s*=\s*(?P<id>[^@]+?)@[^;"<'\s]+(?:[;"<'\s]|$)
   $SEC101/037.SqlCredentialsJdbcHost=(?i)jdbc:sqlserver:\/\/(?P<host>[^:;"<'\s]+)(?:[:;"<'\s]|$)
   $SEC101/037.SqlCredentialsJdbcPort=(?i):\s*(?P<port>[0-9]{4,5})(?:[^0-9]|$)
-  $SEC101/037.SqlCredentialsJdbcSecret=(?i)password\s*=\s*(?P<secret>[^{;"<'\s]+)(?:[;"<'\s]|$)
+  $SEC101/037.SqlCredentialsJdbcSecret=(?i)password\s*=\s*(?P<secret>[^\[\({;"<'\s]+)(?:[;"<'\s]|$)
   $SEC101/037.SqlCredentialsJdbcResource=(?i)database\s*=\s*(?P<resource>[^;"<>*%&\/?'\s]+)(?:[;"<>*%&\/?'\s]|$)
 
   $SEC101/037.SqlCredentialsAdoId=(?i)(?:user id|uid)\s*=\s*(?P<id>[^;"<'\s]+)(?:[;"<'\s]|$)
   $SEC101/037.SqlCredentialsAdoHost=(?i)(?:server|data source)\s*=\s*(tcp:)?(?P<host>[^;,"<'\s]+)(?:[;,"<'\s]|$)
   $SEC101/037.SqlCredentialsAdoPort=(?i),\s*(?P<port>[0-9]{4,5})(?:[^0-9]|$)
-  $SEC101/037.SqlCredentialsAdoSecret=(?i)(?:password|pwd)\s*=\s*(?P<secret>[^{;"<'\s]+)(?:[;"<'\s]|$)
+  $SEC101/037.SqlCredentialsAdoSecret=(?i)(?:password|pwd)\s*=\s*(?P<secret>[^\[\({;"<'\s]+)(?:[;"<'\s]|$)
   $SEC101/037.SqlCredentialsAdoResource=(?i)(?:initial catalog|database)\s*=\s*(?P<resource>[^;"<>*%&:\/?'\s]+)(?:[;"<>*%&:\/?'\s]|$)
 
   $SEC101/037.SqlCredentialsPhp=(?i)sqlsrv:server\s*=\s*(tcp:)?(?P<host>[^,;"<]+)(?:,(?P<port>[0-9]{4,5}))?;\s*Database\s*=\s*(?P<resource>[^;"<>*%&:\/?\s]+)",\s*"(?P<id>[^"]+)",\s*"(?P<secret>[^"]+)"
@@ -126,7 +126,7 @@
   $SEC101/038.PostgreSqlCredentialsAdoId=(?i)(?:username|user|uid|user id)\s*=\s*(?P<id>[^,;"'=|&\]\[><\s]{1,63})(?:[,;"'=|&\]\[><\s]|$)
   $SEC101/038.PostgreSqlCredentialsAdoHost=(?i)(?:host|server)\s*=\s*(?P<host>[^,;:"'=|\(\)\]\[><\s]{3,63})(?:[,;:"'=|\(\)\]\[><\s]|$)
   $SEC101/038.PostgreSqlCredentialsAdoPort=(?i)port\s*=\s*(?P<port>[0-9]{1,5})(?:[^0-9]|$)
-  $SEC101/038.PostgreSqlCredentialsAdoSecret=(?i)(?:password|pwd)\s*=\s*(?P<secret>[^,;"'<\s]{8,128})(?:[,;"'<\s]|$)
+  $SEC101/038.PostgreSqlCredentialsAdoSecret=(?i)(?:password|pwd)\s*=\s*(?P<secret>[^\[\({,;"'<\s]{8,128})(?:[,;"'<\s]|$)
   $SEC101/038.PostgreSqlCredentialsAdoResource=(?i)(?:database|db|dbname)\s*=\s*(?P<resource>[^,;"'=|&\]\[><\s]+)(?:[,;"'=|&\]\[><\s]|$)
 
   $SEC101/041.RabbitMqCredentials=(?i)amqps?:\/\/(?P<id>[^:"]+):(?P<secret>[^@\s]+)@(?P<host>[\w_\-\:]+)\/(?P<resource>[\w]+)(?:[^0-9a-z]|$)


### PR DESCRIPTION
## Changes

Minor regex change of rule 036 & 037 & 038 to filter out the noise of the following format: password=**{**anything**}** or password=**[**anything**]** or password=**(**anything**)**. 
Release record of FPC (Regex candidate reduction) is added.