### PR TITLE
Provide stable id look-up for validators.

### DIFF
--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -18,6 +18,9 @@
 - UER => Eliminate unhandled exceptions in rule.
 - UEE => Eliminate unhandled exceptions in engine.
 
+## v4.3.18 (dev branch) 7/26/2023
+- BRK: Add a descriptor that tags a rule with its stable Id. Update validator retrieval logic to operate against stable rule Id rather than rule name.
+
 ## v4.3.17 (dev branch) 7/18/2023
 - BRK: Disable `SEC101/047.CratesApiKey`. Current dynamic validator returns status code 200 to all tokens. No API endpoint seems to return different status codes to distinguish between valid and invalid API keys
 

--- a/Src/Plugins/AzureDevOpsConfiguration/ServiceConnectionSecurityValidators/AZC102_190.DoNotGrantAllPipelinesAccessValidator.cs
+++ b/Src/Plugins/AzureDevOpsConfiguration/ServiceConnectionSecurityValidators/AZC102_190.DoNotGrantAllPipelinesAccessValidator.cs
@@ -17,6 +17,7 @@ using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.AzureDevOpsConfiguration
 {
+    [ValidatorDescriptor("AZC102/190")]
     public class DoNotGrantAllPipelinesAccessValidator : DynamicValidatorBase
     {
         internal const string NotAuthorizedMessage = "Not able to access required ADO API to check.";

--- a/Src/Plugins/Security/ReviewPotentiallySensitiveDataValidators/SEC102_001.EmailAddressValidator.cs
+++ b/Src/Plugins/Security/ReviewPotentiallySensitiveDataValidators/SEC102_001.EmailAddressValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -9,6 +9,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC102/001")]
     public class EmailAddressValidator : StaticValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/ReviewPotentiallySensitiveFilesValidators/SEC103_017.PfxCryptographicKeyfileValidator.cs
+++ b/Src/Plugins/Security/ReviewPotentiallySensitiveFilesValidators/SEC103_017.PfxCryptographicKeyfileValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -12,6 +12,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC103/017")]
     public class PfxCryptographicKeyfileValidator : StaticValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/ReviewPotentiallySensitiveFilesValidators/SEC103_024.MicrosoftSerializedCertificateStoreFileValidator.cs
+++ b/Src/Plugins/Security/ReviewPotentiallySensitiveFilesValidators/SEC103_024.MicrosoftSerializedCertificateStoreFileValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -9,6 +9,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC103/024")]
     public class MicrosoftSerializedCertificateStoreFileValidator : StaticValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SEC102_003.UrlValidator.cs
+++ b/Src/Plugins/Security/SEC102_003.UrlValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -9,6 +9,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC102/003")]
     public class UrlValidator : StaticValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_001.HttpAuthorizationRequestHeaderValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_001.HttpAuthorizationRequestHeaderValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -12,6 +12,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/001")]
     public class HttpAuthorizationRequestHeaderValidator : DynamicValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_002.GoogleOAuthCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_002.GoogleOAuthCredentialsValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -8,6 +8,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/002")]
     public class GoogleOAuthCredentialsValidator : StaticValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_003.GoogleApiKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_003.GoogleApiKeyValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -13,6 +13,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/003")]
     public class GoogleApiKeyValidator : DynamicValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_004.FacebookAppCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_004.FacebookAppCredentialsValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -12,6 +12,7 @@ using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/004")]
     public class FacebookAppCredentialsValidator : DynamicValidatorBase
     {
         internal const string AccountInformationUri = "https://graph.facebook.com/{0}?access_token={1}";

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_005.SlackApiKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_005.SlackApiKeyValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -13,6 +13,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/005")]
     public class SlackApiKeyValidator : DynamicValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_006.GitHubLegacyPatValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_006.GitHubLegacyPatValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -13,6 +13,7 @@ using Octokit.Internal;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/006")]
     public class GitHubLegacyPatValidator : DynamicValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_007.GitHubAppCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_007.GitHubAppCredentialsValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -12,6 +12,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/007")]
     public class GitHubAppCredentialsValidator : DynamicValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_008.AwsCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_008.AwsCredentialsValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -12,6 +12,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/008")]
     public class AwsCredentialsValidator : DynamicValidatorBase
     {
         internal static IRegex RegexEngine;

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_009.LinkedInCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_009.LinkedInCredentialsValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -8,6 +8,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/009")]
     public class LinkedInCredentialsValidator : StaticValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_010.SquarePatValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_010.SquarePatValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -12,6 +12,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/010")]
     public class SquarePatValidator : DynamicValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_011.SquareCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_011.SquareCredentialsValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -11,6 +11,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/011")]
     public class SquareCredentialsValidator : DynamicValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_012.SlackWebhookValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_012.SlackWebhookValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -12,6 +12,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/012")]
     public class SlackWebhookValidator : DynamicValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_013.CryptographicPrivateKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_013.CryptographicPrivateKeyValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -15,6 +15,7 @@ using Org.BouncyCastle.Bcpg.OpenPgp;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/013")]
     public class CryptographicPrivateKeyValidator : StaticValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_014.FacebookAccessTokenValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_014.FacebookAccessTokenValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -8,6 +8,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/014")]
     public class FacebookAccessTokenValidator : StaticValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_015.AkamaiCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_015.AkamaiCredentialsValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -12,6 +12,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/015")]
     public class AkamaiCredentialsValidator : DynamicValidatorBase
     {
         internal static HttpRequestMessage GenerateRequestMessage(string id,

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_016.StripeApiKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_016.StripeApiKeyValidator.cs
@@ -1,8 +1,11 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/016")]
     public class StripeApiKeyValidator : StripeApiKeyValidatorBase
     {
     }

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_017.NpmLegacyAuthorTokenValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_017.NpmLegacyAuthorTokenValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -9,6 +9,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/017")]
     public class NpmLegacyAuthorTokenValidator : DynamicValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_018.TwilioCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_018.TwilioCredentialsValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -13,6 +13,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/018")]
     public class TwilioCredentialsValidator : DynamicValidatorBase
     {
         internal const string TestCredentialMessage = "Resource not accessible with Test Account Credentials";

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_019.PicaticApiKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_019.PicaticApiKeyValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -8,6 +8,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/019")]
     public class PicaticApiKeyValidator : StaticValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_020.DropboxAccessTokenValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_020.DropboxAccessTokenValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -12,6 +12,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/020")]
     public class DropboxAccessTokenValidator : DynamicValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_021.DropboxAppCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_021.DropboxAppCredentialsValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -13,6 +13,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/021")]
     public class DropboxAppCredentialsValidator : DynamicValidatorBase
     {
         internal const string Uri = "https://content.dropboxapi.com/2/files/get_thumbnail_v2";

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_022.PayPalBraintreeAccessTokenValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_022.PayPalBraintreeAccessTokenValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -8,6 +8,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/022")]
     public class PayPalBraintreeAccessTokenValidator : StaticValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_023.AmazonMwsAuthTokenValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_023.AmazonMwsAuthTokenValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -8,6 +8,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/023")]
     public class AmazonMwsAuthTokenValidator : StaticValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_024.TwilioApiKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_024.TwilioApiKeyValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -8,6 +8,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/024")]
     public class TwilioApiKeyValidator : StaticValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_025.SendGridApiKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_025.SendGridApiKeyValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -14,6 +14,7 @@ using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/025")]
     public class SendGridApiKeyValidator : DynamicValidatorBase
     {
         internal const string ApiUri = "https://api.sendgrid.com/v3/scopes";

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_026.MailgunApiCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_026.MailgunApiCredentialsValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -13,6 +13,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/026")]
     public class MailgunApiCredentialsValidator : DynamicValidatorBase
     {
         internal static HttpRequestMessage GenerateRequestMessage(string id, string secret, string scanIdentityGuid)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_027.MailChimpApiKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_027.MailChimpApiKeyValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -14,6 +14,7 @@ using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/027")]
     public class MailChimpApiKeyValidator : DynamicValidatorBase
     {
         internal const string ApiUri = "https://{0}.api.mailchimp.com/3.0/?fields=account_name";

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_028.PlaintextPasswordValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_028.PlaintextPasswordValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -8,6 +8,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/028")]
     public class PlaintextPasswordValidator : StaticValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_029.AlibabaCloudCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_029.AlibabaCloudCredentialsValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -11,6 +11,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/029")]
     public class AlibabaCloudCredentialsValidator : DynamicValidatorBase
     {
         internal static string UriTemplate = "https://ecs.aliyuncs.com/";

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_030.GoogleServiceAccountKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_030.GoogleServiceAccountKeyValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -8,6 +8,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/030")]
     public class GoogleServiceAccountKeyValidator : StaticValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_031.NuGetApiKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_031.NuGetApiKeyValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -8,6 +8,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/031")]
     public class NuGetApiKeyValidator : StaticValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_032.GpgCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_032.GpgCredentialsValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -8,6 +8,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/032")]
     public class GpgCredentialsValidator : StaticValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_033.MongoDbCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_033.MongoDbCredentialsValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -8,6 +8,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/033")]
     public class MongoDbCredentialsValidator : StaticValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_034.CredentialObjectValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_034.CredentialObjectValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -8,6 +8,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/034")]
     public class CredentialObjectValidator : StaticValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_035.CloudantCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_035.CloudantCredentialsValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -11,6 +11,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/035")]
     public class CloudantCredentialsValidator : DynamicValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_036.MySqlCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_036.MySqlCredentialsValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -13,6 +13,7 @@ using MySqlConnector;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/036")]
     public class MySqlCredentialsValidator : DynamicValidatorBase
     {
         private static readonly HashSet<string> HostsToExclude = new HashSet<string>

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_037.SqlCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_037.SqlCredentialsValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -11,6 +11,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/037")]
     public class SqlCredentialsValidator : DynamicValidatorBase
     {
         internal static IRegex RegexEngine;

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_038.PostgreSqlCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_038.PostgreSqlCredentialsValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -14,6 +14,7 @@ using Npgsql;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/038")]
     public class PostgreSqlCredentialsValidator : DynamicValidatorBase
     {
         private const string PublicNetworkDisabled = "The public network access on this server is disabled";

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_039.ShopifyAccessTokenValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_039.ShopifyAccessTokenValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -8,6 +8,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/039")]
     public class ShopifyAccessTokenValidator : StaticValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_040.ShopifySharedSecretValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_040.ShopifySharedSecretValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -8,6 +8,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/040")]
     public class ShopifySharedSecretValidator : StaticValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_041.RabbitMqCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_041.RabbitMqCredentialsValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -12,6 +12,7 @@ using RabbitMQ.Client;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/041")]
     public class RabbitMqCredentialsValidator : DynamicValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_042.DynatraceTokenValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_042.DynatraceTokenValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -8,6 +8,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/042")]
     public class DynatraceTokenValidator : StaticValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_043.NuGetCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_043.NuGetCredentialsValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -16,6 +16,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/043")]
     public class NuGetCredentialsValidator : DynamicValidatorBase
     {
         internal const string RandomGuid = "05C89BF5-9DF2-4F8C-8F93-FF3EF66E643D";

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_044.NpmCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_044.NpmCredentialsValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -13,6 +13,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/044")]
     public class NpmCredentialsValidator : DynamicValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_045.PostmanApiKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_045.PostmanApiKeyValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -11,6 +11,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/045")]
     public class PostmanApiKeyValidator : DynamicValidatorBase
     {
         internal const string Uri = "https://api.getpostman.com/me";

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_046.DiscordApiCredentialsValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_046.DiscordApiCredentialsValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -13,6 +13,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/046")]
     public class DiscordApiCredentialsValidator : DynamicValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_047.CratesApiKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_047.CratesApiKeyValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -11,6 +11,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/047")]
     public class CratesApiKeyValidator : StaticValidatorBase
     {
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_048.SlackWorkflowKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_048.SlackWorkflowKeyValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -11,6 +11,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/048")]
     public class SlackWorkflowKeyValidator : DynamicValidatorBase
     {
         internal const string WorkflowUri = "https://hooks.slack.com/workflows/{0:id}/{1:secret}";

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_049.TelegramBotTokenValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_049.TelegramBotTokenValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -13,6 +13,7 @@ using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/049")]
     public class TelegramBotTokenValidator : DynamicValidatorBase
     {
         // https://core.telegram.org/bots/api#getme

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_050.NpmIdentifiableAuthorTokenValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_050.NpmIdentifiableAuthorTokenValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -10,6 +10,7 @@ using Microsoft.Security.Utilities;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/050")]
     public class NpmIdentifiableAuthorTokenValidator : DynamicValidatorBase
     {
         private readonly CustomAlphabetEncoder encoder = new CustomAlphabetEncoder();

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_051.StripeTestApiKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_051.StripeTestApiKeyValidator.cs
@@ -1,8 +1,11 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/051")]
     public class StripeTestApiKeyValidator : StripeApiKeyValidatorBase
     {
     }

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_052.StripeLiveRestrictedKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_052.StripeLiveRestrictedKeyValidator.cs
@@ -1,8 +1,11 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/052")]
     public class StripeLiveRestrictedApiKeyValidator : StripeApiKeyValidatorBase
     {
     }

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_053.StripeTestRestrictedApiKeyValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_053.StripeTestRestrictedApiKeyValidator.cs
@@ -1,8 +1,11 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/053")]
     public class StripeTestRestrictedApiKeyValidator : StripeApiKeyValidatorBase
     {
     }

--- a/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_102.AdoPatValidator.cs
+++ b/Src/Plugins/Security/SecurePlaintextSecretsValidators/SEC101_102.AdoPatValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -9,6 +9,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Plugins.Security
 {
+    [ValidatorDescriptor("SEC101/102")]
     public class AdoPatValidator : StaticValidatorBase
     {
         /// <summary>

--- a/Src/Sarif.PatternMatcher.Cli/ExportRulesMetatadaCommand.cs
+++ b/Src/Sarif.PatternMatcher.Cli/ExportRulesMetatadaCommand.cs
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli
 
                             if (!string.IsNullOrEmpty(match.Name))
                             {
-                                staticValidator = ValidatorsCache.GetValidationMethods(match.Name, validators.RuleNameToValidationMethods);
+                                staticValidator = ValidatorsCache.GetValidationMethods(match.Name, validators.RuleIdToValidationMethods);
                             }
 
                             string deprecatedNameContent = hasOneOrMoreDeprecatedRuleNames ?

--- a/Src/Sarif.PatternMatcher.Sdk/ValidatorDescriptorAttribute.cs
+++ b/Src/Sarif.PatternMatcher.Sdk/ValidatorDescriptorAttribute.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk
+{
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+    public class ValidatorDescriptorAttribute : Attribute
+    {
+        public ValidatorDescriptorAttribute(string id)
+        {
+            Id = id;
+        }
+
+        public string Id { get; set; }
+    }
+}

--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -888,8 +888,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             if (_validators != null && matchExpression.IsValidatorEnabled)
             {
                 string filePath = context.CurrentTarget.Uri.GetFilePath();
-                string ruleName = matchExpression.Name ?? reportingDescriptor.Name;
-                IEnumerable<ValidationResult> validationResults = _validators.Validate(ruleName,
+                IEnumerable<ValidationResult> validationResults = _validators.Validate(matchExpression.Id,
                                                                                        context,
                                                                                        mergedGroups,
                                                                                        groups,
@@ -1204,8 +1203,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             if (_validators != null && matchExpression.IsValidatorEnabled)
             {
                 groups["scanTargetFullPath"] = new FlexMatch() { Value = filePath };
-                string ruleName = matchExpression.Name ?? reportingDescriptor.Name;
-                IEnumerable<ValidationResult> validationResults = _validators.Validate(ruleName,
+                IEnumerable<ValidationResult> validationResults = _validators.Validate(matchExpression.Id,
                                                                                        context,
                                                                                        groups,
                                                                                        out bool pluginSupportsDynamicValidation);

--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -991,8 +991,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
                 if (_validators != null && matchExpression.IsValidatorEnabled)
                 {
-                    string ruleName = matchExpression.Name ?? reportingDescriptor.Name;
-                    IEnumerable<ValidationResult> validationResults = _validators.Validate(ruleName,
+                    IEnumerable<ValidationResult> validationResults = _validators.Validate(reportingDescriptor.Id,
                                                                                            context,
                                                                                            match,
                                                                                            out bool pluginSupportsDynamicValidation);

--- a/Src/Sarif.PatternMatcher/ValidatingVisitor.cs
+++ b/Src/Sarif.PatternMatcher/ValidatingVisitor.cs
@@ -39,14 +39,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
             ReportingDescriptor rule = node.GetRule(_run);
 
             StaticValidatorBase staticValidator =
-                ValidatorsCache.GetValidationMethods(rule.Name, _validators.RuleNameToValidationMethods);
-
-            if (staticValidator == null)
-            {
-                string name = rule.Name.Replace("ConnectionString", "Credentials");
-                name = name.Replace("Secret", "Credentials");
-                staticValidator = ValidatorsCache.GetValidationMethods(name, _validators.RuleNameToValidationMethods);
-            }
+                ValidatorsCache.GetValidationMethods(rule.Id, _validators.RuleIdToValidationMethods);
 
             if (staticValidator is DynamicValidatorBase dynamicValidator)
             {

--- a/Src/Sarif.PatternMatcher/ValidatorsCache.cs
+++ b/Src/Sarif.PatternMatcher/ValidatorsCache.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                                   out pluginCanPerformDynamicAnalysis);
         }
 
-        public IEnumerable<ValidationResult> Validate(string ruleName,
+        public IEnumerable<ValidationResult> Validate(string ruleId,
                                                       AnalyzeContext context,
                                                       IDictionary<string, ISet<FlexMatch>> mergedGroups,
                                                       IList<IDictionary<string, FlexMatch>> combinations,
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 }
 
                 foreach (ValidationResult result in ValidateHelper(RuleIdToValidationMethods,
-                                                                   ruleName,
+                                                                   ruleId,
                                                                    context,
                                                                    groups,
                                                                    out pluginCanPerformDynamicAnalysis))

--- a/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/TestValidators/StaticAndDynamicValidatorsExistForMatchExpressionValidator.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/TestValidators/StaticAndDynamicValidatorsExistForMatchExpressionValidator.cs
@@ -8,8 +8,11 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli.TestValidators
 {
+    [ValidatorDescriptor(Id)]
     internal class StaticAndDynamicValidatorsExistForMatchExpressionValidator : DynamicValidatorBase
     {
+        internal const string Id = "TEST001/003";
+
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)
         {
             string secret = groups["0"].Value;

--- a/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/TestValidators/StaticValidatorExistsForMatchExpressionValidator.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher.Cli/TestValidators/StaticValidatorExistsForMatchExpressionValidator.cs
@@ -8,8 +8,11 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Cli.TestValidators
 {
+    [ValidatorDescriptor(Id)]
     internal class StaticValidatorExistsForMatchExpressionValidator : StaticValidatorBase
     {
+        internal const string Id = "TEST001/002";
+
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)
         {
             string secret = groups["0"].Value;

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/SearchSkimmerTests.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/SearchSkimmerTests.cs
@@ -288,12 +288,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 CreateGuidDetectingMatchExpression(
                     allowFileExtension: scanTargetExtension);
 
-            expression.ContentsRegex = "TestRule";
+            expression.ContentsRegex = SpamTestRule.TestRuleId;
 
             SearchDefinition definition = CreateDefaultSearchDefinition(expression);
 
             // This Id will match us up with the TestRuleValidator type.
-            definition.Id = "TestRule";
+            definition.Id = SpamTestRule.TestRuleId;
             definition.Name = "TestRule";
 
             AnalyzeContext context =
@@ -350,12 +350,12 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                 CreateGuidDetectingMatchExpression(
                     allowFileExtension: scanTargetExtension);
 
-            expression.ContentsRegex = "TestRule";
+            expression.ContentsRegex = SpamTestRule.TestRuleId;
 
             SearchDefinition definition = CreateDefaultSearchDefinition(expression);
 
             // This Id will match us up with the TestRuleValidator type.
-            definition.Id = "TestRule";
+            definition.Id = SpamTestRule.TestRuleId;
             definition.Name = "TestRule";
 
             AnalyzeContext context =

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/SpamTestRule.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/SpamTestRule.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Sarif
             }
         }
 
-        private const string TestRuleId = "TEST1001";
+        internal const string TestRuleId = "TEST1001";
 
         protected override ResourceManager ResourceManager => SkimmerBaseTestResources.ResourceManager;
 
@@ -62,6 +62,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 {
                     return SupportedPlatform.Unknown;
                 }
+
                 return SupportedPlatform.All;
             }
         }
@@ -75,6 +76,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 {
                     throw new InvalidOperationException(nameof(TestRuleBehaviors.RaiseExceptionAccessingId));
                 }
+
                 return _id ?? TestRuleId;
             }
             set
@@ -92,6 +94,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                 {
                     throw new InvalidOperationException(nameof(TestRuleBehaviors.RaiseExceptionAccessingId));
                 }
+
                 return _name ?? base.Name;
             }
             set
@@ -179,6 +182,7 @@ namespace Microsoft.CodeAnalysis.Sarif
 
                         Thread.Sleep(s_random.Next(0, 10));
                     }
+
                     break;
                 }
 
@@ -207,6 +211,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                     nameof(SkimmerBaseTestResources.TEST1001_Failed),
                     context.CurrentTarget.Uri.GetFileName()));
             }
+
             if (fileName.Contains(nameof(FailureLevel.Warning), StringComparison.OrdinalIgnoreCase))
             {
                 context.Logger.Log(this,
@@ -214,6 +219,7 @@ namespace Microsoft.CodeAnalysis.Sarif
                     nameof(SkimmerBaseTestResources.TEST1001_Failed),
                     context.CurrentTarget.Uri.GetFileName()));
             }
+
             if (fileName.Contains(nameof(FailureLevel.Note), StringComparison.OrdinalIgnoreCase))
             {
                 context.Logger.Log(this,

--- a/Src/Test.UnitTests.Sarif.PatternMatcher/TestRuleValidator.cs
+++ b/Src/Test.UnitTests.Sarif.PatternMatcher/TestRuleValidator.cs
@@ -9,6 +9,7 @@ using Microsoft.RE2.Managed;
 
 namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 {
+    [ValidatorDescriptor(SpamTestRule.TestRuleId)]
     public class TestRuleValidator : DynamicValidatorBase
     {
         public delegate IEnumerable<ValidationResult> IsValidStaticDelegate(IDictionary<string, FlexMatch> groups);
@@ -26,7 +27,11 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
 
         protected override IEnumerable<ValidationResult> IsValidStaticHelper(IDictionary<string, FlexMatch> groups)
         {
-            if (OverrideIsValidStatic == null) { return null; }
+            if (OverrideIsValidStatic == null)
+            {
+                return null;
+            }
+
             return OverrideIsValidStatic(groups);
         }
 
@@ -35,7 +40,11 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                                                                 IDictionary<string, string> options,
                                                                 ref ResultLevelKind resultLevelKind)
         {
-            if (OverrideIsValidDynamic == null) { return 0; }
+            if (OverrideIsValidDynamic == null)
+            {
+                return 0;
+            }
+
             return OverrideIsValidDynamic(ref fingerprint, ref message, options, ref resultLevelKind);
         }
     }


### PR DESCRIPTION
We previously used the friendly (unstable) rule name to map to validators. The reason is that this data tends to consist of readable terms that are appropriate for type names. But, this makes the system fragile: we can't find validators for historical rule names form historically generated log files.

Now we have a descriptor that tags a rule with its stable rule id. And the validator retrieval logic operates strictly from this data.

Note that in addition to the core change, I added a little (currently disabled) test that can be updated with a directory path to auto-inject this information for files that match the rule validator file name convention.

@marmegh @Jeremiah-Johnson

@HulonJenkins, note this change merges into the commit associated with v4.3.17, to assist in servicing.