### PR TITLE
Release/v4.5.5

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -21,7 +21,7 @@
 ## v4.5.5/26/2023
 - DEP: Update SARIF SDK submodule from [a7029a3 to b77e955](https://github.com/microsoft/sarif-sdk/compare/a7029a3..b77e955). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/b77e955/ReleaseHistory.md).
 - DEP: SARIF SDK update is for v4.2.1, resolves a key unhandled exception issue enumerating zip archives.
-- NEW: Provide `IronRE2` pattern matching `--engine` options.
+- NEW: Provide `IronRE2` pattern matching `--engine` options. [#778](https://github.com/microsoft/sarif-pattern-matcher/pull/778)
 
 ## v4.5.4 6/25/2023
 - NEW: Allow for swapping regex engines (between `RE2`, `DotNet` and `CachedDotNet`) via `--engine` command-line argument and `RegexEngine` context property. [#776](https://github.com/microsoft/sarif-pattern-matcher/pull/776)

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -18,6 +18,11 @@
 - UER => Eliminate unhandled exceptions in rule.
 - UEE => Eliminate unhandled exceptions in engine.
 
+## v4.5.5/26/2023
+- DEP: Update SARIF SDK submodule from [a7029a3 to b77e955](https://github.com/microsoft/sarif-sdk/compare/a7029a3..b77e955). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/b77e955/ReleaseHistory.md).
+- DEP: SARIF SDK update is for v4.2.1, resolves a key unhandled exception issue enumerating zip archives.
+- NEW: Provide `IronRE2` pattern matching `--engine` options.
+
 ## v4.5.4 6/25/2023
 - NEW: Allow for swapping regex engines (between `RE2`, `DotNet` and `CachedDotNet`) via `--engine` command-line argument and `RegexEngine` context property. [#776](https://github.com/microsoft/sarif-pattern-matcher/pull/776)
 
@@ -26,7 +31,7 @@
 - DEP: Update `SEC101/003.GoogleApiKey` in `Security` validating Google API key using HTTP requests.
 - DEP: Update `SEC101/008.AwsCredentials` in `Security` validating AWS credentials using HTTP requests.
 - DEP: Remove `AWSSDK.IdentityManagement` from `Security`.
-- DEP: Remove `GoogleApi` Nuget package from `Security`.
+- DEP: Remove `GoogleApi` NuGet package from `Security`.
 
 ## v4.5.1 5/31/2023
 - DEP: Update SARIF SDK submodule from [441fa8b to dd8b7b8](https://github.com/microsoft/sarif-sdk/compare/441fa8b..dd8b7b8). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/dd8b7b8/ReleaseHistory.md). Additional eventing work.

--- a/Src/Plugins/Security/Security.csproj
+++ b/Src/Plugins/Security/Security.csproj
@@ -61,9 +61,6 @@
       <BuildOutputInPackage Include="Octokit.dll">
         <FinalOutputPath>..\..\..\refs\Octokit.dll</FinalOutputPath>
       </BuildOutputInPackage>
-      <BuildOutputInPackage Include="aliyun-net-sdk-Iot.dll">
-        <FinalOutputPath>..\..\..\refs\aliyun-net-sdk-Iot.dll</FinalOutputPath>
-      </BuildOutputInPackage>
     </ItemGroup>
   </Target>
 

--- a/Src/Plugins/Tests.Security/EndToEndTests.cs
+++ b/Src/Plugins/Tests.Security/EndToEndTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
                 AnalyzeCommand.CreateSkimmersFromDefinitionsFiles(fileSystem,
                                                                   new string[] { regexDefinitionsPath },
                                                                   tool,
-                                                                  RE2Regex.Instance);
+                                                                  IronRE2Regex.Instance);
             return skimmers;
         }
 
@@ -176,7 +176,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 
                 using (context)
                 {
-                    ValidatorBase.RegexInstance = RE2Regex.Instance;
+                    ValidatorBase.RegexInstance = IronRE2Regex.Instance;
                     AnalyzeCommand.AnalyzeTargetHelper(context, skimmers, disabledSkimmers);
                 }
             }

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_008.AwsCredentialsValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_008.AwsCredentialsValidatorTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
             const string secret = "abc123";
             string fingerprintText = $"[id={id}][secret={secret}]";
 
-            ValidatorBase.RegexInstance = RE2Regex.Instance;
+            ValidatorBase.RegexInstance = IronRE2Regex.Instance;
             var awsCredentialsValidator = new AwsCredentialsValidator();
 
             using var requestWithToken = new HttpRequestMessage(HttpMethod.Post, uri);

--- a/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_037.SqlCredentialsValidatorTests.cs
+++ b/Src/Plugins/Tests.Security/SecurePlaintextSecretsValidators/SEC101_037.SqlCredentialsValidatorTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security.Validator
             var fingerprint = new Fingerprint(fingerprintText);
             var keyValuePairs = new Dictionary<string, string>();
 
-            ValidatorBase.RegexInstance = RE2Regex.Instance;
+            ValidatorBase.RegexInstance = IronRE2Regex.Instance;
             var sqlCredentialsValidator = new SqlCredentialsValidator();
             ValidationState actualValidationState = sqlCredentialsValidator.IsValidDynamic(ref fingerprint,
                                                                                            ref message,

--- a/Src/RE2.Managed/IronRE2Regex.cs
+++ b/Src/RE2.Managed/IronRE2Regex.cs
@@ -1,0 +1,170 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+using IronRe2;
+
+using Microsoft.Strings.Interop;
+
+namespace Microsoft.RE2.Managed
+{
+    public class IronRE2Regex : IRegex
+    {
+        public static IronRE2Regex Instance = new IronRE2Regex();
+        public static TimeSpan DefaultTimeout = TimeSpan.FromMilliseconds(int.MaxValue - 1);
+
+        static IronRE2Regex()
+        {
+            RegexCache = new ConcurrentDictionary<Tuple<string, System.Text.RegularExpressions.RegexOptions>, Regex>();
+        }
+
+        private IronRE2Regex()
+        {
+        }
+
+        private static ConcurrentDictionary<Tuple<string, System.Text.RegularExpressions.RegexOptions>, Regex> RegexCache { get; }
+
+        public static Regex GetOrCreateRegex(string pattern, System.Text.RegularExpressions.RegexOptions dotnetRegexOptions)
+        {
+            Options options = ToOptions(dotnetRegexOptions);
+            var key = Tuple.Create(pattern, dotnetRegexOptions);
+            return RegexCache.GetOrAdd(key, _ => new Regex(pattern, options));
+        }
+
+        public bool IsMatch(FlexString input,
+                            string pattern,
+                            System.Text.RegularExpressions.RegexOptions regexOptions = 0,
+                            TimeSpan timeout = default,
+                            string captureGroup = null)
+        {
+            var tuple = new Tuple<string, System.Text.RegularExpressions.RegexOptions>(pattern, regexOptions);
+            Regex regex = GetOrCreateRegex(pattern, regexOptions);
+            Match match = regex.Find(input.String8.Array);
+            return match.Matched;
+        }
+
+        private static Options ToOptions(System.Text.RegularExpressions.RegexOptions dotNetRegexOptions, long maxMemoryInBytes = 256L * 1024L * 1024L)
+        {
+            bool multiline = dotNetRegexOptions.HasFlag(System.Text.RegularExpressions.RegexOptions.Multiline);
+            bool dotNewline = dotNetRegexOptions.HasFlag(System.Text.RegularExpressions.RegexOptions.Singleline);
+            bool ignoreCase = dotNetRegexOptions.HasFlag(System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+
+            return new Options
+            {
+                CaseSensitive = !ignoreCase,
+                DotNewline = dotNewline,
+                OneLine = !multiline,
+                MaxMemory = maxMemoryInBytes,
+            };
+        }
+
+        public FlexMatch Match(FlexString input,
+                               string pattern,
+                               System.Text.RegularExpressions.RegexOptions regexOptions = 0,
+                               TimeSpan timeout = default,
+                               string captureGroup = null)
+        {
+            var tuple = new Tuple<string, System.Text.RegularExpressions.RegexOptions>(pattern, regexOptions);
+            Regex regex = GetOrCreateRegex(pattern, regexOptions);
+            Match match = regex.Find(input.String8.Array);
+
+            int lastUtf8Index = 0;
+            int lastUtf16Index = 0;
+            return ToFlex(match, input, ref lastUtf8Index, ref lastUtf16Index);
+        }
+
+        public IEnumerable<FlexMatch> Matches(FlexString input,
+                                              string pattern,
+                                              System.Text.RegularExpressions.RegexOptions regexOptions = 0,
+                                              TimeSpan timeout = default,
+                                              string captureGroup = null)
+        {
+            Timeout t =
+                timeout == default
+                    ? Timeout.Unlimited
+            : Timeout.Start(timeout);
+
+            var tuple = new Tuple<string, System.Text.RegularExpressions.RegexOptions>(pattern, regexOptions);
+            Regex regex = GetOrCreateRegex(pattern, regexOptions);
+
+            int lastUtf8Index = 0;
+            int lastUtf16Index = 0;
+
+            int index = 0;
+            while (index < input.String8.Array.Length)
+            {
+                Match match = regex.Find(input.String8.Array, index);
+                if (!match.Matched) { yield break; }
+                index = (int)match.Start + 1;
+                yield return ToFlex(match, input, ref lastUtf8Index, ref lastUtf16Index);
+            }
+        }
+
+        public FlexMatch ToFlex(Match match, FlexString input, ref int lastUtf8Index, ref int lastUtf16Index)
+        {
+            if (!match.Matched) { return new FlexMatch() { Success = false, Index = -1, Length = -1, Value = null }; }
+
+            // Map the UTF-8 index to UTF-16
+            int mappedIndex = String8.Utf8ToUtf16((int)match.Start, input, lastUtf8Index, lastUtf16Index);
+            lastUtf8Index = (int)match.Start;
+            lastUtf16Index = mappedIndex;
+
+            // Map the length to UTF-16
+            int mappedEnd = String8.Utf8ToUtf16((int)(match.Start + match.ExtractedText.Length), input, lastUtf8Index, lastUtf16Index);
+            int mappedLength = mappedEnd - mappedIndex;
+
+            // Return the UTF-16 indices but the UTF-8 derived value
+            return new FlexMatch() { Success = true, Index = mappedIndex, Length = mappedLength, Value = match.ExtractedText };
+        }
+
+        public bool Matches(string pattern, string text, out List<Dictionary<string, FlexMatch>> groupedMatches, long maxMemoryInBytes = 256L * 1024L * 1024L)
+        {
+            groupedMatches = new List<Dictionary<string, FlexMatch>>();
+            var captures = new List<Captures>();
+
+            var tuple = new Tuple<string, System.Text.RegularExpressions.RegexOptions>(pattern, 0);
+            Regex regex = GetOrCreateRegex(pattern, 0);
+
+            byte[] bytes = null;
+            var string8 = String8.Convert(text, ref bytes);
+
+            int index = 0;
+
+            while (index < string8.Array.Length)
+            {
+                Captures capture = regex.Captures(string8.Array, index);
+                if (!capture.Matched) { break; }
+                index = (int)capture.Start + 1;
+                captures.Add(capture);
+            }
+
+            foreach (Captures capture in captures)
+            {
+                var current = new Dictionary<string, FlexMatch>(capture.Count);
+
+                Match match;
+
+                int lastUtf8Index = 0;
+                int lastUtf16Index = 0;
+
+                match = capture[0];
+                current["0"] = ToFlex(match, text, ref lastUtf8Index, ref lastUtf16Index);
+
+                foreach (NamedCaptureGroup namedCaptureGroup in regex.NamedCaptures())
+                {
+                    int cIndex = regex.FindNamedCapture(namedCaptureGroup.Name);
+                    match = capture[cIndex];
+                    string groupValue = capture[cIndex].ExtractedText;
+                    current[namedCaptureGroup.Name] = ToFlex(match, text, ref lastUtf8Index, ref lastUtf16Index);
+                }
+
+                groupedMatches.Add(current);
+            }
+
+            return captures.Count > 0;
+        }
+    }
+}

--- a/Src/RE2.Managed/RE2.Managed.csproj
+++ b/Src/RE2.Managed/RE2.Managed.csproj
@@ -46,6 +46,10 @@
     <None Include="RE2.Managed.targets" Pack="true" PackagePath="build\" />
     <None Include="RE2.LICENSE.txt" Pack="true" PackagePath="content\" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="IronRe2" Version="2.0.0" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Strings.Interop\Strings.Interop.csproj" />

--- a/Src/RE2.Managed/RE2.Managed.csproj
+++ b/Src/RE2.Managed/RE2.Managed.csproj
@@ -34,15 +34,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <PackagePath>runtimes/win-x64/native</PackagePath>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\refs\runtimes\linux-x64\native\libre2.so" Pack="true" Link="runtimes/linux-x64/native/libre2.so">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <PackagePath>runtimes/win-x64/native</PackagePath>
-    </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\refs\runtimes\linux-x86\native\libre2.so" Pack="true" Link="runtimes/linux-x86/native/libre2.so">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <PackagePath>runtimes/win-x64/native</PackagePath>
-    </Content>
-
     <None Include="RE2.Managed.targets" Pack="true" PackagePath="build\" />
     <None Include="RE2.LICENSE.txt" Pack="true" PackagePath="content\" />
   </ItemGroup>

--- a/Src/RE2.Managed/RE2Regex.cs
+++ b/Src/RE2.Managed/RE2Regex.cs
@@ -47,7 +47,7 @@ namespace Microsoft.RE2.Managed
             }
         }
 
-        public bool Matches(string pattern, string text, out List<Dictionary<string, FlexMatch>> matches, long maxMemoryInBytes = -1)
+        public bool Matches(string pattern, string text, out List<Dictionary<string, FlexMatch>> matches, long maxMemoryInBytes = 256L * 1024L * 1024L)
         {
             var textToRE2DataMap = new Dictionary<string, Tuple<String8, byte[], int[]>>();
             return Regex2.Matches(pattern, text, out matches, ref textToRE2DataMap, maxMemoryInBytes);

--- a/Src/RE2.Managed/Regex2.cs
+++ b/Src/RE2.Managed/Regex2.cs
@@ -302,7 +302,7 @@ namespace Microsoft.RE2.Managed
                             else
                             {
                                 // GetMapOfUtf8ToUtf16ByteIndices is an expensive call and now is only called
-                                // when absolutely neccessary.
+                                // when absolutely necessary.
                                 // Was previously called everytime, regardless of if there was a match or not.
 
                                 if (indexMap == null)

--- a/Src/Sarif.PatternMatcher.Benchmark/Benchmarks/AnalyzeCommandBenchmarks.cs
+++ b/Src/Sarif.PatternMatcher.Benchmark/Benchmarks/AnalyzeCommandBenchmarks.cs
@@ -55,6 +55,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Benchmark.Benchmarks
             AnalyzeCommand(RE2Regex.Instance);
         }
 
+        [Benchmark]
+        public void AnalyzeCommand_SimpleAnalysisIronRE2()
+        {
+            AnalyzeCommand(IronRE2Regex.Instance);
+        }
+
         private static SearchDefinitions CreateDefinitions(int count)
         {
             var searchDefinitions = new SearchDefinitions()

--- a/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeCommand.cs
@@ -423,6 +423,11 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 {
                     return CachedDotNetRegex.Instance;
                 }
+
+                case RegexEngine.IronRE2:
+                {
+                    return IronRE2Regex.Instance;
+                }
             }
 
             throw new InvalidOperationException($"Unhandled regex engine value: {regexEngine}");

--- a/Src/Sarif.PatternMatcher/AnalyzeContext.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeContext.cs
@@ -3,6 +3,7 @@
 #pragma warning disable SA1117 // Parameters should be on same line or separate line.
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 using Microsoft.CodeAnalysis.Sarif.Driver;
 using Microsoft.Strings.Interop;
@@ -112,8 +113,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
         public static PerLanguageOption<RegexEngine> RegexEngineProperty =>
             new PerLanguageOption<RegexEngine>(
-                "CoreSettings", nameof(RegexEngine), defaultValue: () => RegexEngine.RE2,
-                "The pattern matching to use for scanning. One of RE2, DotNet, CachedDotNet or IronRE2.");
+                "CoreSettings", nameof(RegexEngine), defaultValue: () => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? RegexEngine.RE2 : RegexEngine.CachedDotNet,
+                "The pattern matching to use for scanning. One of RE2 (Windows default), DotNet, CachedDotNet (Linux default) or IronRE2.");
 
         public static PerLanguageOption<string> SniffRegexProperty =>
             new PerLanguageOption<string>(

--- a/Src/Sarif.PatternMatcher/AnalyzeContext.cs
+++ b/Src/Sarif.PatternMatcher/AnalyzeContext.cs
@@ -113,8 +113,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
         public static PerLanguageOption<RegexEngine> RegexEngineProperty =>
             new PerLanguageOption<RegexEngine>(
-                "CoreSettings", nameof(RegexEngine), defaultValue: () => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? RegexEngine.RE2 : RegexEngine.CachedDotNet,
-                "The pattern matching to use for scanning. One of RE2 (Windows default), DotNet, CachedDotNet (Linux default) or IronRE2.");
+                "CoreSettings", nameof(RegexEngine), defaultValue: () => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? RegexEngine.RE2 : RegexEngine.IronRE2,
+                "The pattern matching to use for scanning. One of RE2 (Windows default), DotNet, CachedDotNet or IronRE2 (Linux default).");
 
         public static PerLanguageOption<string> SniffRegexProperty =>
             new PerLanguageOption<string>(

--- a/Src/Sarif.PatternMatcher/CachedDotNetRegex.cs
+++ b/Src/Sarif.PatternMatcher/CachedDotNetRegex.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
 
-using Microsoft.Extensions.FileSystemGlobbing.Internal;
 using Microsoft.RE2.Managed;
 using Microsoft.Strings.Interop;
 

--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -1244,10 +1244,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
         {
             var re2regex = _engine as RE2Regex;
 
-            long maxMemoryInKB =
-                context.MaxMemoryInKilobytes == -1
-                    ? context.MaxMemoryInKilobytes
-                    : 1024 * context.MaxMemoryInKilobytes;
+            long maxMemoryInBytes = 1024 * context.MaxMemoryInKilobytes;
 
             if (re2regex != null)
             {
@@ -1255,13 +1252,13 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                                         searchText,
                                         out matches,
                                         ref context.TextToRE2DataMap,
-                                        maxMemoryInKB);
+                                        maxMemoryInBytes);
             }
 
             return _engine.Matches(contentsRegex,
                                    searchText,
                                    out matches,
-                                   maxMemoryInKB);
+                                   maxMemoryInBytes);
         }
 
         private void ConstructResultAndLogForContentsRegex(FlexMatch binary64DecodedMatch,

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/AnalyzeCommandTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/AnalyzeCommandTests.cs
@@ -573,6 +573,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 RE2Regex.Instance,
                 DotNetRegex.Instance,
                 CachedDotNetRegex.Instance,
+                IronRE2Regex.Instance,
             };
 
             foreach (IRegex regex in regexList)
@@ -588,7 +589,8 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             {
                 DotNetRegex.Instance,
                 CachedDotNetRegex.Instance,
-                RE2Regex.Instance
+                RE2Regex.Instance,
+                IronRE2Regex.Instance,
             };
 
             foreach (IRegex regex in regexList)
@@ -640,7 +642,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 mockFileSystem.Object,
                 new string[] { searchDefinitionsPath },
                 tool,
-                RE2Regex.Instance);
+                IronRE2Regex.Instance);
 
             string scanTargetFileName = Path.Combine(@"C:\", Guid.NewGuid().ToString() + ".test");
             FlexString fileContents = "bar foo foo";

--- a/Targets/build.common.props
+++ b/Targets/build.common.props
@@ -51,7 +51,7 @@
   </PropertyGroup>
 	
   <ItemGroup Label="Common Packages">
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "4.5.4",
+  "version": "4.5.5",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+\\.\\d+\\.\\d+$"


### PR DESCRIPTION
This change enables IronRE2 as an option, running on Windows *or* Linux environments.

We now run IronRE2 for many end-to-end tests, so the behavior looks identical.

With recent ETW work we can easily test this on some real-world tests. We should also rerun the benchmark tests we authored previously.