### PR TITLE
Restore package `RabbitMQ.Client` back to 6.2.1

### DIFF
--- a/Src/Plugins/Security/Security.csproj
+++ b/Src/Plugins/Security/Security.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.Security.Utilities" Version="1.4.0" />
     <PackageReference Include="MySqlConnector" Version="1.2.1" />
     <PackageReference Include="Npgsql" Version="5.0.3" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.5.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.2.1" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.Json" Version="5.0.1" />


### PR DESCRIPTION
## Changes

The previous version change (from 6.2.1 to 6.5.0) will cause build error for other projects referenced `sarif-pattern-matcher` due to `System.Threading.Channels` version conflicts.