### PR TITLE
Update SARIF SDK to dd3741f to enable improved xplat testing.

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -17,7 +17,10 @@
 - FND => False negative reduction in dynamic analysis.
 - UER => Eliminate unhandled exceptions in rule.
 - UEE => Eliminate unhandled exceptions in engine.
-- 
+
+## v4.5.8 UNRELEASED
+- DEP: Update SARIF SDK submodule from [7e8def7 to dd3741f(https://github.com/microsoft/sarif-sdk/compare/7e8def7..dd3741f). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/dd3741f/ReleaseHistory.md).
+
 ## v4.5.7 6/28/2023
 - DEP: Update SARIF SDK submodule from [a7029a3 to 7e8def7(https://github.com/microsoft/sarif-sdk/compare/a7029a3..7e8def7). [Full SARIF SDK release history](https://github.com/microsoft/sarif-sdk/blob/7e8def7/ReleaseHistory.md).
 

--- a/Src/Plugins/Security/Security.csproj
+++ b/Src/Plugins/Security/Security.csproj
@@ -50,14 +50,6 @@
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);GetMyPackageFiles</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
 
-  <Target Name="GetMyPackageFiles">
-    <ItemGroup>
-      <BuildOutputInPackage Include="Octokit.dll">
-        <FinalOutputPath>..\..\..\refs\Octokit.dll</FinalOutputPath>
-      </BuildOutputInPackage>
-    </ItemGroup>
-  </Target>
-
   <Target Name="CopyingSecurityToSpam" AfterTargets="Build">
 
     <ItemGroup>


### PR DESCRIPTION
This change updates SARIF SDK module strictly to avoid test failures between net452 and netstandard 2.0 runs. No product changes.