### PR TITLE
Adding ML inference support for false positive filtering

### DIFF
--- a/Src/Sarif.PatternMatcher.Sdk/Sarif.PatternMatcher.Sdk.csproj
+++ b/Src/Sarif.PatternMatcher.Sdk/Sarif.PatternMatcher.Sdk.csproj
@@ -14,6 +14,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.15.1" />
+    <PackageReference Include="System.Text.Json" Version="7.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\RE2.Managed\RE2.Managed.csproj" />
     <ProjectReference Include="..\sarif-sdk\src\Sarif\Sarif.csproj" />
   </ItemGroup>

--- a/Src/Sarif.PatternMatcher.Sdk/ValidationState.cs
+++ b/Src/Sarif.PatternMatcher.Sdk/ValidationState.cs
@@ -65,5 +65,11 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher.Sdk
         /// The result should be reported as an error.
         /// </summary>
         Authorized,
+
+        /// <summary>
+        /// Pattern is a match and the secret is valid
+        /// per a trained machine learning model.
+        /// </summary>
+        TruePositiveDeterminedByML,
     }
 }

--- a/Src/Sarif.PatternMatcher/SearchSkimmer.cs
+++ b/Src/Sarif.PatternMatcher/SearchSkimmer.cs
@@ -392,6 +392,15 @@ namespace Microsoft.CodeAnalysis.Sarif.PatternMatcher
                     break;
                 }
 
+                case ValidationState.TruePositiveDeterminedByML:
+                {
+                    level = FailureLevel.Error;
+
+                    validationPrefix = "a valid ";
+                    validationSuffix = ", the likelihood of validity was determined by a machine learning model.";
+                    break;
+                }
+
                 default:
                 {
                     throw new InvalidOperationException($"Unrecognized validation value '{state}'.");


### PR DESCRIPTION
## Changes

This PR adds support in SARIF Pattern Matcher for leveraging custom machine learning models to filter out false positives. The PR

1. Adds a new validation state, `TruePositiveDeterminedByML`
2. Elevates the level of a finding to `Error` if the validation state is found to be `TruePositiveDeterminedByML`
3. Adds a new helper function in the `StaticValidatorBase` which leverages ML models to validate a finding. This method vectorizes a string to an integer array, loads an ONNX model, and then obtains a prediction probability by running the input vector on the model. If the prediction probability exceeds a threshold, the secret is deemed to be valid.

* [ ] `ReleaseHistory.md` updated for non-trivial changes
* [ ] Added unit tests
